### PR TITLE
run with a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+chat_api-*.tar
+
+# Since we are building assets from assets/,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+/priv/static/
+
+# Environment variable file
+.env
+
+/okteto.yaml
+/k8s.yaml
+
+# Heroku configuration files
+/phoenix_static_buildpack.config
+/Procfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG MIX_ENV=prod
+ARG MIX_ENV=dev
 FROM elixir:1.10 as dev
 WORKDIR /usr/src/app
 ENV LANG=C.UTF-8
@@ -9,7 +9,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
     mix local.rebar --force
 
 # declared here since they are required at build and run time.
-ENV DATABASE_URL="ecto://postgres:postgres@localhost/chat_api" PORT=4000 SECRET_KEY_BASE="" MIX_ENV=prod FROM_ADDRESS="" MAILGUN_API_KEY=""
+ENV DATABASE_URL="ecto://postgres:postgres@localhost/chat_api" SECRET_KEY_BASE="" MIX_ENV=dev FROM_ADDRESS="" MAILGUN_API_KEY=""
 
 COPY mix.exs mix.lock ./
 COPY config config

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ COPY lib lib
 RUN mix do compile
 RUN mix phx.digest
 
-COPY docker-entrypoint.sh docker-entrypoint.sh
-CMD ["docker-entrypoint.sh"]
+COPY docker-entrypoint.sh .
+CMD ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG MIX_ENV=prod
+FROM elixir:1.10 as dev
+WORKDIR /usr/src/app
+ENV LANG=C.UTF-8
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+    apt-get install -y nodejs fswatch && \
+    mix local.hex --force && \
+    mix local.rebar --force
+
+# declared here since they are required at build and run time.
+ENV DATABASE_URL="ecto://postgres:postgres@localhost/chat_api" PORT=4000 SECRET_KEY_BASE="" MIX_ENV=prod FROM_ADDRESS="" MAILGUN_API_KEY=""
+
+COPY mix.exs mix.lock ./
+COPY config config
+RUN mix do deps.get, deps.compile
+
+COPY assets/package.json assets/package-lock.json ./assets/
+RUN npm install --prefix=assets
+
+COPY priv priv
+COPY assets assets
+RUN npm run build --prefix=assets
+
+COPY lib lib
+RUN mix do compile
+RUN mix phx.digest
+
+COPY docker-entrypoint.sh docker-entrypoint.sh
+CMD ["docker-entrypoint.sh"]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,11 +1,11 @@
 use Mix.Config
 
+database_url =
+  System.get_env("DATABASE_URL") || "ecto://postgres:postgres@localhost/chat_api_dev"
+
 # Configure your database
 config :chat_api, ChatApi.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "chat_api_dev",
-  hostname: "localhost",
+  url: database_url,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+POOL_SIZE=2 mix ecto.setup
+mix phx.server


### PR DESCRIPTION
Initial version of the Dockerfile.  It's not optimized for production just yet, but wanted to send something that works and then build up from there. 

Long term, I think moving to using [phoenix releases](https://hexdocs.pm/phoenix/releases.html) makes sense, since it allows you to have a much smaller docker image.  Also, not sure what you are using for releases, but it would be cool to hook this up for that (we use github releases to ship containers with well-known versions, it works pretty well)


Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>