### PR TITLE
Issue #57 | Fix for saving the correct IP address of customers

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-elixir 1.10.3
-elixir 1.10.4-otp-23
-nodejs 14.7.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.10.3
+elixir 1.10.4-otp-23
+nodejs 14.7.0

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,7 @@ config :chat_api, ChatApi.Repo,
   password: "postgres",
   database: "chat_api_test#{System.get_env("MIX_TEST_PARTITION")}",
   hostname: "localhost",
+  port: System.get_env("DATABASE_PORT") || 5432,
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,

--- a/lib/chat_api_web/ip_address_plug.ex
+++ b/lib/chat_api_web/ip_address_plug.ex
@@ -1,0 +1,55 @@
+defmodule ChatApiWeb.IPAddressPlug do
+  @moduledoc """
+  A plug to change the `Plug.Conn`'s `remote_ip` to use the values provided by the x-forwarded-for header in the event that the header exists.
+  """
+  @behaviour Plug
+
+  def init(opts \\ []), do: opts
+
+  def call(conn, _opts) do
+    ip = get_ip(conn.req_headers, nil)
+
+    case ip do
+      nil -> conn
+      _ -> %{conn | remote_ip: ip}
+    end
+  end
+
+  @spec parse_ip([{String.t(), String.t()}]) :: String.t() | nil
+  defp get_ip([], result), do: result |> truncate_header_value |> clean_ip |> parse_ip
+
+  defp get_ip([{"x-forwarded-for", value} | tail], _result),
+    do: get_ip(tail, value)
+
+  defp get_ip([_ | tail], result), do: get_ip(tail, result)
+
+  @spec truncate_header_value(String.t()) :: String.t()
+  @doc """
+    Given this is a "hot path" in the request lifecycle (served on every request) and Cowboy has a default header value size of 4096 bytes,
+    we want to avoid the possibility of forkbomb attacks (https://en.wikipedia.org/wiki/Fork_bomb).
+    IPv6 addresses are a maximum of 45 characters in length (https://stackoverflow.com/a/7477384)
+    Allowing for a reasonable buffer, only process the first 50 bytes of the header value
+  """
+  def truncate_header_value(<<header_value::bytes-size(50), _rest::binary>> = header)
+      when byte_size(header) >= 50,
+      do: header_value
+
+  def truncate_header_value(header_value), do: header_value
+
+  @spec clean_ip(String.t()) :: String.t() | nil
+  defp clean_ip(ip) when not is_nil(ip) do
+    ip |> String.split(",", trim: true) |> List.first()
+  end
+
+  defp clean_ip(ip), do: ip
+
+  @spec parse_ip(String.t()) :: :inet.ip_address() | nil
+  defp parse_ip(ip) when not is_nil(ip) do
+    case :inet.parse_address(to_charlist(ip)) do
+      {:ok, ip_address} -> ip_address
+      {:error, :einval} -> nil
+    end
+  end
+
+  defp parse_ip(ip), do: ip
+end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -10,6 +10,7 @@ defmodule ChatApiWeb.Router do
   end
 
   pipeline :api do
+    plug(ChatApiWeb.IPAddressPlug)
     plug(:accepts, ["json"])
     plug(ChatApiWeb.APIAuthPlug, otp_app: :chat_api)
   end

