### PR TITLE
Migration script to set `seen_at` field for old messages

### DIFF
--- a/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
+++ b/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
@@ -1,0 +1,46 @@
+defmodule ChatApi.Repo.Migrations.SetMessagesSeenAt do
+  use Ecto.Migration
+
+  import Ecto.Query, warn: false
+
+  alias ChatApi.{Messages, Repo}
+  alias ChatApi.Conversations.Conversation
+  alias ChatApi.Messages.Message
+
+  def up do
+    Conversation
+    |> preload(:messages)
+    |> Repo.all()
+    |> Enum.each(fn conversation ->
+      mark_messages_seen(conversation)
+    end)
+  end
+
+  def down do
+    Repo.update_all(Message, set: [seen_at: nil])
+  end
+
+  defp mark_messages_seen(%{messages: messages}) do
+    timestamp = most_recent_customer_message_timestamp(messages)
+
+    mark_previous_messages_seen(timestamp, messages)
+  end
+
+  defp most_recent_customer_message_timestamp(messages) do
+    messages
+    |> Enum.sort_by(fn msg -> msg.inserted_at end, :desc)
+    |> Enum.find(fn msg -> not is_nil(msg.customer_id) end)
+    |> case do
+      %{inserted_at: timestamp} -> timestamp
+      _ -> nil
+    end
+  end
+
+  defp mark_previous_messages_seen(timestamp, messages) do
+    messages
+    |> Enum.filter(fn msg -> msg.inserted_at < timestamp end)
+    |> Enum.map(fn msg ->
+      Messages.update_message(msg, %{seen_at: msg.inserted_at})
+    end)
+  end
+end

--- a/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
+++ b/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
@@ -11,9 +11,7 @@ defmodule ChatApi.Repo.Migrations.SetMessagesSeenAt do
     Conversation
     |> preload(:messages)
     |> Repo.all()
-    |> Enum.each(fn conversation ->
-      mark_messages_seen(conversation)
-    end)
+    |> Enum.map(fn conv -> mark_messages_seen(conv) end)
   end
 
   def down do


### PR DESCRIPTION
Just using a simple heuristic for now: basically if a customer has replied to a message, we mark all previous messages as "seen"