### PR TITLE
Minor improvements to billing overview page

### DIFF
--- a/assets/src/components/billing/Billing.css
+++ b/assets/src/components/billing/Billing.css
@@ -1,0 +1,3 @@
+.BillingBreakdownTable-priceCell {
+  vertical-align: top;
+}

--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -3,14 +3,95 @@ import {Box, Flex} from 'theme-ui';
 import {Elements} from '@stripe/react-stripe-js';
 import {loadStripe} from '@stripe/stripe-js';
 import * as API from '../../api';
-import {colors, notification, Paragraph, Text, Title} from '../common';
-import {CreditCardTwoTone} from '../icons';
+import {
+  colors,
+  notification,
+  Button,
+  Modal,
+  Paragraph,
+  Table,
+  Text,
+  Title,
+} from '../common';
+import {CreditCardTwoTone, RightCircleOutlined} from '../icons';
 import Spinner from '../Spinner';
 import PaymentForm from './PaymentForm';
+import {PricingOptionsModal} from './PricingOverview';
+import './Billing.css';
 
 const stripe = loadStripe(
   process.env.REACT_APP_STRIPE_PUBLIC_KEY || 'pk_test_xxxxx'
 );
+
+enum Alignment {
+  Right = 'right',
+  Left = 'left',
+  Center = 'center',
+}
+
+const BillingBreakdownTable = () => {
+  const columns = [
+    {
+      title: 'Subscription',
+      dataIndex: 'feature',
+      key: 'feature',
+      render: (value: string, record: any) => {
+        const {includes = []} = record;
+
+        return (
+          <Box>
+            <Box mb={includes.length ? 2 : 0}>
+              <Text strong>{value}</Text>
+            </Box>
+            {includes.map((included: any) => {
+              const {feature} = included;
+
+              return (
+                <Flex key={feature} mb={2} sx={{alignItems: 'center'}}>
+                  <Box mr={2}>
+                    <RightCircleOutlined />
+                  </Box>
+                  <Text type="secondary">{feature}</Text>
+                </Flex>
+              );
+            })}
+          </Box>
+        );
+      },
+    },
+    {
+      title: 'Price per month',
+      dataIndex: 'price',
+      key: 'price',
+      align: Alignment.Right,
+      className: 'BillingBreakdownTable-priceCell',
+      render: (price: number) => {
+        return (
+          <Text strong>
+            {price < 0 ? '-' : ''}${Math.abs(price).toFixed(2)}
+          </Text>
+        );
+      },
+    },
+  ];
+  // Just hard-coding for now
+  const data = [
+    {
+      key: 'plan',
+      feature: 'Starter plan',
+      includes: [
+        {feature: '2 seats'},
+        {feature: '100,000 messages'},
+        {feature: 'Slack integration'},
+      ],
+      price: 0,
+    },
+    {key: 'discount', feature: 'Discount', price: 0},
+    {key: 'total', feature: 'Total', price: 0},
+  ];
+
+  return <Table dataSource={data} columns={columns} pagination={false} />;
+};
 
 type Props = {};
 type State = {
@@ -96,6 +177,27 @@ class BillingOverview extends React.Component<Props, State> {
               </span>
             </Text>
           </Paragraph>
+
+          {/* TODO: implement logic to select subscription plan */}
+          {false && (
+            <Box>
+              <Button>Select plan</Button>
+
+              <Modal
+                title="Select plan"
+                visible={false}
+                width={800}
+                onOk={console.log}
+                onCancel={console.log}
+              >
+                <PricingOptionsModal />
+              </Modal>
+            </Box>
+          )}
+        </Box>
+
+        <Box mb={4}>
+          <BillingBreakdownTable />
         </Box>
 
         <Box mb={4}>

--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import {capitalize} from 'lodash';
+import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
 import {Elements} from '@stripe/react-stripe-js';
 import {loadStripe} from '@stripe/stripe-js';
@@ -28,6 +30,43 @@ enum Alignment {
   Left = 'left',
   Center = 'center',
 }
+
+type CreditCardBrand =
+  | 'amex'
+  | 'cartes_bancaires'
+  | 'diners_club'
+  | 'discover'
+  | 'jcb'
+  | 'mastercard'
+  | 'visa'
+  | 'unionpay'
+  | string;
+
+const getBrandName = (brand: CreditCardBrand) => {
+  switch (brand) {
+    case 'visa':
+      return 'Visa';
+    case 'mastercard':
+      return 'MasterCard';
+    case 'amex':
+      return 'American Express';
+    case 'discover':
+      return 'Discover';
+    case 'unionpay':
+      return 'UnionPay';
+    case 'diners_club':
+      return 'Diners Club';
+    case 'cartes_bancaires':
+      return 'Cartes Bancaires';
+    case 'jcb':
+      return 'JCB';
+    default:
+      return brand
+        .split('_')
+        .map((str) => capitalize(str))
+        .join(' ');
+  }
+};
 
 const BillingBreakdownTable = () => {
   const columns = [
@@ -122,28 +161,24 @@ class BillingOverview extends React.Component<Props, State> {
   formatPaymentMethodInfo = (paymentMethod?: any) => {
     if (!paymentMethod) {
       return (
-        <Flex sx={{alignItems: 'center', my: 1}}>
-          <Text type="secondary">None</Text>
-        </Flex>
+        <Text type="secondary">
+          No credit card information has been entered yet.
+        </Text>
       );
     }
 
-    const {last4, exp_month, exp_year} = paymentMethod;
+    const {brand, last4, exp_month, exp_year} = paymentMethod;
+    const brandName = getBrandName(brand);
+    const expiresAt = dayjs()
+      .set('month', exp_month - 1)
+      .set('year', exp_year)
+      .format('MMM YYYY');
 
     return (
-      <Flex sx={{alignItems: 'center', my: 1}}>
-        <Box mr={2}>
-          <CreditCardTwoTone twoToneColor={colors.primary} />
-        </Box>
-        <Text keyboard style={{letterSpacing: 0.6}}>
-          ••••••••••••{last4}
-        </Text>
-        <Box ml={2}>
-          <Text type="secondary">
-            expires {exp_month}/{exp_year}
-          </Text>
-        </Box>
-      </Flex>
+      <Text type="secondary">
+        Billed to <CreditCardTwoTone twoToneColor={colors.primary} />{' '}
+        {brandName} ending in {last4} (expires {expiresAt})
+      </Text>
     );
   };
 
@@ -200,10 +235,7 @@ class BillingOverview extends React.Component<Props, State> {
           <BillingBreakdownTable />
         </Box>
 
-        <Box mb={4}>
-          <Text strong>Default payment method</Text>
-          <Box>{this.formatPaymentMethodInfo(defaultPaymentMethod)}</Box>
-        </Box>
+        <Box mb={4}>{this.formatPaymentMethodInfo(defaultPaymentMethod)}</Box>
 
         <Box mb={4}>
           <Elements stripe={stripe}>

--- a/assets/src/components/billing/PricingOverview.tsx
+++ b/assets/src/components/billing/PricingOverview.tsx
@@ -81,6 +81,180 @@ const PricingSection = ({
   );
 };
 
+export const PricingOptions = () => {
+  return (
+    <Flex mx={-2} sx={{maxWidth: 960}}>
+      <PricingCard
+        title="Starter"
+        description="Basic live chat and inbox to get you started."
+        cta={
+          <Button type="primary" size="large" block ghost>
+            Create free account
+          </Button>
+        }
+        pricing={
+          <Text>
+            <Text strong>$0</Text> forever
+          </Text>
+        }
+        features={
+          <>
+            <Paragraph>Comes with:</Paragraph>
+
+            <Paragraph>
+              <li>2 seats included</li>
+              <li>100,000 messages</li>
+              <li>Customizable chat widget</li>
+              <li>Slack integration</li>
+            </Paragraph>
+          </>
+        }
+      />
+
+      <PricingCard
+        title="Team"
+        description="Supercharge your support, sales, and marketing."
+        cta={
+          <Button type="primary" size="large" block>
+            Create an account
+          </Button>
+        }
+        pricing={
+          <Text>
+            <Text strong>$40</Text>/month
+          </Text>
+        }
+        features={
+          <>
+            <Paragraph>
+              Everything in <Text strong>Starter</Text> plus:
+            </Paragraph>
+
+            <Paragraph>
+              <li>5 seats included</li>
+              <li>Unlimited messages</li>
+              <li>Additional integrations</li>
+              <li>Webhooks</li>
+            </Paragraph>
+          </>
+        }
+      />
+
+      <PricingCard
+        title="Enterprise"
+        description="Advanced workflows, security, and support."
+        cta={
+          <Button type="primary" size="large" block ghost>
+            Contact sales
+          </Button>
+        }
+        pricing={<Text>Custom pricing</Text>}
+        features={
+          <>
+            <Paragraph>
+              Everything in <Text strong>Team</Text> plus:
+            </Paragraph>
+
+            <Paragraph>
+              <li>Unlimited seats</li>
+              <li>First-class support</li>
+              <li>Custom integrations</li>
+            </Paragraph>
+          </>
+        }
+      />
+    </Flex>
+  );
+};
+
+// TODO: move to separate file?
+export const PricingOptionsModal = () => {
+  return (
+    <Flex mx={-2} sx={{maxWidth: 960}}>
+      <PricingSection
+        title="Starter"
+        description="Basic live chat and inbox to get you started."
+        cta={
+          <Button type="primary" size="large" block ghost>
+            Create free account
+          </Button>
+        }
+        pricing={
+          <Text>
+            <Text strong>$0</Text> forever
+          </Text>
+        }
+        features={
+          <>
+            <Paragraph>Comes with:</Paragraph>
+
+            <Paragraph>
+              <li>2 seats included</li>
+              <li>100,000 messages</li>
+              <li>Customizable chat widget</li>
+              <li>Slack integration</li>
+            </Paragraph>
+          </>
+        }
+      />
+
+      <PricingSection
+        title="Team"
+        description="Supercharge your support, sales, and marketing."
+        cta={
+          <Button type="primary" size="large" block>
+            Create an account
+          </Button>
+        }
+        pricing={
+          <Text>
+            <Text strong>$40</Text>/month
+          </Text>
+        }
+        features={
+          <>
+            <Paragraph>
+              Everything in <Text strong>Starter</Text> plus:
+            </Paragraph>
+
+            <Paragraph>
+              <li>5 seats included</li>
+              <li>Unlimited messages</li>
+              <li>Additional integrations</li>
+              <li>Webhooks</li>
+            </Paragraph>
+          </>
+        }
+        bordered
+      />
+
+      <PricingSection
+        title="Enterprise"
+        description="Advanced workflows, security, and support."
+        cta={
+          <Button type="primary" size="large" block ghost>
+            Contact sales
+          </Button>
+        }
+        pricing={<Text>Custom pricing</Text>}
+        features={
+          <>
+            <Paragraph>
+              Everything in <Text strong>Team</Text> plus:
+            </Paragraph>
+
+            <Paragraph>
+              <li>Unlimited seats</li>
+              <li>First-class support</li>
+              <li>Custom integrations</li>
+            </Paragraph>
+          </>
+        }
+      />
+    </Flex>
+  );
+};
+
 class PricingOverview extends React.Component<Props, State> {
   state = {};
 
@@ -95,172 +269,7 @@ class PricingOverview extends React.Component<Props, State> {
           <Title level={1}>Pricing Overview</Title>
         </Box>
 
-        <Flex mx={-2} sx={{maxWidth: 960}}>
-          <PricingCard
-            title="Starter"
-            description="Basic live chat and inbox to get you started."
-            cta={
-              <Button type="primary" size="large" block ghost>
-                Create free account
-              </Button>
-            }
-            pricing={
-              <Text>
-                <Text strong>$0</Text> forever
-              </Text>
-            }
-            features={
-              <>
-                <Paragraph>Comes with:</Paragraph>
-
-                <Paragraph>
-                  <li>2 seats included</li>
-                  <li>100,000 messages</li>
-                  <li>Customizable chat widget</li>
-                  <li>Slack integration</li>
-                </Paragraph>
-              </>
-            }
-          />
-
-          <PricingCard
-            title="Team"
-            description="Supercharge your support, sales, and marketing."
-            cta={
-              <Button type="primary" size="large" block>
-                Create an account
-              </Button>
-            }
-            pricing={
-              <Text>
-                <Text strong>$40</Text>/month
-              </Text>
-            }
-            features={
-              <>
-                <Paragraph>
-                  Everything in <Text strong>Starter</Text> plus:
-                </Paragraph>
-
-                <Paragraph>
-                  <li>5 seats included</li>
-                  <li>Unlimited messages</li>
-                  <li>Additional integrations</li>
-                  <li>Webhooks</li>
-                </Paragraph>
-              </>
-            }
-          />
-
-          <PricingCard
-            title="Enterprise"
-            description="Advanced workflows, security, and support."
-            cta={
-              <Button type="primary" size="large" block ghost>
-                Contact sales
-              </Button>
-            }
-            pricing={<Text>Custom pricing</Text>}
-            features={
-              <>
-                <Paragraph>
-                  Everything in <Text strong>Team</Text> plus:
-                </Paragraph>
-
-                <Paragraph>
-                  <li>Unlimited seats</li>
-                  <li>First-class support</li>
-                  <li>Custom integrations</li>
-                </Paragraph>
-              </>
-            }
-          />
-        </Flex>
-
-        <Divider />
-
-        <Flex mx={-2} sx={{maxWidth: 960}}>
-          <PricingSection
-            title="Starter"
-            description="Basic live chat and inbox to get you started."
-            cta={
-              <Button type="primary" size="large" block ghost>
-                Create free account
-              </Button>
-            }
-            pricing={
-              <Text>
-                <Text strong>$0</Text> forever
-              </Text>
-            }
-            features={
-              <>
-                <Paragraph>Comes with:</Paragraph>
-
-                <Paragraph>
-                  <li>2 seats included</li>
-                  <li>100,000 messages</li>
-                  <li>Customizable chat widget</li>
-                  <li>Slack integration</li>
-                </Paragraph>
-              </>
-            }
-          />
-
-          <PricingSection
-            title="Team"
-            description="Supercharge your support, sales, and marketing."
-            cta={
-              <Button type="primary" size="large" block>
-                Create an account
-              </Button>
-            }
-            pricing={
-              <Text>
-                <Text strong>$40</Text>/month
-              </Text>
-            }
-            features={
-              <>
-                <Paragraph>
-                  Everything in <Text strong>Starter</Text> plus:
-                </Paragraph>
-
-                <Paragraph>
-                  <li>5 seats included</li>
-                  <li>Unlimited messages</li>
-                  <li>Additional integrations</li>
-                  <li>Webhooks</li>
-                </Paragraph>
-              </>
-            }
-            bordered
-          />
-
-          <PricingSection
-            title="Enterprise"
-            description="Advanced workflows, security, and support."
-            cta={
-              <Button type="primary" size="large" block ghost>
-                Contact sales
-              </Button>
-            }
-            pricing={<Text>Custom pricing</Text>}
-            features={
-              <>
-                <Paragraph>
-                  Everything in <Text strong>Team</Text> plus:
-                </Paragraph>
-
-                <Paragraph>
-                  <li>Unlimited seats</li>
-                  <li>First-class support</li>
-                  <li>Custom integrations</li>
-                </Paragraph>
-              </>
-            }
-          />
-        </Flex>
+        <PricingOptions />
       </Box>
     );
   }


### PR DESCRIPTION
This will need to be dynamic once we actually allow people to select different subscription plans, but for now this handles some of the boilerplate:

<img width="1186" alt="Screen Shot 2020-09-01 at 11 16 16 PM" src="https://user-images.githubusercontent.com/5264279/91928131-40434500-eca9-11ea-91a5-c9380334eced.png">
