### PR TITLE
Include agent info in messages

### DIFF
--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -20,7 +20,17 @@ import Tag from 'antd/lib/tag';
 import Tooltip from 'antd/lib/tooltip';
 import Typography from 'antd/lib/typography';
 
-import {blue, green, red, gold, grey} from '@ant-design/colors';
+import {
+  blue,
+  green,
+  red,
+  volcano,
+  orange,
+  gold,
+  purple,
+  magenta,
+  grey,
+} from '@ant-design/colors';
 
 const {Title, Text, Paragraph} = Typography;
 const {Header, Content, Footer, Sider} = Layout;
@@ -32,6 +42,10 @@ export const colors = {
   green: green[5],
   red: red[5],
   gold: gold[5],
+  volcano: volcano[5],
+  orange: orange[5],
+  purple: purple[5],
+  magenta: magenta[5],
   blue: blue, // expose all blues
   gray: grey, // expose all grays
 };

--- a/assets/src/components/conversations/ChatMessage.tsx
+++ b/assets/src/components/conversations/ChatMessage.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import {colors, Text} from '../common';
-import {SmileTwoTone} from '../icons';
+import {colors, Text, Tooltip} from '../common';
+import {UserOutlined} from '../icons';
 import {formatRelativeTime} from '../../utils';
 import {Message} from '../../types';
 
