### PR TITLE
Add "online" status to customers in the dashboard

### DIFF
--- a/assets/src/App.test.tsx
+++ b/assets/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/assets/src/components/conversations/AllConversations.tsx
+++ b/assets/src/components/conversations/AllConversations.tsx
@@ -11,6 +11,7 @@ const AllConversations = () => {
     all = [],
     conversationsById = {},
     messagesByConversation = {},
+    currentlyOnline = {},
     fetchAllConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -27,6 +28,7 @@ const AllConversations = () => {
       title="All conversations"
       account={account}
       currentUser={currentUser}
+      currentlyOnline={currentlyOnline}
       showGetStarted={isNewUser}
       conversationIds={all}
       conversationsById={conversationsById}

--- a/assets/src/components/conversations/ClosedConversations.tsx
+++ b/assets/src/components/conversations/ClosedConversations.tsx
@@ -11,6 +11,7 @@ const ClosedConversations = () => {
     closed = [],
     conversationsById = {},
     messagesByConversation = {},
+    currentlyOnline = {},
     fetchAllConversations,
     fetchClosedConversations,
     onSelectConversation,
@@ -37,6 +38,7 @@ const ClosedConversations = () => {
       title="Closed"
       account={account}
       currentUser={currentUser}
+      currentlyOnline={currentlyOnline}
       showGetStarted={isNewUser}
       conversationIds={closed}
       conversationsById={conversationsById}

--- a/assets/src/components/conversations/ConversationItem.tsx
+++ b/assets/src/components/conversations/ConversationItem.tsx
@@ -28,12 +28,14 @@ const ConversationItem = ({
   messages,
   color,
   isHighlighted,
+  isCustomerOnline,
   onSelectConversation,
 }: {
   conversation: Array<any>;
   messages: Array<any>;
   color: string;
   isHighlighted?: boolean;
+  isCustomerOnline?: boolean;
   onSelectConversation: (id: string) => void;
 }) => {
   const formatted = formatConversation(conversation, messages);
@@ -67,7 +69,11 @@ const ConversationItem = ({
         </Flex>
 
         {read ? (
-          <Text type="secondary">{date}</Text>
+          isCustomerOnline ? (
+            <Badge status="success" text="Online" />
+          ) : (
+            <Text type="secondary">{date}</Text>
+          )
         ) : (
           <Badge status="processing" />
         )}

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -54,6 +54,7 @@ type Props = {
   title?: string;
   account: any;
   currentUser: any;
+  currentlyOnline?: any;
   loading: boolean;
   showGetStarted: boolean;
   conversationIds: Array<string>;
@@ -115,6 +116,13 @@ class ConversationsContainer extends React.Component<Props, State> {
     if (!selected || ids.indexOf(selected) === -1) {
       this.handleSelectConversation(ids[0]);
     }
+  };
+
+  isCustomerOnline = (customerId: string) => {
+    const {currentlyOnline = {}} = this.props;
+    const key = `customer:${customerId}`;
+
+    return !!(currentlyOnline && currentlyOnline[key]);
   };
 
   handleSelectConversation = (id: string | null) => {
@@ -240,6 +248,8 @@ class ConversationsContainer extends React.Component<Props, State> {
               conversationIds.map((conversationId, idx) => {
                 const conversation = conversationsById[conversationId];
                 const messages = messagesByConversation[conversationId];
+                const {customer_id: customerId} = conversation;
+                const isCustomerOnline = this.isCustomerOnline(customerId);
                 const isHighlighted = conversationId === selectedConversationId;
                 const {gold, red, green, purple, magenta} = colors;
                 // TODO: come up with a better way to make colors/avatars consistent
@@ -251,6 +261,7 @@ class ConversationsContainer extends React.Component<Props, State> {
                     conversation={conversation}
                     messages={messages}
                     isHighlighted={isHighlighted}
+                    isCustomerOnline={isCustomerOnline}
                     color={color}
                     onSelectConversation={this.handleSelectConversation}
                   />

--- a/assets/src/components/conversations/ConversationsProvider.test.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.test.tsx
@@ -1,0 +1,94 @@
+import {
+  updatePresenceWithJoiners,
+  updatePresenceWithExiters,
+} from './ConversationsProvider';
+
+const getTestPresenceState = () => {
+  return {
+    'user:1': {metas: [{phx_ref: '1u'}]},
+    'customer:2': {metas: [{phx_ref: '2c'}]},
+    'user:3': {metas: [{phx_ref: '3u'}]},
+    'customer:4': {metas: [{phx_ref: '4c'}]},
+  };
+};
+
+describe('updatePresenceWithJoiners', () => {
+  test('with brand new presence', () => {
+    const unseen = 'customer:10';
+    const joiners = {
+      [unseen]: {metas: [{phx_ref: 'unseen'}]},
+    };
+    const presence = getTestPresenceState();
+    const update = updatePresenceWithJoiners(joiners, presence);
+
+    expect(update[unseen]?.metas).toEqual([{phx_ref: 'unseen'}]);
+  });
+
+  test('with additional presence for existing customer', () => {
+    const existing = 'customer:2';
+    const joiners = {
+      [existing]: {metas: [{phx_ref: 'another'}]},
+    };
+    const presence = getTestPresenceState();
+    const update = updatePresenceWithJoiners(joiners, presence);
+
+    expect(update[existing]?.metas).toEqual([
+      {phx_ref: '2c'},
+      {phx_ref: 'another'},
+    ]);
+  });
+
+  test('with a combination of new and additional presences', () => {
+    const existing = 'customer:2';
+    const unseen = 'customer:10';
+    const joiners = {
+      [existing]: {metas: [{phx_ref: 'another'}]},
+      [unseen]: {metas: [{phx_ref: 'unseen'}]},
+    };
+    const presence = getTestPresenceState();
+    const update = updatePresenceWithJoiners(joiners, presence);
+
+    expect(update[existing]?.metas).toEqual([
+      {phx_ref: '2c'},
+      {phx_ref: 'another'},
+    ]);
+    expect(update[unseen]?.metas).toEqual([{phx_ref: 'unseen'}]);
+  });
+});
+
+describe('updatePresenceWithExiters', () => {
+  test('removes the key completely if only one presence exists', () => {
+    const key = 'customer:2';
+    const exiters = {
+      [key]: {metas: [{phx_ref: '2c'}]},
+    };
+    const presence = getTestPresenceState();
+    const update = updatePresenceWithExiters(exiters, presence);
+
+    expect(update[key]).toBeNull();
+  });
+
+  test('removes the metadata if multiple presences exist', () => {
+    const key = 'customer:1';
+    const joiners = {
+      [key]: {metas: [{phx_ref: 'another'}]},
+    };
+    const presence = {
+      [key]: {metas: [{phx_ref: 'first'}, {phx_ref: 'another'}]},
+    };
+    const update = updatePresenceWithExiters(joiners, presence);
+
+    expect(update[key]?.metas).toEqual([{phx_ref: 'first'}]);
+  });
+
+  test('does nothing if no presence exists already', () => {
+    const key = 'customer:1';
+    const joiners = {
+      [key]: {metas: [{phx_ref: 'first'}]},
+    };
+    const presence = {};
+    const update = updatePresenceWithExiters(joiners, presence);
+
+    expect(update[key]).toBeNull();
+  });
+});

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -153,6 +153,14 @@ export class ConversationsProvider extends React.Component<Props, State> {
       this.handleConversationUpdated(id, updates);
     });
 
+    this.channel.on('presence_state', (state) => {
+      console.log('Presence state:', state);
+    });
+
+    this.channel.on('presence_diff', (state) => {
+      console.log('Presence diff:', state);
+    });
+
     this.channel
       .join()
       .receive('ok', (res) => {

--- a/assets/src/components/conversations/MyConversations.tsx
+++ b/assets/src/components/conversations/MyConversations.tsx
@@ -11,6 +11,7 @@ const MyConversations = () => {
     mine = [],
     conversationsById = {},
     messagesByConversation = {},
+    currentlyOnline = {},
     fetchMyConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -27,6 +28,7 @@ const MyConversations = () => {
       title="Assigned to me"
       account={account}
       currentUser={currentUser}
+      currentlyOnline={currentlyOnline}
       showGetStarted={isNewUser}
       conversationIds={mine}
       conversationsById={conversationsById}

--- a/assets/src/components/conversations/PriorityConversations.tsx
+++ b/assets/src/components/conversations/PriorityConversations.tsx
@@ -11,6 +11,7 @@ const PriorityConversations = () => {
     priority = [],
     conversationsById = {},
     messagesByConversation = {},
+    currentlyOnline = {},
     fetchPriorityConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -27,6 +28,7 @@ const PriorityConversations = () => {
       title="Prioritized"
       account={account}
       currentUser={currentUser}
+      currentlyOnline={currentlyOnline}
       showGetStarted={isNewUser}
       conversationIds={priority}
       conversationsById={conversationsById}

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -132,7 +132,6 @@ class Demo extends React.Component<Props, State> {
           primaryColor={color}
           accountId={accountId}
           greeting="Hello! Have any questions?"
-          baseUrl="http://localhost:4000"
           defaultIsOpen
         />
       </Box>

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -132,6 +132,7 @@ class Demo extends React.Component<Props, State> {
           primaryColor={color}
           accountId={accountId}
           greeting="Hello! Have any questions?"
+          baseUrl="http://localhost:4000"
           defaultIsOpen
         />
       </Box>

--- a/lib/chat_api/application.ex
+++ b/lib/chat_api/application.ex
@@ -13,6 +13,7 @@ defmodule ChatApi.Application do
       ChatApiWeb.Telemetry,
       # Start the PubSub system
       {Phoenix.PubSub, name: ChatApi.PubSub},
+      ChatApiWeb.Presence,
       # Start the Endpoint (http/https)
       ChatApiWeb.Endpoint
       # Start a worker by calling: ChatApi.Worker.start_link(arg)

--- a/lib/chat_api_web/channels/conversation_channel.ex
+++ b/lib/chat_api_web/channels/conversation_channel.ex
@@ -16,9 +16,10 @@ defmodule ChatApiWeb.ConversationChannel do
     if authorized?(payload, private_conversation_id) do
       conversation = Conversations.get_conversation!(private_conversation_id)
 
+      # TODO: include the customer id here
       {:ok,
-       assign(
-         socket,
+       socket
+       |> assign(
          :conversation,
          ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
        )}

--- a/lib/chat_api_web/channels/conversation_channel.ex
+++ b/lib/chat_api_web/channels/conversation_channel.ex
@@ -24,6 +24,8 @@ defmodule ChatApiWeb.ConversationChannel do
           ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
         )
 
+      # If the payload includes a customer_id, we want to mark this customer
+      # as "online" via Phoenix Presence in the :after_join hook
       case payload do
         %{"customer_id" => customer_id} ->
           send(self(), :after_join)
@@ -43,6 +45,7 @@ defmodule ChatApiWeb.ConversationChannel do
          %{account_id: account_id} <- conversation do
       key = "customer:" <> customer_id
 
+      # Track the presence of this customer in the conversation
       {:ok, _} =
         Presence.track(socket, key, %{
           online_at: inspect(System.system_time(:second))
@@ -50,6 +53,8 @@ defmodule ChatApiWeb.ConversationChannel do
 
       topic = "notification:" <> account_id
 
+      # Track the presence of this customer for the given account,
+      # so agents can see the "online" status in the dashboard
       {:ok, _} =
         Presence.track(self(), topic, key, %{
           online_at: inspect(System.system_time(:second))

--- a/lib/chat_api_web/presence.ex
+++ b/lib/chat_api_web/presence.ex
@@ -1,0 +1,5 @@
+defmodule ChatApiWeb.Presence do
+  use Phoenix.Presence,
+    otp_app: :chat_api,
+    pubsub_server: ChatApi.PubSub
+end


### PR DESCRIPTION
Handles #55

This PR uses Phoenix Presence to track when customers are online:
<img width="1259" alt="Screen Shot 2020-08-03 at 6 55 39 PM" src="https://user-images.githubusercontent.com/5264279/89234883-00f6db00-d5bb-11ea-981e-dc0b3d5f534a.png">


