### PR TITLE
replace log out icon

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -9,12 +9,7 @@ import {
 } from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import {colors, Badge, Layout, Menu, Sider} from './common';
-import {
-  ApiOutlined,
-  MailOutlined,
-  UserOutlined,
-  SettingOutlined,
-} from './icons';
+import {ApiOutlined, MailOutlined, UserOutlined, LogoutOutlined} from './icons';
 import {useAuth} from './auth/AuthProvider';
 import AccountOverview from './account/AccountOverview';
 import GettingStartedOverview from './account/GettingStartedOverview';
@@ -140,7 +135,7 @@ const Dashboard = (props: RouteComponentProps) => {
             <Menu mode="inline" theme="dark">
               <Menu.Item
                 title="Log out"
-                icon={<SettingOutlined />}
+                icon={<LogoutOutlined />}
                 key="logout"
                 onClick={logout}
               >

--- a/assets/src/components/icons.tsx
+++ b/assets/src/components/icons.tsx
@@ -14,6 +14,7 @@ import StarOutlined from '@ant-design/icons/StarOutlined';
 import UploadOutlined from '@ant-design/icons/UploadOutlined';
 import UpOutlined from '@ant-design/icons/UpOutlined';
 import UserOutlined from '@ant-design/icons/UserOutlined';
+import LogoutOutlined from '@ant-design/icons/LogoutOutlined';
 
 export {
   ApiOutlined,
@@ -32,4 +33,5 @@ export {
   UploadOutlined,
   UpOutlined,
   UserOutlined,
+  LogoutOutlined,
 };

--- a/assets/src/components/icons.tsx
+++ b/assets/src/components/icons.tsx
@@ -2,6 +2,7 @@ import ApiOutlined from '@ant-design/icons/ApiOutlined';
 import CheckOutlined from '@ant-design/icons/CheckOutlined';
 import DownOutlined from '@ant-design/icons/DownOutlined';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
+import LogoutOutlined from '@ant-design/icons/LogoutOutlined';
 import MailOutlined from '@ant-design/icons/MailOutlined';
 import PlusOutlined from '@ant-design/icons/PlusOutlined';
 import RightCircleOutlined from '@ant-design/icons/RightCircleOutlined';
@@ -14,13 +15,13 @@ import StarOutlined from '@ant-design/icons/StarOutlined';
 import UploadOutlined from '@ant-design/icons/UploadOutlined';
 import UpOutlined from '@ant-design/icons/UpOutlined';
 import UserOutlined from '@ant-design/icons/UserOutlined';
-import LogoutOutlined from '@ant-design/icons/LogoutOutlined';
 
 export {
   ApiOutlined,
   CheckOutlined,
   DownOutlined,
   LoadingOutlined,
+  LogoutOutlined,
   MailOutlined,
   PlusOutlined,
   RightCircleOutlined,
@@ -33,5 +34,4 @@ export {
   UploadOutlined,
   UpOutlined,
   UserOutlined,
-  LogoutOutlined,
 };


### PR DESCRIPTION
Hi,

in this PR I changed the log out icon as requested in the this [issue](https://github.com/papercups-io/papercups/issues/52)

<img width="1012" alt="Screenshot 2020-07-31 at 23 15 48" src="https://user-images.githubusercontent.com/7046787/89078015-d2db8600-d383-11ea-8be6-2347d3b23c0a.png">