@@ -22,8 +22,10 @@ const ChatMessage = ({
   isLastInGroup,
   shouldDisplayTimestamp,
 }: Props) => {
-  const {body, created_at, user_id} = message;
-  const isAgent = !!user_id;
+  const {body, created_at, user} = message;
+  const isAgent = !!user;
+  // TODO: once we have customer metadata, show customer name/email here instead
+  const tooltip = user ? user.email : 'Anonymous Customer';
   const created = dayjs.utc(created_at);
   const timestamp = formatRelativeTime(created);
 
@@ -55,13 +57,27 @@ const ChatMessage = ({
   return (
     <Box pr={4} pl={0} pb={isLastInGroup ? 3 : 2}>
       <Flex sx={{justifyContent: 'flex-start', alignItems: 'center'}}>
-        <Box mr={3} mt={1}>
-          {/* TODO: include name/email to distinguish between agents */}
-          <SmileTwoTone
-            style={{fontSize: 20}}
-            twoToneColor={isAgent ? colors.primary : colors.gold}
-          />
-        </Box>
+        <Tooltip title={tooltip}>
+          <Flex
+            mr={2}
+            sx={{
+              bg: isAgent ? colors.primary : colors.gold,
+              height: 32,
+              width: 32,
+              borderRadius: '50%',
+              justifyContent: 'center',
+              alignItems: 'center',
+              color: '#fff',
+            }}
+          >
+            {isAgent ? (
+              tooltip.slice(0, 1).toUpperCase()
+            ) : (
+              <UserOutlined style={{color: colors.white}} />
+            )}
+          </Flex>
+        </Tooltip>
+
         <Box
           px={3}
           py={2}
@@ -76,7 +92,7 @@ const ChatMessage = ({
         </Box>
       </Flex>
       {shouldDisplayTimestamp && (
-        <Flex m={1} pl={4} sx={{justifyContent: 'flex-start'}}>
+        <Flex my={1} mx={2} pl={4} sx={{justifyContent: 'flex-start'}}>
           <Text type="secondary">Sent {timestamp}</Text>
         </Flex>
       )}

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -20,13 +20,6 @@ import ConversationHeader from './ConversationHeader';
 import ConversationItem from './ConversationItem';
 import ConversationFooter from './ConversationFooter';
 
-const formatMessage = (message: any) => {
-  return {
-    ...message,
-    sender: message.customer_id ? 'customer' : 'agent',
-  };
-};
-
 const EmptyMessagesPlaceholder = () => {
   return (
     <Box my={4}>
@@ -240,9 +233,9 @@ class ConversationsContainer extends React.Component<Props, State> {
                 const conversation = conversationsById[conversationId];
                 const messages = messagesByConversation[conversationId];
                 const isHighlighted = conversationId === selectedConversationId;
-                const {gold, red, green, gray} = colors;
+                const {gold, red, green, purple, magenta} = colors;
                 // TODO: come up with a better way to make colors/avatars consistent
-                const color = [gold, red, green, gray[0]][idx % 4];
+                const color = [gold, red, green, purple, magenta][idx % 5];
 
                 return (
                   <ConversationItem
@@ -294,9 +287,8 @@ class ConversationsContainer extends React.Component<Props, State> {
                 sx={{minHeight: '100%'}}
               >
                 {messages.length ? (
-                  messages.map((message: any, key: number) => {
+                  messages.map((msg: any, key: number) => {
                     // Slight hack
-                    const msg = formatMessage(message);
                     const next = messages[key + 1];
                     const isMe = msg.user_id && msg.user_id === currentUser.id;
                     const isLastInGroup = next

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -10,8 +10,7 @@ export type Message = {
   customer_id?: string;
   conversation_id: string;
   user_id?: string;
-  // Deprecate
-  sender: string;
+  user?: User;
 };
 
 // NB: actual conversation records will look different

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -31,7 +31,7 @@ defmodule ChatApi.Conversations do
     |> where(account_id: ^account_id)
     |> where(^filter_where(params))
     |> order_by(desc: :inserted_at)
-    |> preload([:customer, :messages])
+    |> preload([:customer, [messages: :user]])
     |> Repo.all()
   end
 
@@ -63,7 +63,7 @@ defmodule ChatApi.Conversations do
         where: c.customer_id == ^customer_id and c.account_id == ^account_id,
         select: c,
         order_by: [desc: :inserted_at],
-        preload: [:customer, :messages]
+        preload: [:customer, messages: :user]
       )
 
     Repo.all(query)

--- a/lib/chat_api/messages.ex
+++ b/lib/chat_api/messages.ex
@@ -46,7 +46,7 @@ defmodule ChatApi.Messages do
 
   """
   def get_message!(id) do
-    Message |> Repo.get!(id) |> Repo.preload(:conversation)
+    Message |> Repo.get!(id) |> Repo.preload([:conversation, :customer, :user])
   end
 
   @doc """

--- a/lib/chat_api_web/channels/conversation_channel.ex
+++ b/lib/chat_api_web/channels/conversation_channel.ex
@@ -46,8 +46,9 @@ defmodule ChatApiWeb.ConversationChannel do
           Map.merge(payload, %{"conversation_id" => conversation_id, "account_id" => account_id})
 
         {:ok, message} = Messages.create_message(msg)
+        message = Messages.get_message!(message.id)
         Conversations.mark_conversation_unread(conversation_id)
-        result = ChatApiWeb.MessageView.render("message.json", message: message)
+        result = ChatApiWeb.MessageView.render("expanded.json", message: message)
 
         # TODO: double check that this still works as expected
         broadcast(socket, "shout", result)

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -52,7 +52,8 @@ defmodule ChatApiWeb.NotificationChannel do
 
   def handle_in("shout", payload, socket) do
     {:ok, message} = Messages.create_message(payload)
-    result = ChatApiWeb.MessageView.render("message.json", message: message)
+    message = Messages.get_message!(message.id)
+    result = ChatApiWeb.MessageView.render("expanded.json", message: message)
     # TODO: write doc explaining difference between push, broadcast, etc.
     push(socket, "shout", result)
 

--- a/lib/chat_api_web/views/conversation_view.ex
+++ b/lib/chat_api_web/views/conversation_view.ex
@@ -42,7 +42,7 @@ defmodule ChatApiWeb.ConversationView do
       customer_id: conversation.customer_id,
       assignee_id: conversation.assignee_id,
       customer: render_one(conversation.customer, CustomerView, "customer.json"),
-      messages: render_many(conversation.messages, MessageView, "message.json")
+      messages: render_many(conversation.messages, MessageView, "expanded.json")
     }
   end
 end

--- a/lib/chat_api_web/views/message_view.ex
+++ b/lib/chat_api_web/views/message_view.ex
@@ -1,6 +1,6 @@
 defmodule ChatApiWeb.MessageView do
   use ChatApiWeb, :view
-  alias ChatApiWeb.MessageView
+  alias ChatApiWeb.{MessageView, UserView}
 
   def render("index.json", %{messages: messages}) do
     %{data: render_many(messages, MessageView, "message.json")}
@@ -18,6 +18,18 @@ defmodule ChatApiWeb.MessageView do
       customer_id: message.customer_id,
       conversation_id: message.conversation_id,
       user_id: message.user_id
+    }
+  end
+
+  def render("expanded.json", %{message: message}) do
+    %{
+      id: message.id,
+      body: message.body,
+      created_at: message.inserted_at,
+      conversation_id: message.conversation_id,
+      customer_id: message.customer_id,
+      user_id: message.user_id,
+      user: render_one(message.user, UserView, "user.json")
     }
   end
 end

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -30,7 +30,9 @@ defmodule ChatApi.MessagesTest do
 
     test "list_messages/0 returns all messages" do
       message = message_fixture()
-      assert Messages.list_messages() == [message]
+      messages = Messages.list_messages() |> Enum.map(fn msg -> msg.body end)
+
+      assert messages == [message.body]
     end
 
     test "get_message!/1 returns the message with given id" do


### PR DESCRIPTION
Adds sender info to messages. In the near future, we'll want to allow putting a little profile photo here to add a personal touch, so the customer can see the agent.

<img width="1382" alt="Screen Shot 2020-07-27 at 6 43 44 PM" src="https://user-images.githubusercontent.com/5264279/88599175-23c44500-d039-11ea-9f2b-6d9261399e6f.png">
