### PR TITLE
Add support for customer `external_id`s as integers

### DIFF
--- a/assets/src/components/customers/CustomerDetailsModal.tsx
+++ b/assets/src/components/customers/CustomerDetailsModal.tsx
@@ -14,6 +14,7 @@ export const CustomerDetailsContent = ({customer}: {customer: any}) => {
     browser,
     os,
     phone,
+    external_id: externalId,
     created_at: createdAt,
     updated_at: lastUpdatedAt,
     current_url: lastSeenUrl,
@@ -46,6 +47,14 @@ export const CustomerDetailsContent = ({customer}: {customer: any}) => {
           <Paragraph>{phone || 'Unknown'}</Paragraph>
         </Box>
       </Flex>
+
+      <Box mb={2}>
+        <Box>
+          <Text strong>ID</Text>
+        </Box>
+
+        <Paragraph>{externalId || 'Unknown'}</Paragraph>
+      </Box>
 
       <Box mb={2}>
         <Box>

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -30,6 +30,9 @@ defmodule ChatApi.Customers.Customer do
     field(:screen_width, :integer)
     field(:lib, :string)
 
+    # Freeform
+    field(:metadata, :map)
+
     has_many(:messages, Message)
     has_many(:conversations, Conversation)
     belongs_to(:account, Account)
@@ -71,6 +74,7 @@ defmodule ChatApi.Customers.Customer do
   def metadata_changeset(customer, attrs) do
     customer
     |> cast(attrs, [
+      :metadata,
       :email,
       :name,
       :phone,

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -14,8 +14,13 @@ defmodule ChatApiWeb.CustomerController do
   end
 
   def create(conn, %{"customer" => customer_params}) do
-    ip = conn.remote_ip |> :inet_parse.ntoa() |> to_string()
-    params = Map.merge(customer_params, %{"ip" => ip})
+    params =
+      customer_params
+      |> Map.merge(%{
+        "ip" => conn.remote_ip |> :inet_parse.ntoa() |> to_string(),
+        "last_seen_at" => DateTime.utc_now()
+      })
+      |> Customers.sanitize_metadata()
 
     with {:ok, %Customer{} = customer} <- Customers.create_customer(params) do
       conn

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -20,6 +20,7 @@ defmodule ChatApiWeb.CustomerView do
       first_seen: customer.first_seen,
       last_seen: customer.last_seen,
       phone: customer.phone,
+      external_id: customer.external_id,
       host: customer.host,
       pathname: customer.pathname,
       current_url: customer.current_url,

--- a/priv/repo/migrations/20200911145259_add_metadata_to_customers.exs
+++ b/priv/repo/migrations/20200911145259_add_metadata_to_customers.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddMetadataToCustomers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:customers) do
+      add(:metadata, :map)
+    end
+  end
+end

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -92,6 +92,12 @@ defmodule ChatApi.CustomersTest do
       assert customer.account_id != new_account.id
     end
 
+    test "sanitize_metadata/1 ensures external_id is always a string" do
+      assert %{"external_id" => nil} = Customers.sanitize_metadata(%{"external_id" => nil})
+      assert %{"external_id" => "123"} = Customers.sanitize_metadata(%{"external_id" => "123"})
+      assert %{"external_id" => "123"} = Customers.sanitize_metadata(%{"external_id" => 123})
+    end
+
     test "update_customer/2 with invalid data returns error changeset" do
       customer = customer_fixture()
       assert {:error, %Ecto.Changeset{}} = Customers.update_customer(customer, @invalid_attrs)
@@ -109,12 +115,20 @@ defmodule ChatApi.CustomersTest do
       assert %Ecto.Changeset{} = Customers.change_customer(customer)
     end
 
-    test "find_by_external_id/1 returns a customer by external_id" do
+    test "find_by_external_id/2 returns a customer by external_id" do
       external_id = "cus_123"
       customer = customer_fixture(%{external_id: external_id})
       account_id = customer.account_id
 
-      assert customer = Customers.find_by_external_id(account_id, external_id)
+      assert customer = Customers.find_by_external_id(external_id, account_id)
+    end
+
+    test "find_by_external_id/2 works with integer external_ids" do
+      external_id = "123"
+      customer = customer_fixture(%{external_id: external_id})
+      account_id = customer.account_id
+
+      assert customer = Customers.find_by_external_id(123, account_id)
     end
   end
 end

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -70,6 +70,15 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
 
+    test "ensures external_id is a string", %{
+      conn: conn
+    } do
+      customer = Map.merge(valid_create_attrs(), %{external_id: 123})
+      resp = post(conn, Routes.customer_path(conn, :create), customer: customer)
+
+      assert %{"external_id" => "123"} = json_response(resp, 201)["data"]
+    end
+
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.customer_path(conn, :create), customer: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -143,6 +143,18 @@ defmodule ChatApiWeb.CustomerControllerTest do
       assert email == @update_attrs.email
       assert name == @update_attrs.name
     end
+
+    test "ensures external_id is a string", %{
+      conn: conn,
+      customer: %Customer{id: id} = customer
+    } do
+      resp =
+        put(conn, Routes.customer_path(conn, :update_metadata, customer),
+          metadata: %{external_id: 123}
+        )
+
+      assert %{"id" => ^id, "external_id" => "123"} = json_response(resp, 200)["data"]
+    end
   end
 
   describe "identifies a customer by external_id" do


### PR DESCRIPTION
Fixes issue when users pass in integer as the `external_id` field for customer metadata