### PR TITLE
Make it possible to identify customers by `external_id` via the API

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -37,6 +37,14 @@ defmodule ChatApi.Customers do
   """
   def get_customer!(id), do: Repo.get!(Customer, id)
 
+  def find_by_external_id(account_id, external_id) do
+    Customer
+    |> where(account_id: ^account_id, external_id: ^external_id)
+    |> order_by(desc: :updated_at)
+    |> first()
+    |> Repo.one()
+  end
+
   @doc """
   Creates a customer.
 

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -30,6 +30,23 @@ defmodule ChatApiWeb.CustomerController do
     render(conn, "show.json", customer: customer)
   end
 
+  def identify(conn, %{
+        "external_id" => external_id,
+        "account_id" => account_id
+      }) do
+    case Customers.find_by_external_id(account_id, external_id) do
+      %{id: customer_id} ->
+        json(conn, %{
+          data: %{
+            customer_id: customer_id
+          }
+        })
+
+      _ ->
+        json(conn, %{data: %{customer_id: nil}})
+    end
+  end
+
   def update(conn, %{"id" => id, "customer" => customer_params}) do
     customer = Customers.get_customer!(id)
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -26,10 +26,12 @@ defmodule ChatApiWeb.Router do
     resources("/session", SessionController, singleton: true, only: [:create, :delete])
     post("/session/renew", SessionController, :renew)
 
+    # TODO: figure out a way to secure these methods so they aren't abused
     post("/accounts", AccountController, :create)
     post("/conversations", ConversationController, :create)
     post("/customers", CustomerController, :create)
     put("/customers/:id/metadata", CustomerController, :update_metadata)
+    get("/customers/identify", CustomerController, :identify)
     get("/widget_settings", WidgetSettingsController, :show)
     put("/widget_settings/metadata", WidgetSettingsController, :update_metadata)
 

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -108,5 +108,13 @@ defmodule ChatApi.CustomersTest do
       customer = customer_fixture()
       assert %Ecto.Changeset{} = Customers.change_customer(customer)
     end
+
+    test "find_by_external_id/1 returns a customer by external_id" do
+      external_id = "cus_123"
+      customer = customer_fixture(%{external_id: external_id})
+      account_id = customer.account_id
+
+      assert customer = Customers.find_by_external_id(account_id, external_id)
+    end
   end
 end


### PR DESCRIPTION
This will allow us to identify customers by the `external_id` passed in by our users, rather than always relying on whatever is cached in the browser/`localStorage`