--- a/test/chat_api_web/plugs/ip_address_plug_test.exs
+++ b/test/chat_api_web/plugs/ip_address_plug_test.exs
@@ -1,0 +1,99 @@
+defmodule ChatApiWeb.IPAddressPlugTest do
+  @moduledoc """
+  Tests for the ChatApiWeb.IPAddressPlug plug
+  """
+  use ExUnit.Case, async: true
+  use Plug.Test
+  alias ChatApiWeb.IPAddressPlug
+
+  @x_forwarded_for_header "x-forwarded-for"
+  @ipv4_default {127, 0, 0, 1}
+  @ipv6_default {0, 0, 0, 0, 0, 0, 0, 1}
+  defp make_call(conn, header, value) do
+    c = if header, do: put_req_header(conn, header, value), else: conn
+    IPAddressPlug.call(c, []).remote_ip
+  end
+
+  defp test_ipv4_conn(header \\ nil, value \\ nil) do
+    c = %{conn("GET", "/") | remote_ip: @ipv4_default}
+    make_call(c, header, value)
+  end
+
+  defp test_ipv6_conn(header \\ nil, value \\ nil) do
+    c = %{conn("GET", "/") | remote_ip: @ipv6_default}
+    make_call(c, header, value)
+  end
+
+  defp random_number_string(n) do
+    charset = '012345678'
+
+    Enum.reduce(0..(n - 1), [], fn _i, acc ->
+      [Enum.random(charset) | acc]
+    end)
+    |> to_string()
+  end
+
+  describe "IPAddressPlug.truncate_header_value " do
+    test "truncates the first 50 chars/bytes of the header's value" do
+      first_50 = random_number_string(50)
+      next_250 = random_number_string(250)
+
+      combined = "#{first_50}#{next_250}"
+
+      assert IPAddressPlug.truncate_header_value(combined) == first_50
+    end
+
+    test "doesn't truncate a header value less than 50 chars/bytes in length" do
+      first_45 = random_number_string(45)
+
+      assert IPAddressPlug.truncate_header_value(first_45) == first_45
+    end
+  end
+
+  describe "IPAddressPlug.call " do
+    test "does not touch conn.remote_ip if there's no x-forwarded-for header present" do
+      assert test_ipv4_conn() == @ipv4_default
+      assert test_ipv6_conn() == @ipv6_default
+    end
+
+    test "does not touch conn.remote_ip if a x-forwarded-for header exists but contains an invalid value" do
+      assert test_ipv4_conn(@x_forwarded_for_header, "invalid header") ==
+               @ipv4_default
+
+      assert test_ipv4_conn(@x_forwarded_for_header, "invalid 1, invalid 2, invalid 3") ==
+               @ipv4_default
+    end
+
+    test "returns valid remote_ip when the x-forwarded-for header is present" do
+      assert test_ipv4_conn(@x_forwarded_for_header, "203.0.113.1,198.51.100.101,198.51.100.102") ==
+               {203, 0, 113, 1}
+
+      assert test_ipv4_conn(
+               @x_forwarded_for_header,
+               "203.0.113.1, 198.51.100.101, 198.51.100.102"
+             ) ==
+               {203, 0, 113, 1}
+
+      assert test_ipv4_conn(@x_forwarded_for_header, "203.0.113.1") ==
+               {203, 0, 113, 1}
+
+      assert test_ipv6_conn(
+               @x_forwarded_for_header,
+               "0004:a63f:dbd5:ca43:46b4:3da2:4e5d:03d2,3347:b17f:a4c9:019e:67ec:bb88:31f3:f5c5,1596:6fe0:866e:a17e:3134:3f5c:fa80:e1bb,3aa0:b189:8a73:1f3c:a1cf:2d95:2753:719b"
+             ) ==
+               {4, 42_559, 56_277, 51_779, 18_100, 15_778, 20_061, 978}
+
+      assert test_ipv6_conn(
+               @x_forwarded_for_header,
+               "0004:a63f:dbd5:ca43:46b4:3da2:4e5d:03d2, 3347:b17f:a4c9:019e:67ec:bb88:31f3:f5c5, 1596:6fe0:866e:a17e:3134:3f5c:fa80:e1bb, 3aa0:b189:8a73:1f3c:a1cf:2d95:2753:719b"
+             ) ==
+               {4, 42_559, 56_277, 51_779, 18_100, 15_778, 20_061, 978}
+
+      assert test_ipv6_conn(
+               @x_forwarded_for_header,
+               "0004:a63f:dbd5:ca43:46b4:3da2:4e5d:03d2"
+             ) ==
+               {4, 42_559, 56_277, 51_779, 18_100, 15_778, 20_061, 978}
+    end
+  end
+end


### PR DESCRIPTION
#### Summary. 

Implement a custom Plug (`ChatApiWeb.IPAddressPlug`) in the request pipeline to extract the value of the  `x-forwarded-for` header (when present) when Phoenix is running behind a reverse proxy (like is the case with Cloudflare, Heroku etc).

This implementation supports both IPv4 and IPv6 IP addresses. I looked into the solution at https://www.cogini.com/blog/getting-the-client-public-ip-address-in-phoenix/ but refrained from using too much logic from there as it (1) wasn't the most idiomatic Elixir code and (2) only seemed to work with IPv4 addresses.

Given this Plug runs on every request, extra consideration was made for performance and security (i.e. guarding against possible ForkBomb attacks with large `x-forwarded-for` values).

Tests accompany this PR covering both "happy" and "unhappy" code paths. The implementation has been tested both locally and on a PR environment in Heroku:

![image](https://user-images.githubusercontent.com/782219/91680210-5ca37e00-eaff-11ea-8b7a-6ba13fdd351c.png)

#### Ticket Link. 

Fixes: https://github.com/papercups-io/papercups/issues/57