### PR TITLE
Add `sent_at` field to Message, fix/refactor some Slack issues

### DIFF
--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -422,6 +422,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     this.channel.push('shout', {
       body: message,
       conversation_id: conversationId,
+      sent_at: new Date().toISOString(),
     });
 
     if (cb && typeof cb === 'function') {

--- a/lib/chat_api/chat/message.ex
+++ b/lib/chat_api/chat/message.ex
@@ -11,6 +11,7 @@ defmodule ChatApi.Messages.Message do
   @foreign_key_type :binary_id
   schema "messages" do
     field(:body, :string)
+    field(:sent_at, :utc_datetime)
     belongs_to(:conversation, Conversation)
     belongs_to(:account, Account)
     belongs_to(:customer, Customer)
@@ -22,7 +23,7 @@ defmodule ChatApi.Messages.Message do
   @doc false
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:body, :conversation_id, :account_id, :customer_id, :user_id])
+    |> cast(attrs, [:body, :conversation_id, :account_id, :customer_id, :user_id, :sent_at])
     |> validate_required([:body, :account_id])
   end
 end

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -51,8 +51,11 @@ defmodule ChatApiWeb.NotificationChannel do
   def handle_in("shout", payload, socket) do
     with %{current_user: current_user} <- socket.assigns,
          %{id: user_id, account_id: account_id} <- current_user do
-      msg = Map.merge(payload, %{"user_id" => user_id, "account_id" => account_id})
-      {:ok, message} = Messages.create_message(msg)
+      {:ok, message} =
+        payload
+        |> Map.merge(%{"user_id" => user_id, "account_id" => account_id})
+        |> Messages.create_message()
+
       message = Messages.get_message!(message.id)
       result = ChatApiWeb.MessageView.render("expanded.json", message: message)
 

--- a/lib/chat_api_web/views/message_view.ex
+++ b/lib/chat_api_web/views/message_view.ex
@@ -15,6 +15,7 @@ defmodule ChatApiWeb.MessageView do
       id: message.id,
       body: message.body,
       created_at: message.inserted_at,
+      sent_at: message.sent_at,
       customer_id: message.customer_id,
       conversation_id: message.conversation_id,
       user_id: message.user_id
@@ -26,6 +27,7 @@ defmodule ChatApiWeb.MessageView do
       id: message.id,
       body: message.body,
       created_at: message.inserted_at,
+      sent_at: message.sent_at,
       conversation_id: message.conversation_id,
       customer_id: message.customer_id,
       user_id: message.user_id,

--- a/priv/repo/migrations/20200711201020_create_accounts.exs
+++ b/priv/repo/migrations/20200711201020_create_accounts.exs
@@ -3,8 +3,8 @@ defmodule ChatApi.Repo.Migrations.CreateAccounts do
 
   def change do
     create table(:accounts, primary_key: false) do
-      add :id, :binary_id, primary_key: true
-      add :company_name, :string
+      add(:id, :binary_id, primary_key: true)
+      add(:company_name, :string)
 
       timestamps()
     end

--- a/priv/repo/migrations/20200711233730_create_customers.exs
+++ b/priv/repo/migrations/20200711233730_create_customers.exs
@@ -3,9 +3,9 @@ defmodule ChatApi.Repo.Migrations.CreateCustomers do
 
   def change do
     create table(:customers, primary_key: false) do
-      add :id, :binary_id, primary_key: true
-      add :first_seen, :date, null: false
-      add :last_seen, :date, null: false
+      add(:id, :binary_id, primary_key: true)
+      add(:first_seen, :date, null: false)
+      add(:last_seen, :date, null: false)
       add(:account_id, references(:accounts, type: :uuid))
 
       timestamps()

--- a/priv/repo/migrations/20200716230614_create_user_invitations.exs
+++ b/priv/repo/migrations/20200716230614_create_user_invitations.exs
@@ -3,9 +3,9 @@ defmodule ChatApi.Repo.Migrations.CreateUserInvitations do
 
   def change do
     create table(:user_invitations, primary_key: false) do
-      add :id, :binary_id, primary_key: true
-      add :account_id, references(:accounts, type: :uuid), null: false
-      add :expires_at, :utc_datetime, null: false
+      add(:id, :binary_id, primary_key: true)
+      add(:account_id, references(:accounts, type: :uuid), null: false)
+      add(:expires_at, :utc_datetime, null: false)
 
       timestamps()
     end

--- a/priv/repo/migrations/20200817172356_add_sent_at_to_messages.exs
+++ b/priv/repo/migrations/20200817172356_add_sent_at_to_messages.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddSentAtToMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:messages) do
+      add(:sent_at, :utc_datetime)
+    end
+  end
+end


### PR DESCRIPTION
Adds the `sent_at` field to `messages` so we can track how long it takes to send (comparing `sent_at` vs `inserted_at`/`created_at`) as well as handle showing messages in the widget before they've successfully sent (to handle https://github.com/papercups-io/papercups/issues/162 and https://github.com/papercups-io/papercups/issues/99)