### PR TITLE
Set up webhook event subscriptions

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -36,6 +36,10 @@ export type WidgetSettingsParams = {
   new_message_placeholder?: string;
 };
 
+export type EventSubscriptionParams = {
+  webhook_url: string;
+};
+
 export const getAccessToken = (): string | null => {
   const tokens = getAuthTokens();
 
@@ -338,6 +342,49 @@ export const fetchSlackAuthorization = async (token = getAccessToken()) => {
   return request
     .get(`/api/slack/authorization`)
     .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const fetchEventSubscriptions = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/event_subscriptions`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const verifyWebhookUrl = async (
+  url: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/event_subscriptions/verify`)
+    .set('Authorization', token)
+    .send({url})
+    .then((res) => res.body.data);
+};
+
+export const createEventSubscriptions = async (
+  params: EventSubscriptionParams,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/event_subscriptions`)
+    .set('Authorization', token)
+    .send({
+      event_subscription: params,
+    })
     .then((res) => res.body.data);
 };
 

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -371,7 +371,7 @@ export const verifyWebhookUrl = async (
     .then((res) => res.body.data);
 };
 
-export const createEventSubscriptions = async (
+export const createEventSubscription = async (
   params: EventSubscriptionParams,
   token = getAccessToken()
 ) => {
@@ -384,6 +384,24 @@ export const createEventSubscriptions = async (
     .set('Authorization', token)
     .send({
       event_subscription: params,
+    })
+    .then((res) => res.body.data);
+};
+
+export const updateEventSubscription = async (
+  id: string,
+  updates: EventSubscriptionParams,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .put(`/api/event_subscriptions/${id}`)
+    .set('Authorization', token)
+    .send({
+      event_subscription: updates,
     })
     .then((res) => res.body.data);
 };

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -406,6 +406,19 @@ export const updateEventSubscription = async (
     .then((res) => res.body.data);
 };
 
+export const deleteEventSubscription = async (
+  id: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/event_subscriptions/${id}`)
+    .set('Authorization', token);
+};
+
 export const authorizeSlackIntegration = async (
   code: string,
   token = getAccessToken()

--- a/assets/src/components/auth/Register.tsx
+++ b/assets/src/components/auth/Register.tsx
@@ -151,7 +151,7 @@ class Register extends React.Component<Props, State> {
                 <Input
                   id="companyName"
                   size="large"
-                  type="companyName"
+                  type="text"
                   autoComplete="company-name"
                   value={companyName}
                   onChange={this.handleChangeCompanyName}

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -13,6 +13,7 @@ import {
   Title,
 } from '../common';
 import {RightCircleOutlined} from '../icons';
+import {BASE_URL} from '../../config';
 import * as API from '../../api';
 // Testing widget in separate package
 import ChatWidget from '@papercups-io/chat-widget';
@@ -161,6 +162,7 @@ class Demo extends React.Component<Props, State> {
           accountId={accountId}
           greeting="Hello :) have any questions or feedback? Alex or Kam will reply as soon as they can!"
           customer={customer}
+          baseUrl={BASE_URL}
           defaultIsOpen
         />
       </Box>

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -3,10 +3,22 @@ import {RouteComponentProps} from 'react-router-dom';
 import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
 import qs from 'query-string';
-import {colors, Button, Paragraph, Table, Tag, Text, Title} from '../common';
+import {
+  colors,
+  Button,
+  Input,
+  Modal,
+  Paragraph,
+  Table,
+  Tag,
+  Text,
+  Title,
+} from '../common';
+import {PlusOutlined} from '../icons';
 import Spinner from '../Spinner';
 import {SLACK_CLIENT_ID} from '../../config';
 import * as API from '../../api';
+import {sleep} from '../../utils';
 
 type IntegrationType = {
   key: 'slack' | 'gmail';
@@ -16,16 +28,258 @@ type IntegrationType = {
   icon: string;
 };
 
+type WebhookEventSubscription = {
+  webhook_url: string;
+  verified: boolean;
+  created_at?: string | null;
+};
+
+const IntegrationsTable = ({
+  integrations,
+}: {
+  integrations: Array<IntegrationType>;
+}) => {
+  const columns = [
+    {
+      title: 'Integration',
+      dataIndex: 'integration',
+      key: 'integration',
+      render: (value: string, record: any) => {
+        const {icon} = record;
+
+        return (
+          <Flex sx={{alignItems: 'center'}}>
+            <img src={icon} alt={value} style={{height: 20}} />
+            <Text strong style={{marginLeft: 8}}>
+              {value}
+            </Text>
+          </Flex>
+        );
+      },
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: string) => {
+        return value === 'connected' ? (
+          <Tag color={colors.green}>Connected</Tag>
+        ) : (
+          <Tag>Not connected</Tag>
+        );
+      },
+    },
+    {
+      title: 'Connected since',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => {
+        if (!value) {
+          return '--';
+        }
+
+        return dayjs(value).format('MMMM DD, YYYY');
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (action: any, record: any) => {
+        const {key, status} = record;
+        const isConnected = status === 'connected';
+        // NB: when testing locally, update `origin` to an ngrok url
+        // pointing at localhost:4000 (or wherever your server is running)
+        const origin = window.location.origin;
+        const redirect = `${origin}/integrations/slack`;
+        const q = {
+          scope:
+            'incoming-webhook chat:write channels:history channels:manage chat:write.public users:read users:read.email',
+          user_scope: 'channels:history',
+          client_id: SLACK_CLIENT_ID,
+          redirect_uri: redirect,
+        };
+        const query = qs.stringify(q);
+
+        switch (key) {
+          case 'slack':
+            return (
+              <a href={`https://slack.com/oauth/v2/authorize?${query}`}>
+                <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
+              </a>
+            );
+          default:
+            return <Button disabled>Coming soon!</Button>;
+        }
+      },
+    },
+  ];
+
+  return <Table dataSource={integrations} columns={columns} />;
+};
+
+const WebhooksTable = ({
+  webhooks,
+}: {
+  webhooks: Array<WebhookEventSubscription>;
+}) => {
+  const columns = [
+    {
+      title: 'Webhook URL',
+      dataIndex: 'webhook_url',
+      key: 'webhook_url',
+      render: (value: string, record: any) => {
+        return (
+          <Text keyboard strong>
+            {value}
+          </Text>
+        );
+      },
+    },
+    {
+      title: 'Status',
+      dataIndex: 'verified',
+      key: 'verified',
+      render: (verified: boolean) => {
+        return verified ? (
+          <Tag color={colors.green}>Verified</Tag>
+        ) : (
+          <Tag>Unverified</Tag>
+        );
+      },
+    },
+    {
+      title: 'Connected since',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => {
+        if (!value) {
+          return '--';
+        }
+
+        return dayjs(value).format('MMMM DD, YYYY');
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (action: any, record: any) => {
+        return <Button>Update</Button>;
+      },
+    },
+  ];
+
+  return <Table rowKey="id" dataSource={webhooks} columns={columns} />;
+};
+
+// TODO: clean up a bit
+const NewWebhookModal = ({
+  visible,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  onSuccess: (webhook: WebhookEventSubscription) => void;
+  onCancel: () => void;
+}) => {
+  const [url, setWebhookUrl] = React.useState('');
+  const [isVerifying, setIsVerifying] = React.useState(false);
+  const [isVerified, setIsVerified] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const handleChangeUrl = (e: any) => setWebhookUrl(e.target.value);
+
+  const handleVerifyUrl = async () => {
+    console.log('Verifying:', url);
+    setIsVerifying(true);
+
+    const {verified} = await API.verifyWebhookUrl(url);
+    console.log('Verified?', verified);
+    await sleep(1000);
+
+    setIsVerifying(false);
+    setIsVerified(verified);
+  };
+
+  const handleCancelWebhook = () => {
+    onCancel();
+    setWebhookUrl('');
+    setIsVerified(false);
+  };
+
+  const handleSaveWebhook = async () => {
+    console.log('Saving:', url);
+    setIsSaving(true);
+
+    const webhook = await API.createEventSubscriptions({
+      webhook_url: url,
+    });
+
+    setIsSaving(false);
+    onSuccess(webhook);
+    setWebhookUrl('');
+    setIsVerified(false);
+  };
+
+  return (
+    <Modal
+      title="Add webhook URL"
+      visible={visible}
+      onOk={handleSaveWebhook}
+      onCancel={handleCancelWebhook}
+      footer={[
+        <Button key="cancel" onClick={handleCancelWebhook}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleSaveWebhook}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box mb={2}>
+        <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
+          <label htmlFor="webhook_url">Webhook URL</label>
+
+          {isVerifying ? (
+            <Text type="secondary">Verifying...</Text>
+          ) : isVerified ? (
+            <Text>Verified!</Text>
+          ) : null}
+        </Flex>
+        <Input
+          id="webhook_url"
+          size="large"
+          type="text"
+          value={url}
+          placeholder="https://myawesomeapp.com/api/webhook"
+          onChange={handleChangeUrl}
+          onBlur={handleVerifyUrl}
+        />
+      </Box>
+    </Modal>
+  );
+};
+
 type Props = RouteComponentProps<{type?: string}> & {};
 type State = {
   loading: boolean;
+  isWebhookModalOpen: boolean;
   integrations: Array<IntegrationType>;
+  webhooks: Array<WebhookEventSubscription>;
 };
 
 class IntegrationsOverview extends React.Component<Props, State> {
   state: State = {
     loading: true,
+    isWebhookModalOpen: false,
     integrations: [],
+    webhooks: [],
   };
 
   async componentDidMount() {
@@ -42,8 +296,9 @@ class IntegrationsOverview extends React.Component<Props, State> {
         this.fetchSlackIntegration(),
         this.fetchGmailIntegration(),
       ]);
+      const webhooks = await API.fetchEventSubscriptions();
 
-      this.setState({integrations, loading: false});
+      this.setState({integrations, webhooks, loading: false});
     } catch (err) {
       console.log('Error loading integrations:', err);
 
@@ -88,83 +343,40 @@ class IntegrationsOverview extends React.Component<Props, State> {
     }
   };
 
+  handleAddWebhook = () => {
+    this.setState({isWebhookModalOpen: true});
+  };
+
+  refreshEventSubscriptions = async () => {
+    try {
+      const webhooks = await API.fetchEventSubscriptions();
+
+      this.setState({webhooks});
+    } catch (err) {
+      console.log('Error refreshing event subscriptions:', err);
+    }
+  };
+
+  handleWebhookModalSuccess = (webhook: WebhookEventSubscription) => {
+    this.setState({
+      webhooks: [...this.state.webhooks, webhook],
+      isWebhookModalOpen: false,
+    });
+
+    this.refreshEventSubscriptions();
+  };
+
+  handleWebhookModalCancel = () => {
+    this.setState({isWebhookModalOpen: false});
+  };
+
   render() {
-    const {loading, integrations = []} = this.state;
-    const columns = [
-      {
-        title: 'Integration',
-        dataIndex: 'integration',
-        key: 'integration',
-        render: (value: string, record: any) => {
-          const {icon} = record;
-
-          return (
-            <Flex sx={{alignItems: 'center'}}>
-              <img src={icon} alt={value} style={{height: 20}} />
-              <Text strong style={{marginLeft: 8}}>
-                {value}
-              </Text>
-            </Flex>
-          );
-        },
-      },
-      {
-        title: 'Status',
-        dataIndex: 'status',
-        key: 'status',
-        render: (value: string) => {
-          return value === 'connected' ? (
-            <Tag color={colors.green}>Connected</Tag>
-          ) : (
-            <Tag>Not connected</Tag>
-          );
-        },
-      },
-      {
-        title: 'Connected since',
-        dataIndex: 'created_at',
-        key: 'created_at',
-        render: (value: string) => {
-          if (!value) {
-            return '--';
-          }
-
-          return dayjs(value).format('MMMM DD, YYYY');
-        },
-      },
-      {
-        title: 'Action',
-        dataIndex: 'action',
-        key: 'action',
-        render: (action: any, record: any) => {
-          const {key, status} = record;
-          const isConnected = status === 'connected';
-          // NB: when testing locally, update `origin` to an ngrok url
-          // pointing at localhost:4000 (or wherever your server is running)
-          const origin = window.location.origin;
-          const redirect = `${origin}/integrations/slack`;
-          const q = {
-            scope:
-              'incoming-webhook chat:write channels:history channels:manage chat:write.public users:read users:read.email',
-            user_scope: 'channels:history',
-            client_id: SLACK_CLIENT_ID,
-            redirect_uri: redirect,
-          };
-          const query = qs.stringify(q);
-
-          switch (key) {
-            case 'slack':
-              return (
-                <a href={`https://slack.com/oauth/v2/authorize?${query}`}>
-                  <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
-                </a>
-              );
-            default:
-              return <Button disabled>Coming soon!</Button>;
-          }
-        },
-      },
-    ];
+    const {
+      loading,
+      isWebhookModalOpen,
+      webhooks = [],
+      integrations = [],
+    } = this.state;
 
     if (loading) {
       return (
@@ -183,7 +395,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
 
     return (
       <Box p={4}>
-        <Box mb={5}>
+        <Box mb={4}>
           <Title level={4}>Integrations</Title>
 
           <Paragraph>
@@ -196,9 +408,38 @@ class IntegrationsOverview extends React.Component<Props, State> {
           </Paragraph>
 
           <Box my={4}>
-            <Table dataSource={integrations} columns={columns} />;
+            <IntegrationsTable integrations={integrations} />
           </Box>
         </Box>
+
+        <Box mb={4}>
+          <Title level={4}>Event Subscriptions</Title>
+
+          <Flex sx={{justifyContent: 'space-between', alignItems: 'baseline'}}>
+            <Paragraph>
+              <Text>
+                Create your own integrations with custom webhooks{' '}
+                <span role="img" aria-label=":)">
+                  🤓
+                </span>
+              </Text>
+            </Paragraph>
+
+            <Button icon={<PlusOutlined />} onClick={this.handleAddWebhook}>
+              Add webhook URL
+            </Button>
+          </Flex>
+
+          <Box my={4}>
+            <WebhooksTable webhooks={webhooks} />
+          </Box>
+        </Box>
+
+        <NewWebhookModal
+          visible={isWebhookModalOpen}
+          onSuccess={this.handleWebhookModalSuccess}
+          onCancel={this.handleWebhookModalCancel}
+        />
       </Box>
     );
   }

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -1,313 +1,21 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
-import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
 import qs from 'query-string';
-import {
-  colors,
-  Button,
-  Divider,
-  Input,
-  Modal,
-  Paragraph,
-  Table,
-  Tag,
-  Text,
-  Title,
-} from '../common';
+import {Button, Paragraph, Text, Title} from '../common';
 import {PlusOutlined} from '../icons';
 import Spinner from '../Spinner';
-import {SLACK_CLIENT_ID} from '../../config';
 import * as API from '../../api';
-import {sleep} from '../../utils';
-
-type IntegrationType = {
-  key: 'slack' | 'gmail';
-  integration: string;
-  status: 'connected' | 'not_connected';
-  created_at?: string | null;
-  icon: string;
-};
-
-type WebhookEventSubscription = {
-  webhook_url: string;
-  verified: boolean;
-  created_at?: string | null;
-};
-
-const IntegrationsTable = ({
-  integrations,
-}: {
-  integrations: Array<IntegrationType>;
-}) => {
-  const columns = [
-    {
-      title: 'Integration',
-      dataIndex: 'integration',
-      key: 'integration',
-      render: (value: string, record: any) => {
-        const {icon} = record;
-
-        return (
-          <Flex sx={{alignItems: 'center'}}>
-            <img src={icon} alt={value} style={{height: 20}} />
-            <Text strong style={{marginLeft: 8}}>
-              {value}
-            </Text>
-          </Flex>
-        );
-      },
-    },
-    {
-      title: 'Status',
-      dataIndex: 'status',
-      key: 'status',
-      render: (value: string) => {
-        return value === 'connected' ? (
-          <Tag color={colors.green}>Connected</Tag>
-        ) : (
-          <Tag>Not connected</Tag>
-        );
-      },
-    },
-    {
-      title: 'Connected since',
-      dataIndex: 'created_at',
-      key: 'created_at',
-      render: (value: string) => {
-        if (!value) {
-          return '--';
-        }
-
-        return dayjs(value).format('MMMM DD, YYYY');
-      },
-    },
-    {
-      title: '',
-      dataIndex: 'action',
-      key: 'action',
-      render: (action: any, record: any) => {
-        const {key, status} = record;
-        const isConnected = status === 'connected';
-        // NB: when testing locally, update `origin` to an ngrok url
-        // pointing at localhost:4000 (or wherever your server is running)
-        const origin = window.location.origin;
-        const redirect = `${origin}/integrations/slack`;
-        const q = {
-          scope:
-            'incoming-webhook chat:write channels:history channels:manage chat:write.public users:read users:read.email',
-          user_scope: 'channels:history',
-          client_id: SLACK_CLIENT_ID,
-          redirect_uri: redirect,
-        };
-        const query = qs.stringify(q);
-
-        switch (key) {
-          case 'slack':
-            return (
-              <a href={`https://slack.com/oauth/v2/authorize?${query}`}>
-                <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
-              </a>
-            );
-          default:
-            return <Button disabled>Coming soon!</Button>;
-        }
-      },
-    },
-  ];
-
-  return <Table dataSource={integrations} columns={columns} />;
-};
-
-const WebhooksTable = ({
-  webhooks,
-}: {
-  webhooks: Array<WebhookEventSubscription>;
-}) => {
-  const columns = [
-    {
-      title: 'Webhook URL',
-      dataIndex: 'webhook_url',
-      key: 'webhook_url',
-      render: (value: string, record: any) => {
-        return (
-          <Text keyboard strong>
-            {value}
-          </Text>
-        );
-      },
-    },
-    {
-      title: 'Status',
-      dataIndex: 'verified',
-      key: 'verified',
-      render: (verified: boolean) => {
-        return verified ? (
-          <Tag color={colors.green}>Verified</Tag>
-        ) : (
-          <Tag>Unverified</Tag>
-        );
-      },
-    },
-    {
-      title: 'Connected since',
-      dataIndex: 'created_at',
-      key: 'created_at',
-      render: (value: string) => {
-        if (!value) {
-          return '--';
-        }
-
-        return dayjs(value).format('MMMM DD, YYYY');
-      },
-    },
-    {
-      title: '',
-      dataIndex: 'action',
-      key: 'action',
-      render: (action: any, record: any) => {
-        return <Button>Update</Button>;
-      },
-    },
-  ];
-
-  return <Table rowKey="id" dataSource={webhooks} columns={columns} />;
-};
-
-// TODO: clean up a bit
-const NewWebhookModal = ({
-  visible,
-  onSuccess,
-  onCancel,
-}: {
-  visible: boolean;
-  onSuccess: (webhook: WebhookEventSubscription) => void;
-  onCancel: () => void;
-}) => {
-  const [url, setWebhookUrl] = React.useState('');
-  const [isVerifying, setIsVerifying] = React.useState(false);
-  const [isVerified, setIsVerified] = React.useState(false);
-  const [isSaving, setIsSaving] = React.useState(false);
-
-  const handleChangeUrl = (e: any) => setWebhookUrl(e.target.value);
-
-  const handleVerifyUrl = async () => {
-    console.log('Verifying:', url);
-    setIsVerifying(true);
-
-    const {verified} = await API.verifyWebhookUrl(url);
-    console.log('Verified?', verified);
-    await sleep(1000);
-
-    setIsVerifying(false);
-    setIsVerified(verified);
-  };
-
-  const handleCancelWebhook = () => {
-    onCancel();
-    setWebhookUrl('');
-    setIsVerified(false);
-  };
-
-  const handleSaveWebhook = async () => {
-    console.log('Saving:', url);
-    setIsSaving(true);
-
-    const webhook = await API.createEventSubscriptions({
-      webhook_url: url,
-    });
-
-    setIsSaving(false);
-    onSuccess(webhook);
-    setWebhookUrl('');
-    setIsVerified(false);
-  };
-
-  return (
-    <Modal
-      title="Add webhook URL"
-      visible={visible}
-      onOk={handleSaveWebhook}
-      onCancel={handleCancelWebhook}
-      footer={[
-        <Button key="cancel" onClick={handleCancelWebhook}>
-          Cancel
-        </Button>,
-        <Button
-          key="submit"
-          type="primary"
-          loading={isSaving}
-          onClick={handleSaveWebhook}
-        >
-          Save
-        </Button>,
-      ]}
-    >
-      <Box>
-        <Paragraph>
-          <Text>
-            You can subscribe to be notified of events in Papercups (for
-            example, when a new message is created) at a URL of your choice.
-          </Text>
-        </Paragraph>
-
-        <Box>
-          <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
-            <label htmlFor="webhook_url">
-              <Text strong>Webhook URL</Text>
-            </label>
-
-            {isVerifying ? (
-              <Text type="secondary">Verifying...</Text>
-            ) : isVerified ? (
-              <Text>Verified!</Text>
-            ) : null}
-          </Flex>
-          <Input
-            id="webhook_url"
-            size="large"
-            type="text"
-            value={url}
-            placeholder="https://myawesomeapp.com/api/webhook"
-            onChange={handleChangeUrl}
-            onBlur={handleVerifyUrl}
-          />
-        </Box>
-
-        <Divider />
-
-        <Paragraph>
-          <Text type="secondary">
-            We'll send HTTP POST requests to this URL when events occur. As soon
-            as you enter a URL, we'll send a request with a{' '}
-            <Text code>payload</Text> parameter, and your endpoint must respond
-            with the value.
-          </Text>
-        </Paragraph>
-
-        <Paragraph>
-          <Text type="secondary">
-            Note that for development URLs using <Text code>localhost</Text>,
-            you may need to use a tool like{' '}
-            <a
-              href="https://ngrok.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              ngrok
-            </a>{' '}
-            to test your URL.
-          </Text>
-        </Paragraph>
-      </Box>
-    </Modal>
-  );
-};
+import {IntegrationType, WebhookEventSubscription} from './support';
+import IntegrationsTable from './IntegrationsTable';
+import WebhooksTable from './WebhooksTable';
+import NewWebhookModal from './NewWebhookModal';
 
 type Props = RouteComponentProps<{type?: string}> & {};
 type State = {
   loading: boolean;
   isWebhookModalOpen: boolean;
+  selectedWebhook: WebhookEventSubscription | null;
   integrations: Array<IntegrationType>;
   webhooks: Array<WebhookEventSubscription>;
 };
@@ -316,6 +24,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
   state: State = {
     loading: true,
     isWebhookModalOpen: false,
+    selectedWebhook: null,
     integrations: [],
     webhooks: [],
   };
@@ -385,6 +94,10 @@ class IntegrationsOverview extends React.Component<Props, State> {
     this.setState({isWebhookModalOpen: true});
   };
 
+  handleUpdateWebhook = (webhook: WebhookEventSubscription) => {
+    this.setState({isWebhookModalOpen: true, selectedWebhook: webhook});
+  };
+
   refreshEventSubscriptions = async () => {
     try {
       const webhooks = await API.fetchEventSubscriptions();
@@ -397,21 +110,22 @@ class IntegrationsOverview extends React.Component<Props, State> {
 
   handleWebhookModalSuccess = (webhook: WebhookEventSubscription) => {
     this.setState({
-      webhooks: [...this.state.webhooks, webhook],
       isWebhookModalOpen: false,
+      selectedWebhook: null,
     });
 
     this.refreshEventSubscriptions();
   };
 
   handleWebhookModalCancel = () => {
-    this.setState({isWebhookModalOpen: false});
+    this.setState({isWebhookModalOpen: false, selectedWebhook: null});
   };
 
   render() {
     const {
       loading,
       isWebhookModalOpen,
+      selectedWebhook,
       webhooks = [],
       integrations = [],
     } = this.state;
@@ -469,11 +183,15 @@ class IntegrationsOverview extends React.Component<Props, State> {
           </Flex>
 
           <Box my={4}>
-            <WebhooksTable webhooks={webhooks} />
+            <WebhooksTable
+              webhooks={webhooks}
+              onUpdateWebhook={this.handleUpdateWebhook}
+            />
           </Box>
         </Box>
 
         <NewWebhookModal
+          webhook={selectedWebhook}
           visible={isWebhookModalOpen}
           onSuccess={this.handleWebhookModalSuccess}
           onCancel={this.handleWebhookModalCancel}

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -6,6 +6,7 @@ import qs from 'query-string';
 import {
   colors,
   Button,
+  Divider,
   Input,
   Modal,
   Paragraph,
@@ -242,25 +243,62 @@ const NewWebhookModal = ({
         </Button>,
       ]}
     >
-      <Box mb={2}>
-        <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
-          <label htmlFor="webhook_url">Webhook URL</label>
+      <Box>
+        <Paragraph>
+          <Text>
+            You can subscribe to be notified of events in Papercups (for
+            example, when a new message is created) at a URL of your choice.
+          </Text>
+        </Paragraph>
 
-          {isVerifying ? (
-            <Text type="secondary">Verifying...</Text>
-          ) : isVerified ? (
-            <Text>Verified!</Text>
-          ) : null}
-        </Flex>
-        <Input
-          id="webhook_url"
-          size="large"
-          type="text"
-          value={url}
-          placeholder="https://myawesomeapp.com/api/webhook"
-          onChange={handleChangeUrl}
-          onBlur={handleVerifyUrl}
-        />
+        <Box>
+          <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <label htmlFor="webhook_url">
+              <Text strong>Webhook URL</Text>
+            </label>
+
+            {isVerifying ? (
+              <Text type="secondary">Verifying...</Text>
+            ) : isVerified ? (
+              <Text>Verified!</Text>
+            ) : null}
+          </Flex>
+          <Input
+            id="webhook_url"
+            size="large"
+            type="text"
+            value={url}
+            placeholder="https://myawesomeapp.com/api/webhook"
+            onChange={handleChangeUrl}
+            onBlur={handleVerifyUrl}
+          />
+        </Box>
+
+        <Divider />
+
+        <Paragraph>
+          <Text type="secondary">
+            We'll send HTTP POST requests to this URL when events occur. As soon
+            as you enter a URL, we'll send a request with a{' '}
+            <Text code>payload</Text> parameter, and your endpoint must respond
+            with the value.
+          </Text>
+        </Paragraph>
+
+        <Paragraph>
+          <Text type="secondary">
+            Note that for development URLs using <Text code>localhost</Text>,
+            you may need to use a tool like{' '}
+            <a
+              href="https://ngrok.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ngrok
+            </a>{' '}
+            to test your URL.
+          </Text>
+        </Paragraph>
       </Box>
     </Modal>
   );

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -98,6 +98,17 @@ class IntegrationsOverview extends React.Component<Props, State> {
     this.setState({isWebhookModalOpen: true, selectedWebhook: webhook});
   };
 
+  handleDeleteWebhook = async (webhook: WebhookEventSubscription) => {
+    const {id: webhookId} = webhook;
+
+    if (!webhookId) {
+      return;
+    }
+
+    await API.deleteEventSubscription(webhookId);
+    await this.refreshEventSubscriptions();
+  };
+
   refreshEventSubscriptions = async () => {
     try {
       const webhooks = await API.fetchEventSubscriptions();
@@ -186,6 +197,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
             <WebhooksTable
               webhooks={webhooks}
               onUpdateWebhook={this.handleUpdateWebhook}
+              onDeleteWebhook={this.handleDeleteWebhook}
             />
           </Box>
         </Box>

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import {Flex} from 'theme-ui';
+import qs from 'query-string';
+import {colors, Button, Table, Tag, Text} from '../common';
+import {SLACK_CLIENT_ID} from '../../config';
+import {IntegrationType} from './support';
+
+const IntegrationsTable = ({
+  integrations,
+}: {
+  integrations: Array<IntegrationType>;
+}) => {
+  const columns = [
+    {
+      title: 'Integration',
+      dataIndex: 'integration',
+      key: 'integration',
+      render: (value: string, record: any) => {
+        const {icon} = record;
+
+        return (
+          <Flex sx={{alignItems: 'center'}}>
+            <img src={icon} alt={value} style={{height: 20}} />
+            <Text strong style={{marginLeft: 8}}>
+              {value}
+            </Text>
+          </Flex>
+        );
+      },
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      render: (value: string) => {
+        return value === 'connected' ? (
+          <Tag color={colors.green}>Connected</Tag>
+        ) : (
+          <Tag>Not connected</Tag>
+        );
+      },
+    },
+    {
+      title: 'Connected since',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => {
+        if (!value) {
+          return '--';
+        }
+
+        return dayjs(value).format('MMMM DD, YYYY');
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (action: any, record: any) => {
+        const {key, status} = record;
+        const isConnected = status === 'connected';
+        // NB: when testing locally, update `origin` to an ngrok url
+        // pointing at localhost:4000 (or wherever your server is running)
+        const origin = window.location.origin;
+        const redirect = `${origin}/integrations/slack`;
+        const q = {
+          scope:
+            'incoming-webhook chat:write channels:history channels:manage chat:write.public users:read users:read.email',
+          user_scope: 'channels:history',
+          client_id: SLACK_CLIENT_ID,
+          redirect_uri: redirect,
+        };
+        const query = qs.stringify(q);
+
+        switch (key) {
+          case 'slack':
+            return (
+              <a href={`https://slack.com/oauth/v2/authorize?${query}`}>
+                <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
+              </a>
+            );
+          default:
+            return <Button disabled>Coming soon!</Button>;
+        }
+      },
+    },
+  ];
+
+  return <Table dataSource={integrations} columns={columns} />;
+};
+
+export default IntegrationsTable;

--- a/assets/src/components/integrations/NewWebhookModal.tsx
+++ b/assets/src/components/integrations/NewWebhookModal.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Button, Divider, Input, Modal, Paragraph, Text} from '../common';
+import * as API from '../../api';
+import {sleep} from '../../utils';
+import {WebhookEventSubscription} from './support';
+
+// TODO: clean up a bit
+const NewWebhookModal = ({
+  webhook,
+  visible,
+  onSuccess,
+  onCancel,
+}: {
+  webhook?: WebhookEventSubscription | null;
+  visible: boolean;
+  onSuccess: (webhook: WebhookEventSubscription) => void;
+  onCancel: () => void;
+}) => {
+  const defaultWebhookUrl = webhook?.webhook_url ?? '';
+  const [url, setWebhookUrl] = React.useState(defaultWebhookUrl);
+  const [isVerifying, setIsVerifying] = React.useState(false);
+  const [isVerified, setIsVerified] = React.useState(false);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  // TODO: figure out a better way to handle this
+  React.useEffect(() => {
+    const url = webhook?.webhook_url ?? '';
+
+    setWebhookUrl(url);
+  }, [webhook]);
+
+  const handleChangeUrl = (e: any) => setWebhookUrl(e.target.value);
+
+  const handleVerifyUrl = async () => {
+    console.log('Verifying:', url);
+    setIsVerifying(true);
+
+    const {verified} = await API.verifyWebhookUrl(url);
+    console.log('Verified?', verified);
+    await sleep(1000);
+
+    setIsVerifying(false);
+    setIsVerified(verified);
+  };
+
+  const handleCancelWebhook = () => {
+    onCancel();
+    setWebhookUrl('');
+    setIsVerified(false);
+  };
+
+  const handleSaveWebhook = async () => {
+    console.log('Saving:', url);
+    setIsSaving(true);
+    const existingWebhookId = webhook && webhook.id;
+    const params = {webhook_url: url};
+    const result = existingWebhookId
+      ? await API.updateEventSubscription(existingWebhookId, params)
+      : await API.createEventSubscription(params);
+
+    setIsSaving(false);
+    onSuccess(result);
+    setWebhookUrl('');
+    setIsVerified(false);
+  };
+
+  return (
+    <Modal
+      title="Add webhook URL"
+      visible={visible}
+      onOk={handleSaveWebhook}
+      onCancel={handleCancelWebhook}
+      footer={[
+        <Button key="cancel" onClick={handleCancelWebhook}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleSaveWebhook}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Paragraph>
+          <Text>
+            You can subscribe to be notified of events in Papercups (for
+            example, when a new message is created) at a URL of your choice.
+          </Text>
+        </Paragraph>
+
+        <Box>
+          <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
+            <label htmlFor="webhook_url">
+              <Text strong>Webhook URL</Text>
+            </label>
+
+            {isVerifying ? (
+              <Text type="secondary">Verifying...</Text>
+            ) : isVerified ? (
+              <Text>Verified!</Text>
+            ) : null}
+          </Flex>
+          <Input
+            id="webhook_url"
+            size="large"
+            type="text"
+            value={url}
+            placeholder="https://myawesomeapp.com/api/webhook"
+            onChange={handleChangeUrl}
+            onBlur={handleVerifyUrl}
+          />
+        </Box>
+
+        <Divider />
+
+        <Paragraph>
+          <Text type="secondary">
+            We'll send HTTP POST requests to this URL when events occur. As soon
+            as you enter a URL, we'll send a request with a{' '}
+            <Text code>payload</Text> parameter, and your endpoint must respond
+            with the value.
+          </Text>
+        </Paragraph>
+
+        <Paragraph>
+          <Text type="secondary">
+            Note that for development URLs using <Text code>localhost</Text>,
+            you may need to use a tool like{' '}
+            <a
+              href="https://ngrok.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ngrok
+            </a>{' '}
+            to test your URL.
+          </Text>
+        </Paragraph>
+      </Box>
+    </Modal>
+  );
+};
+
+export default NewWebhookModal;

--- a/assets/src/components/integrations/WebhooksTable.tsx
+++ b/assets/src/components/integrations/WebhooksTable.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import {colors, Button, Table, Tag, Text} from '../common';
+import {WebhookEventSubscription} from './support';
+
+const WebhooksTable = ({
+  webhooks,
+  onUpdateWebhook,
+}: {
+  webhooks: Array<WebhookEventSubscription>;
+  onUpdateWebhook: (webhook: WebhookEventSubscription) => void;
+}) => {
+  const columns = [
+    {
+      title: 'Webhook URL',
+      dataIndex: 'webhook_url',
+      key: 'webhook_url',
+      render: (value: string, record: any) => {
+        return (
+          <Text keyboard strong>
+            {value}
+          </Text>
+        );
+      },
+    },
+    {
+      title: 'Status',
+      dataIndex: 'verified',
+      key: 'verified',
+      render: (verified: boolean) => {
+        return verified ? (
+          <Tag color={colors.green}>Verified</Tag>
+        ) : (
+          <Tag>Unverified</Tag>
+        );
+      },
+    },
+    {
+      title: 'Connected since',
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (value: string) => {
+        if (!value) {
+          return '--';
+        }
+
+        return dayjs(value).format('MMMM DD, YYYY');
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (action: any, record: WebhookEventSubscription) => {
+        return <Button onClick={() => onUpdateWebhook(record)}>Update</Button>;
+      },
+    },
+  ];
+
+  return <Table rowKey="id" dataSource={webhooks} columns={columns} />;
+};
+
+export default WebhooksTable;

--- a/assets/src/components/integrations/WebhooksTable.tsx
+++ b/assets/src/components/integrations/WebhooksTable.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
+import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
-import {colors, Button, Table, Tag, Text} from '../common';
+import {colors, Button, Popconfirm, Table, Tag, Text} from '../common';
 import {WebhookEventSubscription} from './support';
 
 const WebhooksTable = ({
   webhooks,
   onUpdateWebhook,
+  onDeleteWebhook,
 }: {
   webhooks: Array<WebhookEventSubscription>;
   onUpdateWebhook: (webhook: WebhookEventSubscription) => void;
+  onDeleteWebhook: (webhook: WebhookEventSubscription) => void;
 }) => {
   const columns = [
     {
@@ -52,7 +55,25 @@ const WebhooksTable = ({
       dataIndex: 'action',
       key: 'action',
       render: (action: any, record: WebhookEventSubscription) => {
-        return <Button onClick={() => onUpdateWebhook(record)}>Update</Button>;
+        return (
+          <Flex mx={-1}>
+            <Box mx={1}>
+              <Button onClick={() => onUpdateWebhook(record)}>Update</Button>
+            </Box>
+            <Box mx={1}>
+              {/* TODO: maybe use an icon here instead? (and figure out how to animate deletions) */}
+              <Popconfirm
+                title="Are you sure you want to delete this webhook?"
+                okText="Yes"
+                cancelText="No"
+                placement="topLeft"
+                onConfirm={() => onDeleteWebhook(record)}
+              >
+                <Button danger>Remove</Button>
+              </Popconfirm>
+            </Box>
+          </Flex>
+        );
       },
     },
   ];

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -1,0 +1,14 @@
+export type IntegrationType = {
+  key: 'slack' | 'gmail';
+  integration: string;
+  status: 'connected' | 'not_connected';
+  created_at?: string | null;
+  icon: string;
+};
+
+export type WebhookEventSubscription = {
+  id?: string;
+  webhook_url: string;
+  verified: boolean;
+  created_at?: string | null;
+};

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -84,7 +84,7 @@ defmodule ChatApi.Conversations do
 
   """
   def get_conversation!(id) do
-    Conversation |> Repo.get!(id) |> Repo.preload([:messages, :customer])
+    Conversation |> Repo.get!(id) |> Repo.preload([:customer, messages: [user: :profile]])
   end
 
   def get_conversation(id) do

--- a/lib/chat_api/event_subscriptions.ex
+++ b/lib/chat_api/event_subscriptions.ex
@@ -1,0 +1,104 @@
+defmodule ChatApi.EventSubscriptions do
+  @moduledoc """
+  The EventSubscriptions context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.EventSubscriptions.EventSubscription
+
+  @doc """
+  Returns the list of event_subscriptions.
+
+  ## Examples
+
+      iex> list_event_subscriptions(account_id)
+      [%EventSubscription{}, ...]
+
+  """
+  def list_event_subscriptions(account_id) do
+    EventSubscription |> where(account_id: ^account_id) |> Repo.all()
+  end
+
+  @doc """
+  Gets a single event_subscription.
+
+  Raises `Ecto.NoResultsError` if the Event subscription does not exist.
+
+  ## Examples
+
+      iex> get_event_subscription!(123)
+      %EventSubscription{}
+
+      iex> get_event_subscription!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_event_subscription!(id), do: Repo.get!(EventSubscription, id)
+
+  @doc """
+  Creates a event_subscription.
+
+  ## Examples
+
+      iex> create_event_subscription(%{field: value})
+      {:ok, %EventSubscription{}}
+
+      iex> create_event_subscription(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_event_subscription(attrs \\ %{}) do
+    %EventSubscription{}
+    |> EventSubscription.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a event_subscription.
+
+  ## Examples
+
+      iex> update_event_subscription(event_subscription, %{field: new_value})
+      {:ok, %EventSubscription{}}
+
+      iex> update_event_subscription(event_subscription, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_event_subscription(%EventSubscription{} = event_subscription, attrs) do
+    event_subscription
+    |> EventSubscription.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a event_subscription.
+
+  ## Examples
+
+      iex> delete_event_subscription(event_subscription)
+      {:ok, %EventSubscription{}}
+
+      iex> delete_event_subscription(event_subscription)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_event_subscription(%EventSubscription{} = event_subscription) do
+    Repo.delete(event_subscription)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking event_subscription changes.
+
+  ## Examples
+
+      iex> change_event_subscription(event_subscription)
+      %Ecto.Changeset{data: %EventSubscription{}}
+
+  """
+  def change_event_subscription(%EventSubscription{} = event_subscription, attrs \\ %{}) do
+    EventSubscription.changeset(event_subscription, attrs)
+  end
+end

--- a/lib/chat_api/event_subscriptions/event_subscription.ex
+++ b/lib/chat_api/event_subscriptions/event_subscription.ex
@@ -1,0 +1,25 @@
+defmodule ChatApi.EventSubscriptions.EventSubscription do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "event_subscriptions" do
+    field :scope, :string
+    field :webhook_url, :string
+    field :verified, :boolean, default: false
+
+    belongs_to(:account, Account)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(event_subscription, attrs) do
+    event_subscription
+    |> cast(attrs, [:webhook_url, :verified, :account_id, :scope])
+    |> validate_required([:webhook_url, :account_id])
+  end
+end

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -56,13 +56,10 @@ defmodule ChatApiWeb.NotificationChannel do
         |> Map.merge(%{"user_id" => user_id, "account_id" => account_id})
         |> Messages.create_message()
 
-      # message = Messages.get_message!(message.id)
       message
       |> Map.get(:id)
       |> Messages.get_message!()
       |> broadcast_new_message()
-
-      # broadcast_new_message(message)
     end
 
     {:noreply, socket}

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -3,7 +3,7 @@ defmodule ChatApiWeb.NotificationChannel do
 
   alias ChatApiWeb.Presence
   alias Phoenix.Socket.Broadcast
-  alias ChatApi.{Messages, Conversations}
+  alias ChatApi.{Messages, Conversations, EventSubscriptions}
 
   @impl true
   def join("notification:" <> account_id, %{"ids" => ids}, socket) do
@@ -56,17 +56,13 @@ defmodule ChatApiWeb.NotificationChannel do
         |> Map.merge(%{"user_id" => user_id, "account_id" => account_id})
         |> Messages.create_message()
 
-      message = Messages.get_message!(message.id)
-      result = ChatApiWeb.MessageView.render("expanded.json", message: message)
+      # message = Messages.get_message!(message.id)
+      message
+      |> Map.get(:id)
+      |> Messages.get_message!()
+      |> broadcast_new_message()
 
-      # TODO: write doc explaining difference between push, broadcast, etc.
-      push(socket, "shout", result)
-
-      %{conversation_id: conversation_id} = result
-      topic = "conversation:" <> conversation_id
-
-      ChatApiWeb.Endpoint.broadcast_from!(self(), topic, "shout", result)
-      ChatApi.Slack.send_conversation_message_alert(conversation_id, message.body, type: :agent)
+      # broadcast_new_message(message)
     end
 
     {:noreply, socket}
@@ -99,6 +95,41 @@ defmodule ChatApiWeb.NotificationChannel do
     end
 
     {:noreply, socket}
+  end
+
+  defp send_message_alerts(message) do
+    %{conversation_id: conversation_id, customer_id: customer_id, body: body} = message
+    type = if is_nil(customer_id), do: :agent, else: :customer
+
+    # TODO: how should we handle errors here?
+    ChatApi.Slack.send_conversation_message_alert(conversation_id, body, type: type)
+  end
+
+  # TODO: DRY up with conversation channel
+  defp send_webhook_notifications(account_id, payload) do
+    EventSubscriptions.notify_event_subscriptions(account_id, %{
+      "event" => "message:created",
+      "payload" => payload
+    })
+  end
+
+  defp broadcast_new_message(message) do
+    json = ChatApiWeb.MessageView.render("expanded.json", message: message)
+    %{conversation_id: conversation_id, account_id: account_id} = message
+    topic = "conversation:" <> conversation_id
+
+    # TODO: explain the difference between broadcast! and broadcast_from! and
+    # why we use one vs the other here
+    ChatApiWeb.Endpoint.broadcast!(topic, "shout", json)
+
+    # Handling async for now
+    Task.start(fn ->
+      send_message_alerts(message)
+    end)
+
+    Task.start(fn ->
+      send_webhook_notifications(account_id, json)
+    end)
   end
 
   defp put_new_topics(socket, topics) do

--- a/lib/chat_api_web/controllers/event_subscription_controller.ex
+++ b/lib/chat_api_web/controllers/event_subscription_controller.ex
@@ -1,0 +1,56 @@
+defmodule ChatApiWeb.EventSubscriptionController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.EventSubscriptions
+  alias ChatApi.EventSubscriptions.EventSubscription
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(conn, _params) do
+    with %{account_id: account_id} <- conn.assigns.current_user do
+      event_subscriptions = EventSubscriptions.list_event_subscriptions(account_id)
+      render(conn, "index.json", event_subscriptions: event_subscriptions)
+    end
+  end
+
+  def create(conn, %{"event_subscription" => event_subscription_params}) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         params <- Map.merge(event_subscription_params, %{"account_id" => account_id}),
+         {:ok, %EventSubscription{} = event_subscription} <-
+           EventSubscriptions.create_event_subscription(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header(
+        "location",
+        Routes.event_subscription_path(conn, :show, event_subscription)
+      )
+      |> render("show.json", event_subscription: event_subscription)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    event_subscription = EventSubscriptions.get_event_subscription!(id)
+    render(conn, "show.json", event_subscription: event_subscription)
+  end
+
+  def update(conn, %{"id" => id, "event_subscription" => event_subscription_params}) do
+    event_subscription = EventSubscriptions.get_event_subscription!(id)
+
+    with {:ok, %EventSubscription{} = event_subscription} <-
+           EventSubscriptions.update_event_subscription(
+             event_subscription,
+             event_subscription_params
+           ) do
+      render(conn, "show.json", event_subscription: event_subscription)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    event_subscription = EventSubscriptions.get_event_subscription!(id)
+
+    with {:ok, %EventSubscription{}} <-
+           EventSubscriptions.delete_event_subscription(event_subscription) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -22,8 +22,13 @@ defmodule ChatApiWeb.MessageController do
   end
 
   def create(conn, %{"message" => message_params}) do
-    with {:ok, %Message{} = msg} <- Messages.create_message(message_params),
-         message <- Messages.get_message!(msg.id) do
+    with %{id: user_id, account_id: account_id} <- conn.assigns.current_user,
+         {:ok, %Message{} = msg} <-
+           message_params
+           |> Map.merge(%{"user_id" => user_id, "account_id" => account_id})
+           |> Messages.create_message(),
+         message <-
+           Messages.get_message!(msg.id) do
       broadcast_new_message(message)
 
       conn

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -1,7 +1,7 @@
 defmodule ChatApiWeb.MessageController do
   use ChatApiWeb, :controller
 
-  alias ChatApi.Messages
+  alias ChatApi.{EventSubscriptions, Messages}
   alias ChatApi.Messages.Message
 
   action_fallback(ChatApiWeb.FallbackController)
@@ -55,12 +55,35 @@ defmodule ChatApiWeb.MessageController do
   end
 
   defp broadcast_new_message(message) do
-    result = ChatApiWeb.MessageView.render("expanded.json", message: message)
-    %{conversation_id: conversation_id, body: body, customer_id: customer_id} = message
+    json = ChatApiWeb.MessageView.render("expanded.json", message: message)
+    %{conversation_id: conversation_id, account_id: account_id} = message
     topic = "conversation:" <> conversation_id
+
+    ChatApiWeb.Endpoint.broadcast!(topic, "shout", json)
+
+    # Handling async for now
+    Task.start(fn ->
+      send_message_alerts(message)
+    end)
+
+    Task.start(fn ->
+      send_webhook_notifications(account_id, json)
+    end)
+  end
+
+  defp send_message_alerts(message) do
+    %{conversation_id: conversation_id, customer_id: customer_id, body: body} = message
     type = if is_nil(customer_id), do: :agent, else: :customer
 
-    ChatApiWeb.Endpoint.broadcast!(topic, "shout", result)
+    # TODO: how should we handle errors here?
     ChatApi.Slack.send_conversation_message_alert(conversation_id, body, type: type)
+  end
+
+  # TODO: DRY up with conversation channel
+  defp send_webhook_notifications(account_id, payload) do
+    EventSubscriptions.notify_event_subscriptions(account_id, %{
+      "event" => "message:created",
+      "payload" => payload
+    })
   end
 end

--- a/lib/chat_api_web/controllers/session_controller.ex
+++ b/lib/chat_api_web/controllers/session_controller.ex
@@ -12,6 +12,9 @@ defmodule ChatApiWeb.SessionController do
       {:ok, conn} ->
         json(conn, %{
           data: %{
+            user_id: conn.assigns.current_user.id,
+            email: conn.assigns.current_user.email,
+            account_id: conn.assigns.current_user.account_id,
             token: conn.private[:api_auth_token],
             renew_token: conn.private[:api_renew_token]
           }
@@ -36,9 +39,12 @@ defmodule ChatApiWeb.SessionController do
         |> put_status(401)
         |> json(%{error: %{status: 401, message: "Invalid token"}})
 
-      {conn, _user} ->
+      {conn, user} ->
         json(conn, %{
           data: %{
+            user_id: user.id,
+            email: user.email,
+            account_id: user.account_id,
             token: conn.private[:api_auth_token],
             renew_token: conn.private[:api_renew_token]
           }

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -94,11 +94,10 @@ defmodule ChatApiWeb.SlackController do
     # TODO: switch to `debug`
     Logger.info("Payload from Slack webhook: #{inspect(payload)}")
 
-    case payload do
-      # TODO: remove!
-      %{"event" => "webhook:verify"} ->
-        send_resp(conn, 200, payload["payload"])
+    # TODO: remove after testing webhook event subscriptions!
+    handle_test_payload(payload)
 
+    case payload do
       %{"event" => event} ->
         handle_event(event)
         send_resp(conn, 200, "")
@@ -109,6 +108,10 @@ defmodule ChatApiWeb.SlackController do
       _ ->
         send_resp(conn, 200, "")
     end
+  end
+
+  defp handle_test_payload(%{"event" => event, "payload" => payload}) do
+    IO.inspect("Event: #{inspect(event)} - Payload: #{inspect(payload)}")
   end
 
   defp handle_event(%{"bot_id" => _bot_id} = _event) do

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -95,6 +95,10 @@ defmodule ChatApiWeb.SlackController do
     Logger.info("Payload from Slack webhook: #{inspect(payload)}")
 
     case payload do
+      # TODO: remove!
+      %{"event" => "webhook:verify"} ->
+        send_resp(conn, 200, payload["payload"])
+
       %{"event" => event} ->
         handle_event(event)
         send_resp(conn, 200, "")

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -94,9 +94,6 @@ defmodule ChatApiWeb.SlackController do
     # TODO: switch to `debug`
     Logger.info("Payload from Slack webhook: #{inspect(payload)}")
 
-    # TODO: remove after testing webhook event subscriptions!
-    handle_test_payload(payload)
-
     case payload do
       %{"event" => event} ->
         handle_event(event)
@@ -108,10 +105,6 @@ defmodule ChatApiWeb.SlackController do
       _ ->
         send_resp(conn, 200, "")
     end
-  end
-
-  defp handle_test_payload(%{"event" => event, "payload" => payload}) do
-    IO.inspect("Event: #{inspect(event)} - Payload: #{inspect(payload)}")
   end
 
   defp handle_event(%{"bot_id" => _bot_id} = _event) do

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -64,6 +64,7 @@ defmodule ChatApiWeb.Router do
     resources("/messages", MessageController, except: [:new, :edit])
     resources("/conversations", ConversationController, except: [:new, :edit, :create])
     resources("/customers", CustomerController, except: [:new, :edit, :create])
+    resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
   end
 
   # Enables LiveDashboard only for development

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -65,6 +65,7 @@ defmodule ChatApiWeb.Router do
     resources("/conversations", ConversationController, except: [:new, :edit, :create])
     resources("/customers", CustomerController, except: [:new, :edit, :create])
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
+    post("/event_subscriptions/verify", EventSubscriptionController, :verify)
   end
 
   # Enables LiveDashboard only for development

--- a/lib/chat_api_web/views/event_subscription_view.ex
+++ b/lib/chat_api_web/views/event_subscription_view.ex
@@ -1,0 +1,22 @@
+defmodule ChatApiWeb.EventSubscriptionView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.EventSubscriptionView
+
+  def render("index.json", %{event_subscriptions: event_subscriptions}) do
+    %{data: render_many(event_subscriptions, EventSubscriptionView, "event_subscription.json")}
+  end
+
+  def render("show.json", %{event_subscription: event_subscription}) do
+    %{data: render_one(event_subscription, EventSubscriptionView, "event_subscription.json")}
+  end
+
+  def render("event_subscription.json", %{event_subscription: event_subscription}) do
+    %{
+      id: event_subscription.id,
+      webhook_url: event_subscription.webhook_url,
+      verified: event_subscription.verified,
+      account_id: event_subscription.account_id,
+      scope: event_subscription.scope
+    }
+  end
+end

--- a/lib/chat_api_web/views/event_subscription_view.ex
+++ b/lib/chat_api_web/views/event_subscription_view.ex
@@ -13,6 +13,8 @@ defmodule ChatApiWeb.EventSubscriptionView do
   def render("event_subscription.json", %{event_subscription: event_subscription}) do
     %{
       id: event_subscription.id,
+      created_at: event_subscription.inserted_at,
+      updated_at: event_subscription.updated_at,
       webhook_url: event_subscription.webhook_url,
       verified: event_subscription.verified,
       account_id: event_subscription.account_id,

--- a/priv/repo/migrations/20200822192627_create_event_subscriptions.exs
+++ b/priv/repo/migrations/20200822192627_create_event_subscriptions.exs
@@ -1,0 +1,18 @@
+defmodule ChatApi.Repo.Migrations.CreateEventSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    create table(:event_subscriptions, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:webhook_url, :string)
+      add(:verified, :boolean, default: false, null: false)
+      add(:scope, :string)
+
+      add(:account_id, references(:accounts, type: :uuid, on_delete: :delete_all))
+
+      timestamps()
+    end
+
+    create(index(:event_subscriptions, [:account_id]))
+  end
+end

--- a/test/chat_api/event_subscriptions_test.exs
+++ b/test/chat_api/event_subscriptions_test.exs
@@ -1,0 +1,116 @@
+defmodule ChatApi.EventSubscriptionsTest do
+  use ChatApi.DataCase
+
+  alias ChatApi.{Accounts, EventSubscriptions}
+
+  describe "event_subscriptions" do
+    alias ChatApi.EventSubscriptions.EventSubscription
+
+    @valid_attrs %{
+      scope: "some scope",
+      verified: true,
+      webhook_url: "some webhook_url"
+    }
+    @update_attrs %{
+      scope: "some updated scope",
+      verified: false,
+      webhook_url: "some updated webhook_url"
+    }
+    @invalid_attrs %{account_id: nil, scope: nil, verified: nil, webhook_url: nil}
+
+    def event_subscription_fixture(attrs \\ %{}) do
+      %{id: account_id} = account_fixture()
+
+      {:ok, event_subscription} =
+        attrs
+        |> Enum.into(%{account_id: account_id})
+        |> Enum.into(@valid_attrs)
+        |> EventSubscriptions.create_event_subscription()
+
+      event_subscription
+    end
+
+    def account_fixture(attrs \\ %{}) do
+      {:ok, account} =
+        %{company_name: "Test Inc"}
+        |> Enum.into(attrs)
+        |> Accounts.create_account()
+
+      account
+    end
+
+    setup do
+      account = account_fixture()
+
+      {:ok, account: account}
+    end
+
+    test "list_event_subscriptions/0 returns all event_subscriptions", %{account: account} do
+      event_subscription = event_subscription_fixture(%{account_id: account.id})
+      assert EventSubscriptions.list_event_subscriptions(account.id) == [event_subscription]
+    end
+
+    test "get_event_subscription!/1 returns the event_subscription with given id" do
+      event_subscription = event_subscription_fixture()
+
+      assert EventSubscriptions.get_event_subscription!(event_subscription.id) ==
+               event_subscription
+    end
+
+    test "create_event_subscription/1 with valid data creates a event_subscription", %{
+      account: account
+    } do
+      attrs = Map.merge(@valid_attrs, %{account_id: account.id})
+
+      assert {:ok, %EventSubscription{} = event_subscription} =
+               EventSubscriptions.create_event_subscription(attrs)
+
+      assert event_subscription.account_id == account.id
+      assert event_subscription.scope == "some scope"
+      assert event_subscription.verified == true
+      assert event_subscription.webhook_url == "some webhook_url"
+    end
+
+    test "create_event_subscription/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               EventSubscriptions.create_event_subscription(@invalid_attrs)
+    end
+
+    test "update_event_subscription/2 with valid data updates the event_subscription" do
+      event_subscription = event_subscription_fixture()
+
+      assert {:ok, %EventSubscription{} = event_subscription} =
+               EventSubscriptions.update_event_subscription(event_subscription, @update_attrs)
+
+      assert event_subscription.scope == "some updated scope"
+      assert event_subscription.verified == false
+      assert event_subscription.webhook_url == "some updated webhook_url"
+    end
+
+    test "update_event_subscription/2 with invalid data returns error changeset" do
+      event_subscription = event_subscription_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               EventSubscriptions.update_event_subscription(event_subscription, @invalid_attrs)
+
+      assert event_subscription ==
+               EventSubscriptions.get_event_subscription!(event_subscription.id)
+    end
+
+    test "delete_event_subscription/1 deletes the event_subscription" do
+      event_subscription = event_subscription_fixture()
+
+      assert {:ok, %EventSubscription{}} =
+               EventSubscriptions.delete_event_subscription(event_subscription)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        EventSubscriptions.get_event_subscription!(event_subscription.id)
+      end
+    end
+
+    test "change_event_subscription/1 returns a event_subscription changeset" do
+      event_subscription = event_subscription_fixture()
+      assert %Ecto.Changeset{} = EventSubscriptions.change_event_subscription(event_subscription)
+    end
+  end
+end

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -20,8 +20,12 @@ defmodule ChatApiWeb.ConversationControllerTest do
 
   def fixture(:conversation) do
     account = fixture(:account)
-    attrs = Map.put(@create_attrs, :account_id, account.id)
-    {:ok, conversation} = Conversations.create_conversation(attrs)
+
+    {:ok, conversation} =
+      @create_attrs
+      |> Enum.into(%{account_id: account.id})
+      |> Conversations.create_conversation()
+
     conversation
   end
 

--- a/test/chat_api_web/controllers/event_subscription_controller_test.exs
+++ b/test/chat_api_web/controllers/event_subscription_controller_test.exs
@@ -1,0 +1,146 @@
+defmodule ChatApiWeb.EventSubscriptionControllerTest do
+  use ChatApiWeb.ConnCase
+
+  alias ChatApi.{Accounts, EventSubscriptions}
+  alias ChatApi.EventSubscriptions.EventSubscription
+
+  @create_attrs %{
+    scope: "some scope",
+    verified: true,
+    webhook_url: "some webhook_url"
+  }
+  @update_attrs %{
+    scope: "some updated scope",
+    verified: false,
+    webhook_url: "some updated webhook_url"
+  }
+  @invalid_attrs %{account_id: nil, scope: nil, verified: nil, webhook_url: nil}
+
+  def fixture(:event_subscription) do
+    account = fixture(:account)
+
+    {:ok, event_subscription} =
+      @create_attrs
+      |> Enum.into(%{account_id: account.id})
+      |> EventSubscriptions.create_event_subscription()
+
+    event_subscription
+  end
+
+  def fixture(:account) do
+    {:ok, account} = Accounts.create_account(%{company_name: "Taro"})
+    account
+  end
+
+  setup %{conn: conn} do
+    account = fixture(:account)
+    user = %ChatApi.Users.User{email: "test@example.com", account_id: account.id}
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account}
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all event_subscriptions", %{authed_conn: authed_conn} do
+      resp = get(authed_conn, Routes.event_subscription_path(authed_conn, :index))
+      assert json_response(resp, 200)["data"] == []
+    end
+  end
+
+  describe "create event_subscription" do
+    test "renders event_subscription when data is valid", %{authed_conn: authed_conn} do
+      resp =
+        post(authed_conn, Routes.event_subscription_path(authed_conn, :create),
+          event_subscription: @create_attrs
+        )
+
+      assert %{"id" => id} = json_response(resp, 201)["data"]
+
+      resp = get(authed_conn, Routes.event_subscription_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "scope" => "some scope",
+               "verified" => true,
+               "webhook_url" => "some webhook_url"
+             } = json_response(resp, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      resp =
+        post(authed_conn, Routes.event_subscription_path(authed_conn, :create),
+          event_subscription: @invalid_attrs
+        )
+
+      assert json_response(resp, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update event_subscription" do
+    setup [:create_event_subscription]
+
+    test "renders event_subscription when data is valid", %{
+      authed_conn: authed_conn,
+      event_subscription: %EventSubscription{id: id} = event_subscription
+    } do
+      conn =
+        put(authed_conn, Routes.event_subscription_path(authed_conn, :update, event_subscription),
+          event_subscription: @update_attrs
+        )
+
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.event_subscription_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "scope" => "some updated scope",
+               "verified" => false,
+               "webhook_url" => "some updated webhook_url"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{
+      authed_conn: authed_conn,
+      event_subscription: event_subscription
+    } do
+      conn =
+        put(authed_conn, Routes.event_subscription_path(authed_conn, :update, event_subscription),
+          event_subscription: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete event_subscription" do
+    setup [:create_event_subscription]
+
+    test "deletes chosen event_subscription", %{
+      authed_conn: authed_conn,
+      event_subscription: event_subscription
+    } do
+      conn =
+        delete(
+          authed_conn,
+          Routes.event_subscription_path(authed_conn, :delete, event_subscription)
+        )
+
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(authed_conn, Routes.event_subscription_path(authed_conn, :show, event_subscription))
+      end
+    end
+  end
+
+  defp create_event_subscription(_) do
+    event_subscription = fixture(:event_subscription)
+    %{event_subscription: event_subscription}
+  end
+end

--- a/test/chat_api_web/controllers/event_subscription_controller_test.exs
+++ b/test/chat_api_web/controllers/event_subscription_controller_test.exs
@@ -6,12 +6,10 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
 
   @create_attrs %{
     scope: "some scope",
-    verified: true,
     webhook_url: "some webhook_url"
   }
   @update_attrs %{
     scope: "some updated scope",
-    verified: false,
     webhook_url: "some updated webhook_url"
   }
   @invalid_attrs %{account_id: nil, scope: nil, verified: nil, webhook_url: nil}
@@ -66,7 +64,6 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
       assert %{
                "id" => id,
                "scope" => "some scope",
-               "verified" => true,
                "webhook_url" => "some webhook_url"
              } = json_response(resp, 200)["data"]
     end
@@ -100,7 +97,6 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
       assert %{
                "id" => id,
                "scope" => "some updated scope",
-               "verified" => false,
                "webhook_url" => "some updated webhook_url"
              } = json_response(conn, 200)["data"]
     end


### PR DESCRIPTION
Should handle https://github.com/papercups-io/papercups/issues/80

TODOs:
- [x] Set up `event_subscriptions` table 
- [x] Add ability to set up webhook URLs in the "Integrations" UI
- [x] Webhook URLs will need to be verified before they can be used (i.e. send a random string to the URL and make sure it replies with the correct string, the same way Slack verifies webhook URLs)
- [x] On `message:created`, send event payload to the account's verified webhook URLs
- (`conversation:created`, and `conversation:updated` events will be handled later)

<img width="1299" alt="Screen Shot 2020-08-23 at 10 23 53 PM" src="https://user-images.githubusercontent.com/5264279/90997389-62ddab80-e58f-11ea-89c4-78da69d8fefc.png">
<img width="879" alt="Screen Shot 2020-08-23 at 10 24 00 PM" src="https://user-images.githubusercontent.com/5264279/90997390-63764200-e58f-11ea-81ed-e2892aab55c5.png">
