### PR TITLE
add front end validation for password match in user registration form

### DIFF
--- a/assets/src/components/auth/Register.tsx
+++ b/assets/src/components/auth/Register.tsx
@@ -42,12 +42,35 @@ class Register extends React.Component<Props, State> {
   };
 
   handleChangePassword = (e: any) => {
-    this.setState({password: e.target.value});
+    let value = e.target.value;
+    this.setState({password: value});
+    this.validatePassword(value);
   };
 
   handleChangePasswordConfirmation = (e: any) => {
-    this.setState({passwordConfirmation: e.target.value});
+    let value = e.target.value;
+    this.setState({passwordConfirmation: value});
+    this.validatePasswordConfirmation(value);
   };
+
+  validatePasswordConfirmation(passwordConfirmation: string) {
+    if (passwordConfirmation !== this.state.password) {
+      this.setState({error: 'password confirmation does not match'});
+    } else {
+      this.setState({error: null});
+    }
+  }
+
+  validatePassword(password: string) {
+    // skip validation until password confirmation is set
+    if (this.state.passwordConfirmation.length === 0) return;
+
+    if (password !== this.state.passwordConfirmation) {
+      this.setState({error: 'password confirmation does not match'});
+    } else {
+      this.setState({error: null});
+    }
+  }
 
   handleSubmit = (e: any) => {
     e.preventDefault();


### PR DESCRIPTION
Hi 

I added the password confirmation validation to registration form component as requested [here](https://github.com/papercups-io/papercups/issues/98)

here is how it looks like:
<img width="908" alt="Screenshot 2020-08-08 at 17 55 17" src="https://user-images.githubusercontent.com/7046787/89714691-ca490800-d9a0-11ea-827b-2ccbb9c410f3.png">
<img width="1031" alt="Screenshot 2020-08-08 at 17 54 51" src="https://user-images.githubusercontent.com/7046787/89714692-cc12cb80-d9a0-11ea-8459-6e8a8e0e2a72.png">
