### PR TITLE
Auto assign conversation to yourself when you respond in a conversation for the first time

### DIFF
--- a/lib/chat_api/messages.ex
+++ b/lib/chat_api/messages.ex
@@ -31,6 +31,16 @@ defmodule ChatApi.Messages do
     Repo.one(query)
   end
 
+  def count_messages_sent_by_company_user_in_conversation(conversation_id) do
+    query =
+      from(m in Message,
+        where: m.conversation_id == ^conversation_id and not is_nil(m.user_id),
+        select: count("*")
+      )
+
+    Repo.one(query)
+  end
+
   @doc """
   Gets a single message.
 

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -59,11 +59,11 @@ defmodule ChatApiWeb.NotificationChannel do
       result = ChatApiWeb.MessageView.render("expanded.json", message: message)
 
       # If the received message is the first one sent by any company user, assign the conversation to the user
-      if Messages.count_messages_sent_by_company_user_in_conversation(message.conversation_id) == @messages_limit_to_autoassign do
-        {:ok, conversation} =
-          message.conversation_id
-          |> Conversations.get_conversation!()
-          |> Conversations.update_conversation(%{assignee_id: message.user_id})
+      if Messages.count_messages_sent_by_company_user_in_conversation(message.conversation_id) ==
+           @messages_limit_to_autoassign do
+        message.conversation_id
+        |> Conversations.get_conversation!()
+        |> Conversations.update_conversation(%{assignee_id: message.user_id})
       end
 
       # TODO: write doc explaining difference between push, broadcast, etc.


### PR DESCRIPTION
Hi @reichert621 ✋ 

## Problem

Conversations are manually assigned to a user at the moment. It would be much better if a conversation was automatically assigned to the first user to reply back in the conversation.

## Proposed solution

1. New query that counts how many messages have been sent by a company user in a conversation.
2. When a company user replies back, the notification channel handles the message and stores it.
3. If the new query is executed in that moment, the result should be 1.
4. Then we know the conversation should be assigned to that company user.

Related to #149 by @cheeseblubber.