### PR TITLE
Setup instructions via asdf-vm

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+erlang 23.0.3
+elixir 1.10.4-otp-23
+nodejs 14.7.0
+postgres 12.3

--- a/README.md
+++ b/README.md
@@ -21,52 +21,23 @@ Stay tuned! We'll be posting a more detailed roadmap soon 🤓
 
 Papercups runs on Elixir/Phoenix, with a TypeScript React app for the frontend.
 
-If you haven't installed Elixir, Phoenix, NodeJS, and PostgresQL yet, you can find some great instructions here: https://hexdocs.pm/phoenix/installation.html
 
-**tl;dr:**
-
-- Install Elixir: https://elixir-lang.org/install.html
-- Install Hex:
-
-```
-mix local.hex
-```
-
-- To check that we are on Elixir 1.6 and Erlang 20 or later, run:
-
-```
-elixir -v
-Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
-
-Elixir 1.6.3
-```
-
-- Install the Phoenix application generator:
-
-```
-mix archive.install hex phx_new 1.5.4
-```
-
-- Install NodeJS: https://nodejs.org/en/download/
-- Install PostgresQL: https://wiki.postgresql.org/wiki/Detailed_installation_guides
-
-### Cloning the repo
+- Install [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
+- Install [asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install)
+- Install [Erlang dependencies](https://github.com/asdf-vm/asdf-erlang#before-asdf-install)
 
 ```
 git clone git@github.com:papercups-io/papercups.git
 cd papercups
+asdf install
+mix local.hex
+mix deps.get
+cd assets && npm install
+mix ecto.setup
+mix phx.server
 ```
 
-### To start your server
-
-- Install backend dependencies with `mix deps.get`
-- Install frontend dependencies with `cd assets && npm install`
-- Create and migrate your database with `mix ecto.setup`
-- Start the server with `mix phx.server`
-
 This will automatically start up the React frontend in watch mode on `localhost:3000`, with the API running on `localhost:4000`.
-
-### To start client side
 
 The frontend code will start up automatically when you run `mix phx.server`, but for more information see: [assets/README.md](assets/README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Papercups
 
-Papercups is an open source live customer chat web app. We offer a hosted version at [app.papercups.io](https://app.papercups.io/).
+Papercups is an open source live customer chat web app. We offer a hosted
+version at [app.papercups.io](https://app.papercups.io/).
 
-You can check out how our chat widget looks and play around with customizing it on our [demo page](https://app.papercups.io/demo/). The chat widget component is also open sourced at [github.com/papercups-io/chat-widget](https://github.com/papercups-io/chat-widget).
+You can check out how our chat widget looks and play around with customizing it
+on our [demo page](https://app.papercups.io/demo/). The chat widget component
+is also open sourced at
+[github.com/papercups-io/chat-widget](https://github.com/papercups-io/chat-widget).
 
 _Watch how easy it is to get set up with our Slack integration 🚀 :_
 ![slack-setup](https://user-images.githubusercontent.com/4218509/88716918-a0583180-d0d4-11ea-93b3-12437ac51138.gif)
@@ -13,14 +17,17 @@ _Watch how easy it is to get set up with our Slack integration 🚀 :_
 
 ## Philosophy
 
-We wanted to make a self-hosted version of tools like Intercom and Drift for companies that have privacy and security concerns about having customer data going to third party services. We’re starting with chat right now but we want to expand into all forms of customer communication like email campaigns and push notifications.
+We wanted to make a self-hosted version of tools like Intercom and Drift for
+companies that have privacy and security concerns about having customer data
+going to third party services. We’re starting with chat right now but we want
+to expand into all forms of customer communication like email campaigns and
+push notifications.
 
 Stay tuned! We'll be posting a more detailed roadmap soon 🤓
 
 ## Getting started
 
 Papercups runs on Elixir/Phoenix, with a TypeScript React app for the frontend.
-
 
 - Install [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
 - Install [asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install)
@@ -37,13 +44,16 @@ mix ecto.setup
 mix phx.server
 ```
 
-This will automatically start up the React frontend in watch mode on `localhost:3000`, with the API running on `localhost:4000`.
+This will automatically start up the React frontend in watch mode on `localhost:3000`,
+with the API running on `localhost:4000`.
 
-The frontend code will start up automatically when you run `mix phx.server`, but for more information see: [assets/README.md](assets/README.md)
+The frontend code will start up automatically when you run `mix phx.server`,
+but for more information see: [assets/README.md](assets/README.md)
 
 ### Developing on Docker
 
-You can edit your local code when developing with docker and it will update in the container.
+You can edit your local code when developing with docker and it will update in
+the container.
 
 _The docker file is made for development only at the moment_
 
@@ -61,7 +71,9 @@ mix test
 
 ## Get in touch
 
-Come say hi to us on [Slack](https://join.slack.com/t/papercups-io/shared_invite/zt-gfs0d269-dEHm3SYs_5KmFKQ9YhBzDw) or [Discord](https://discord.gg/Dq2A3eh)! :wave:
+Come say hi to us on
+[Slack](https://join.slack.com/t/papercups-io/shared_invite/zt-gfs0d269-dEHm3SYs_5KmFKQ9YhBzDw)
+or [Discord](https://discord.gg/Dq2A3eh)! :wave:
 
 # Appendix
 
@@ -69,9 +81,11 @@ Come say hi to us on [Slack](https://join.slack.com/t/papercups-io/shared_invite
 
 ## Setting up email alerts
 
-Set the environment variables in the [`.env.example`](https://github.com/papercups-io/papercups/blob/master/.env.example) file.
+Set the environment variables in the
+[`.env.example`](https://github.com/papercups-io/papercups/blob/master/.env.example) file.
 
-At the moment we only support [Mailgun](https://www.mailgun.com/) — other messaging channels are coming soon!
+At the moment we only support [Mailgun](https://www.mailgun.com/) — other
+messaging channels are coming soon!
 
 ## Deploying
 
@@ -84,7 +98,8 @@ heroku run "POOL_SIZE=2 mix ecto.migrate"
 
 ## Running compiler on file change
 
-_Note_: Make sure you are running this inside of ChatApi otherwise it'll trigger on UI changes
+_Note_: Make sure you are running this inside of ChatApi otherwise it'll
+trigger on UI changes
 
 ```
 ./scripts/compile_watch.sh


### PR DESCRIPTION
Hi there!

I've had a lot of success using `asdf` to manage language runtimes, and I think it offers the cleanest approach to keeping every developer in sync. Here's a quick attempt at changing the setup instructions; I'd love for someone who doesn't have `asdf` installed to run through them for QA.

Once change I would personally make, but hesitated to here, is to use a [per-project Postgres](https://jamey.thesharps.us/2019/05/29/per-project-postgres/) setup via [direnv](https://direnv.net/). I like the per-project setup, but it would be a slightly larger change that should go in another PR.