### PR TITLE
Fix auth persistence, refresh token every 20 mins

### DIFF
--- a/assets/src/components/auth/AuthProvider.tsx
+++ b/assets/src/components/auth/AuthProvider.tsx
@@ -54,6 +54,7 @@ export class AuthProvider extends React.Component<Props, State> {
       return;
     }
 
+    // Attempt refresh auth session on load
     await this.refresh(refreshToken);
 
     this.setState({loading: false});
@@ -72,6 +73,8 @@ export class AuthProvider extends React.Component<Props, State> {
 
     const nextRefreshToken = tokens && tokens.renew_token;
 
+    // Refresh the session every 20 mins to avoid the access token expiring
+    // (By default, the session will expire after 30 mins)
     this.timeout = setTimeout(
       () => this.refresh(nextRefreshToken),
       AUTH_SESSION_TTL


### PR DESCRIPTION
Before, if you left the app open for >30 mins, the session would expire and prevent the user from fetching any more data from the server.

This PR fixes that so the refresh token is sent every 20 mins to ensure the session is still alive. (Another approach would've been to attempt a refresh anytime we see a 401 error, but this was much easier to get done quickly, and doesn't seem like that much worse of an approach.)