### PR TITLE
Minor tweak to signup button on demo page

### DIFF
--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -2,6 +2,7 @@ import Alert from 'antd/lib/alert';
 import Badge from 'antd/lib/badge';
 import Button from 'antd/lib/button';
 import DatePicker from 'antd/lib/date-picker';
+import Divider from 'antd/lib/divider';
 import Dropdown from 'antd/lib/dropdown';
 import Input from 'antd/lib/input';
 import Layout from 'antd/lib/layout';
@@ -53,6 +54,7 @@ export {
   Badge,
   Button,
   DatePicker,
+  Divider,
   Dropdown,
   Input,
   Menu,

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import {RouteComponentProps, Link} from 'react-router-dom';
-import {Box} from 'theme-ui';
+import {Box, Flex} from 'theme-ui';
 import {TwitterPicker} from 'react-color';
 import qs from 'query-string';
-import {colors, Input, Paragraph, Title} from '../common';
+import {
+  colors,
+  Button,
+  Divider,
+  Input,
+  Paragraph,
+  Text,
+  Title,
+} from '../common';
+import {RightCircleOutlined} from '../icons';
 // Testing widget in separate package
 import ChatWidget from '@papercups-io/chat-widget';
-import {Button} from '../common';
 
 type Props = RouteComponentProps & {};
 type State = {
@@ -93,6 +101,19 @@ class Demo extends React.Component<Props, State> {
           />
         </Box>
 
+        <Divider />
+
+        <Flex mb={4} sx={{alignItems: 'center'}}>
+          <Box mr={3}>
+            <Text strong>Ready to get started?</Text>
+          </Box>
+          <Link to="/register">
+            <Button type="primary" icon={<RightCircleOutlined />}>
+              Sign up for free
+            </Button>
+          </Link>
+        </Flex>
+
         <ChatWidget
           title={title || 'Welcome!'}
           subtitle={subtitle}
@@ -100,9 +121,6 @@ class Demo extends React.Component<Props, State> {
           accountId={accountId}
           defaultIsOpen
         />
-        <Link to="/register">
-          <Button type="primary">Register</Button>
-        </Link>
       </Box>
     );
   }

--- a/assets/src/components/icons.tsx
+++ b/assets/src/components/icons.tsx
@@ -4,6 +4,7 @@ import DownOutlined from '@ant-design/icons/DownOutlined';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
 import MailOutlined from '@ant-design/icons/MailOutlined';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
+import RightCircleOutlined from '@ant-design/icons/RightCircleOutlined';
 import SendOutlined from '@ant-design/icons/SendOutlined';
 import SettingOutlined from '@ant-design/icons/SettingOutlined';
 import SmileOutlined from '@ant-design/icons/SmileOutlined';
@@ -21,6 +22,7 @@ export {
   LoadingOutlined,
   MailOutlined,
   PlusOutlined,
+  RightCircleOutlined,
   SendOutlined,
   SettingOutlined,
   SmileOutlined,


### PR DESCRIPTION
Thoughts?

Before:
<img width="1280" alt="Screen Shot 2020-07-25 at 9 59 23 AM" src="https://user-images.githubusercontent.com/5264279/88458657-9e386d80-ce5d-11ea-824b-88301f051dc2.png">

After:
<img width="1280" alt="Screen Shot 2020-07-25 at 9 58 58 AM" src="https://user-images.githubusercontent.com/5264279/88458659-9e386d80-ce5d-11ea-97ba-dd707aa3d6fa.png">
