### PR TITLE
Show number of unread conversations in tab

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2387,6 +2387,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-PYRoU1XJFOzQ3BHvWL1T8iDNbRjdMDJMT5hFmZKGbsq09kbSqJy61uwEpTrbTNWDopVphUT34zUSVLK9pjsgYQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-router": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
@@ -13659,6 +13668,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -13779,6 +13804,11 @@
           }
         }
       }
+    },
+    "react-side-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "react-syntax-highlighter": {
       "version": "12.2.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -29,6 +29,7 @@
     "react-color": "^2.18.1",
     "react-dom": "^16.13.1",
     "react-emoji-render": "^1.2.4",
+    "react-helmet": "^6.1.0",
     "react-markdown": "^4.3.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
@@ -75,6 +76,7 @@
   "devDependencies": {
     "@types/query-string": "^6.3.0",
     "@types/react-color": "^3.0.4",
+    "@types/react-helmet": "^6.1.0",
     "cpx": "^1.5.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   Link,
   RouteComponentProps,
 } from 'react-router-dom';
+import {Helmet} from 'react-helmet';
 import {Box, Flex} from 'theme-ui';
 import {colors, Badge, Layout, Menu, Sider} from './common';
 import {ApiOutlined, MailOutlined, UserOutlined, LogoutOutlined} from './icons';
@@ -29,11 +30,18 @@ const Dashboard = (props: RouteComponentProps) => {
   const {pathname} = useLocation();
   const {unreadByCategory: unread} = useConversations();
   const [section, key] = pathname.split('/').slice(1); // Slice off initial slash
+  const totalNumUnread = (unread && unread.all) || 0;
 
   const logout = () => auth.logout().then(() => props.history.push('/login'));
 
   return (
     <Layout>
+      <Helmet>
+        <title>
+          {totalNumUnread ? `(${totalNumUnread}) New message!` : 'Papercups'}
+        </title>
+      </Helmet>
+
       <Sider
         width={220}
         collapsed={false}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Uses `react-helmet` to dynamically set `document.title` with number of unread conversations.

<img width="421" alt="Screen Shot 2020-08-18 at 10 49 12 AM" src="https://user-images.githubusercontent.com/5264279/90528472-a6c05300-e140-11ea-9fd3-4d8a6d330929.png">

Handles the first part of https://github.com/papercups-io/papercups/issues/148 (still need to add flash)
