### PR TITLE
Set up API to update customer metadata from chat widget

### DIFF
--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -286,7 +286,6 @@ export class ConversationsProvider extends React.Component<Props, State> {
     this.channel.push('shout', {
       body: message,
       conversation_id: conversationId,
-      sender: 'agent', // TODO: remove?
     });
 
     if (cb && typeof cb === 'function') {

--- a/assets/src/components/demo/Widget.tsx
+++ b/assets/src/components/demo/Widget.tsx
@@ -66,20 +66,10 @@ class Widget extends React.Component<Props, State> {
 
         this.setState({
           conversationId,
-          messages: messages
-            .map((msg: any) => {
-              return {
-                body: msg.body,
-                created_at: msg.created_at,
-                customer_id: msg.customer_id,
-                // Deprecate
-                sender: msg.customer_id ? 'customer' : 'agent',
-              };
-            })
-            .sort(
-              (a: any, b: any) =>
-                +new Date(a.created_at) - +new Date(b.created_at)
-            ),
+          messages: messages.sort(
+            (a: any, b: any) =>
+              +new Date(a.created_at) - +new Date(b.created_at)
+          ),
         });
 
         this.joinConversationChannel(conversationId, customerId);
@@ -174,7 +164,6 @@ class Widget extends React.Component<Props, State> {
     this.channel.push('shout', {
       body: message,
       customer_id: this.state.customerId,
-      sender: 'customer', // TODO: remove?
     });
 
     this.setState({message: ''});

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -73,6 +73,12 @@ defmodule ChatApi.Customers do
     |> Repo.update()
   end
 
+  def update_customer_metadata(%Customer{} = customer, attrs) do
+    customer
+    |> Customer.metadata_changeset(attrs)
+    |> Repo.update()
+  end
+
   @doc """
   Deletes a customer.
 

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -47,4 +47,19 @@ defmodule ChatApi.Customers.Customer do
     ])
     |> validate_required([:first_seen, :last_seen, :account_id])
   end
+
+  def metadata_changeset(customer, attrs) do
+    customer
+    |> cast(attrs, [
+      :email,
+      :name,
+      :phone,
+      :external_id,
+      :browser,
+      :browser_version,
+      :browser_language,
+      :os,
+      :ip
+    ])
+  end
 end

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -36,6 +36,14 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  def update_metadata(conn, %{"id" => id, "metadata" => metadata}) do
+    customer = Customers.get_customer!(id)
+
+    with {:ok, %Customer{} = customer} <- Customers.update_customer_metadata(customer, metadata) do
+      render(conn, "show.json", customer: customer)
+    end
+  end
+
   def delete(conn, %{"id" => id}) do
     customer = Customers.get_customer!(id)
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -29,6 +29,7 @@ defmodule ChatApiWeb.Router do
     post("/accounts", AccountController, :create)
     post("/conversations", ConversationController, :create)
     post("/customers", CustomerController, :create)
+    put("/customers/:id/metadata", CustomerController, :update_metadata)
 
     # TODO: figure out a better name?
     get("/conversations/customer", ConversationController, :find_by_customer)

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -23,9 +23,15 @@ defmodule ChatApi.CustomersTest do
     }
 
     def add_account_id(attrs) do
-      {:ok, account} = Accounts.create_account(%{company_name: "Taro"})
-      attr = Enum.into(attrs, %{account_id: account.id})
-      attr
+      account = account_fixture()
+
+      Enum.into(attrs, %{account_id: account.id})
+    end
+
+    def account_fixture(_attrs \\ %{}) do
+      {:ok, account} = Accounts.create_account(%{company_name: "Test Inc"})
+
+      account
     end
 
     def customer_fixture(attrs \\ %{}) do
@@ -67,6 +73,21 @@ defmodule ChatApi.CustomersTest do
       assert customer.email == @update_attrs.email
       assert customer.name == @update_attrs.name
       assert customer.phone == @update_attrs.phone
+    end
+
+    test "update_customer_metadata/2 only updates customizable fields" do
+      customer = customer_fixture()
+      new_account = account_fixture()
+      attrs = Enum.into(@update_attrs, %{account_id: new_account.id})
+
+      assert {:ok, %Customer{} = customer} = Customers.update_customer_metadata(customer, attrs)
+
+      assert customer.email == @update_attrs.email
+      assert customer.name == @update_attrs.name
+      assert customer.phone == @update_attrs.phone
+
+      # `account_id` should not be customizable through this API
+      assert customer.account_id != new_account.id
     end
 
     test "update_customer/2 with invalid data returns error changeset" do

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -110,6 +110,31 @@ defmodule ChatApiWeb.CustomerControllerTest do
     end
   end
 
+  describe "update customer metadata" do
+    setup [:create_customer]
+
+    test "renders customer when data is valid", %{
+      conn: conn,
+      authed_conn: authed_conn,
+      customer: %Customer{id: id} = customer
+    } do
+      resp =
+        put(conn, Routes.customer_path(conn, :update_metadata, customer), metadata: @update_attrs)
+
+      assert %{"id" => ^id} = json_response(resp, 200)["data"]
+
+      resp = get(authed_conn, Routes.customer_path(authed_conn, :show, id))
+
+      assert %{
+               "email" => email,
+               "name" => name
+             } = json_response(resp, 200)["data"]
+
+      assert email == @update_attrs.email
+      assert name == @update_attrs.name
+    end
+  end
+
   defp create_customer(_) do
     customer = fixture(:customer)
     %{customer: customer}


### PR DESCRIPTION
This PR just sets up the API to be consumed from the widget (in this PR https://github.com/papercups-io/chat-widget/pull/8)