### PR TITLE
Truncate the `current_url` of the customer metadata if it is longer than 255 chars

### DIFF
--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -40,7 +40,12 @@ const CustomerMetadataPopoverContent = ({customer}: {customer: any}) => {
   const {current_url, browser, os} = customer;
 
   return (
-    <Box>
+    <Box
+      sx={{
+        maxWidth: 480,
+        wordBreak: 'break-all',
+      }}
+    >
       {current_url && (
         <Box mb={1}>
           <Text strong>Current URL: </Text>

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -91,12 +91,26 @@ defmodule ChatApi.Customers do
     |> Repo.update()
   end
 
+  # TODO: figure out if any of this can be done in the changeset, or if there's
+  # a better way to handle this in general
   def sanitize_metadata(metadata) do
     case metadata do
       %{"external_id" => external_id} when is_integer(external_id) ->
+        # Ensure `external_id` is always a string
         metadata
         |> Map.merge(%{"external_id" => to_string(external_id)})
         |> sanitize_metadata()
+
+      %{"current_url" => current_url} ->
+        if String.length(current_url) > 255 do
+          # Ensure `current_url` is never longer than 255 characters
+          # (TODO: maybe just support longer urls in the future?)
+          metadata
+          |> Map.merge(%{"current_url" => String.slice(current_url, 0, 250) <> "..."})
+          |> sanitize_metadata()
+        else
+          metadata
+        end
 
       _ ->
         metadata

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -98,6 +98,16 @@ defmodule ChatApi.CustomersTest do
       assert %{"external_id" => "123"} = Customers.sanitize_metadata(%{"external_id" => 123})
     end
 
+    test "sanitize_metadata/1 truncates the current_url if it is too long" do
+      current_url =
+        "http://example.com/login?next=/insights%3Finsight%3DTRENDS%26interval%3Dday%26events%3D%255B%257B%2522id%2522%253A%2522%2524pageview%2522%252C%2522name%2522%253A%2522%2524pageview%2522%252C%2522type%2522%253A%2522events%2522%252C%2522order%2522%253A0%252C%2522math%2522%253A%2522total%2522%257D%255D%26display%3DActionsTable%26actions%3D%255B%255D%26new_entity%3D%255B%255D%26breakdown%3D%2524browser%26breakdown_type%3Devent%26properties%3D%255B%255D"
+
+      assert %{"current_url" => truncated} =
+               Customers.sanitize_metadata(%{"current_url" => current_url})
+
+      assert String.length(truncated) <= 255
+    end
+
     test "update_customer/2 with invalid data returns error changeset" do
       customer = customer_fixture()
       assert {:error, %Ecto.Changeset{}} = Customers.update_customer(customer, @invalid_attrs)

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -79,6 +79,19 @@ defmodule ChatApiWeb.CustomerControllerTest do
       assert %{"external_id" => "123"} = json_response(resp, 201)["data"]
     end
 
+    test "truncates current_url if it is too long", %{
+      conn: conn
+    } do
+      current_url =
+        "http://example.com/login?next=/insights%3Finsight%3DTRENDS%26interval%3Dday%26events%3D%255B%257B%2522id%2522%253A%2522%2524pageview%2522%252C%2522name%2522%253A%2522%2524pageview%2522%252C%2522type%2522%253A%2522events%2522%252C%2522order%2522%253A0%252C%2522math%2522%253A%2522total%2522%257D%255D%26display%3DActionsTable%26actions%3D%255B%255D%26new_entity%3D%255B%255D%26breakdown%3D%2524browser%26breakdown_type%3Devent%26properties%3D%255B%255D"
+
+      customer = Map.merge(valid_create_attrs(), %{current_url: current_url})
+      resp = post(conn, Routes.customer_path(conn, :create), customer: customer)
+
+      assert %{"current_url" => truncated} = json_response(resp, 201)["data"]
+      assert String.length(truncated) <= 255
+    end
+
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.customer_path(conn, :create), customer: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}


### PR DESCRIPTION
Temp fix for a bug we're seeing when customers are at a URL with a really long query string