### PR TITLE
add metadata to conversation header

### DIFF
--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -7,6 +7,7 @@ import {
   StarFilled,
   UploadOutlined,
   UserOutlined,
+  QuestionCircleOutlined,
 } from '../icons';
 
 const ConversationHeader = ({
@@ -40,9 +41,22 @@ const ConversationHeader = ({
     priority,
     customer = {},
   } = conversation;
-  const {name, email} = customer;
+  const {name, email, current_url, browser, os} = customer;
   const assigneeId = assignee_id ? String(assignee_id) : undefined;
   const hasBothNameAndEmail = !!(name && email);
+  const metaData = (
+    <Fragment>
+      <p>
+        <strong>Current URL:</strong> {current_url}
+      </p>
+      <p>
+        <strong>Browser:</strong> {browser}
+      </p>
+      <p>
+        <strong>OS:</strong> {os}
+      </p>
+    </Fragment>
+  );
 
   return (
     <header
@@ -58,22 +72,29 @@ const ConversationHeader = ({
         backgroundColor={colors.white}
         sx={{justifyContent: 'space-between', alignItems: 'center'}}
       >
-        <Box>
-          <Title
-            level={4}
-            style={{
-              marginBottom: hasBothNameAndEmail ? 0 : 4,
-              marginTop: hasBothNameAndEmail ? 0 : 4,
-            }}
-          >
-            {name || email || 'Anonymous User'}
-          </Title>
-          {hasBothNameAndEmail && (
-            <Box style={{marginLeft: 1}}>
-              <Text type="secondary">{email}</Text>
-            </Box>
-          )}
-        </Box>
+        <Flex>
+          <Box>
+            <Title
+              level={4}
+              style={{
+                marginBottom: hasBothNameAndEmail ? 0 : 4,
+                marginTop: hasBothNameAndEmail ? 0 : 4,
+              }}
+            >
+              {name || email || 'Anonymous User'}
+            </Title>
+            {hasBothNameAndEmail && (
+              <Box style={{marginLeft: 1}}>
+                <Text type="secondary">{email}</Text>
+              </Box>
+            )}
+          </Box>
+          <Box mx={1} my={1}>
+            <Tooltip title={metaData} placement="bottomLeft">
+              <QuestionCircleOutlined />
+            </Tooltip>
+          </Box>
+        </Flex>
 
         <Flex mx={-1}>
           <Box mx={1}>

--- a/assets/src/components/icons.tsx
+++ b/assets/src/components/icons.tsx
@@ -18,6 +18,7 @@ import StarOutlined from '@ant-design/icons/StarOutlined';
 import UploadOutlined from '@ant-design/icons/UploadOutlined';
 import UpOutlined from '@ant-design/icons/UpOutlined';
 import UserOutlined from '@ant-design/icons/UserOutlined';
+import QuestionCircleOutlined from '@ant-design/icons/QuestionCircleOutlined';
 
 export {
   ApiOutlined,
@@ -40,4 +41,5 @@ export {
   UploadOutlined,
   UpOutlined,
   UserOutlined,
+  QuestionCircleOutlined,
 };

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -11,6 +11,14 @@ defmodule ChatApiWeb.CustomerView do
   end
 
   def render("customer.json", %{customer: customer}) do
-    %{id: customer.id, name: customer.name, email: customer.email, phone: customer.phone}
+    %{
+      id: customer.id,
+      name: customer.name,
+      email: customer.email,
+      phone: customer.phone,
+      current_url: customer.current_url,
+      browser: customer.browser,
+      os: customer.os,
+    }
   end
 end


### PR DESCRIPTION
HI @reichert621 

here I added a tooltip with some metadata. This is related to issue https://github.com/papercups-io/papercups/issues/182
<img width="1429" alt="Screenshot 2020-08-22 at 22 02 06" src="https://user-images.githubusercontent.com/7046787/90964745-b71b5980-e4c3-11ea-9cf0-56fa9c8464f3.png">
