### PR TITLE
Add name, email, phone, etc to `customers` table

### DIFF
--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -31,7 +31,14 @@ const ConversationHeader = ({
     return null;
   }
 
-  const {id: conversationId, assignee_id, status, priority} = conversation;
+  const {
+    id: conversationId,
+    assignee_id,
+    status,
+    priority,
+    customer = {},
+  } = conversation;
+  const {name, email} = customer;
   const assigneeId = assignee_id ? String(assignee_id) : undefined;
 
   return (
@@ -49,7 +56,7 @@ const ConversationHeader = ({
         sx={{justifyContent: 'space-between', alignItems: 'baseline'}}
       >
         <Title level={4} style={{marginBottom: 0, marginTop: 4}}>
-          Anonymous User
+          {name || email || 'Anonymous User'}
         </Title>
 
         <Flex mx={-1}>

--- a/assets/src/components/conversations/ConversationItem.tsx
+++ b/assets/src/components/conversations/ConversationItem.tsx
@@ -17,7 +17,6 @@ const formatConversation = (conversation: any, messages: Array<any> = []) => {
 
   return {
     ...conversation,
-    customer: 'Anonymous User',
     date: date || '1d', // TODO
     preview: recent && recent.body ? recent.body : '...',
     messages: messages,
@@ -39,6 +38,7 @@ const ConversationItem = ({
 }) => {
   const formatted = formatConversation(conversation, messages);
   const {id, priority, status, customer, date, preview, read} = formatted;
+  const {name, email} = customer;
   const isPriority = priority === 'priority';
   const isClosed = status === 'closed';
 
@@ -63,7 +63,7 @@ const ConversationItem = ({
               <SmileTwoTone style={{fontSize: 16}} twoToneColor={color} />
             )}
           </Box>
-          <Text strong>{customer}</Text>
+          <Text strong>{name || email || 'Anonymous User'}</Text>
         </Flex>
 
         {read ? (

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -11,6 +11,16 @@ defmodule ChatApi.Customers.Customer do
   schema "customers" do
     field(:first_seen, :date)
     field(:last_seen, :date)
+    field(:email, :string)
+    field(:name, :string)
+    field(:phone, :string)
+    field(:external_id, :string)
+    field(:browser, :string)
+    field(:browser_version, :string)
+    field(:browser_language, :string)
+    field(:os, :string)
+    field(:ip, :string)
+
     has_many(:messages, Message)
     has_many(:conversations, Conversation)
     belongs_to(:account, Account)
@@ -21,7 +31,20 @@ defmodule ChatApi.Customers.Customer do
   @doc false
   def changeset(customer, attrs) do
     customer
-    |> cast(attrs, [:first_seen, :last_seen, :account_id])
+    |> cast(attrs, [
+      :first_seen,
+      :last_seen,
+      :account_id,
+      :email,
+      :name,
+      :phone,
+      :external_id,
+      :browser,
+      :browser_version,
+      :browser_language,
+      :os,
+      :ip
+    ])
     |> validate_required([:first_seen, :last_seen, :account_id])
   end
 end

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -12,7 +12,10 @@ defmodule ChatApiWeb.CustomerController do
   end
 
   def create(conn, %{"customer" => customer_params}) do
-    with {:ok, %Customer{} = customer} <- Customers.create_customer(customer_params) do
+    ip = conn.remote_ip |> :inet_parse.ntoa() |> to_string()
+    params = Map.merge(customer_params, %{"ip" => ip})
+
+    with {:ok, %Customer{} = customer} <- Customers.create_customer(params) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.customer_path(conn, :show, customer))

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -11,6 +11,6 @@ defmodule ChatApiWeb.CustomerView do
   end
 
   def render("customer.json", %{customer: customer}) do
-    %{id: customer.id}
+    %{id: customer.id, name: customer.name, email: customer.email, phone: customer.phone}
   end
 end

--- a/priv/repo/migrations/20200727025014_add_identifier_fields_to_customer.exs
+++ b/priv/repo/migrations/20200727025014_add_identifier_fields_to_customer.exs
@@ -1,0 +1,18 @@
+defmodule ChatApi.Repo.Migrations.AddIdentifierFieldsToCustomer do
+  use Ecto.Migration
+
+  def change do
+    alter table(:customers) do
+      add(:email, :string)
+      add(:name, :string)
+      add(:phone, :string)
+      add(:external_id, :string)
+
+      add(:browser, :string)
+      add(:browser_version, :string)
+      add(:browser_language, :string)
+      add(:os, :string)
+      add(:ip, :string)
+    end
+  end
+end

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -63,6 +63,10 @@ defmodule ChatApi.CustomersTest do
     test "update_customer/2 with valid data updates the customer" do
       customer = customer_fixture()
       assert {:ok, %Customer{} = customer} = Customers.update_customer(customer, @update_attrs)
+
+      assert customer.email == @update_attrs.email
+      assert customer.name == @update_attrs.name
+      assert customer.phone == @update_attrs.phone
     end
 
     test "update_customer/2 with invalid data returns error changeset" do

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -13,7 +13,10 @@ defmodule ChatApi.CustomersTest do
     }
     @update_attrs %{
       first_seen: ~D[2020-01-01],
-      last_seen: ~D[2020-01-02]
+      last_seen: ~D[2020-01-02],
+      name: "Test User",
+      email: "user@test.com",
+      phone: "+16501235555"
     }
     @invalid_attrs %{
       first_seen: 3

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -11,7 +11,10 @@ defmodule ChatApiWeb.CustomerControllerTest do
   }
   @update_attrs %{
     first_seen: ~D[2020-01-01],
-    last_seen: ~D[2020-01-02]
+    last_seen: ~D[2020-01-02],
+    name: "Test User",
+    email: "user@test.com",
+    phone: "+16501235555"
   }
 
   @invalid_attrs %{


### PR DESCRIPTION
This PR sets the groundwork for sending customer metadata over through the widget:
- adds name, email, phone, IP, browser info, etc fields to `customers` table
- automatically saves IP address when creating new customer record
- show name or email in UI if one exists for the customer on the conversation (see screenshots below)

<img width="1297" alt="Screen Shot 2020-07-27 at 11 50 49 AM" src="https://user-images.githubusercontent.com/5264279/88563174-a4664f80-cfff-11ea-8853-8558a80ea3e0.png">

<img width="1297" alt="Screen Shot 2020-07-27 at 11 50 51 AM" src="https://user-images.githubusercontent.com/5264279/88563167-a16b5f00-cfff-11ea-9ec8-e0b6fb7d208e.png">
