### PR TITLE
Add "admin" vs "user" roles

### DIFF
--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -52,14 +52,18 @@ class AccountOverview extends React.Component<Props, State> {
   };
 
   handleGenerateInviteUrl = async () => {
-    const {id: token} = await API.generateUserInvitation();
+    try {
+      const {id: token} = await API.generateUserInvitation();
 
-    this.setState(
-      {
-        inviteUrl: `${BASE_URL}/register/${token}`,
-      },
-      () => this.focusAndHighlightInput()
-    );
+      this.setState(
+        {
+          inviteUrl: `${BASE_URL}/register/${token}`,
+        },
+        () => this.focusAndHighlightInput()
+      );
+    } catch (err) {
+      console.error('Failed to generate user invitation URL:', err);
+    }
   };
 
   focusAndHighlightInput = () => {
@@ -146,12 +150,12 @@ class AccountOverview extends React.Component<Props, State> {
 
     return API.updateAccountInfo({company_name: companyName})
       .then((account) => {
-        console.log('Successfully updated company name!', account);
+        console.debug('Successfully updated company name!', account);
 
         this.setState({isEditing: false});
       })
       .catch((err) => {
-        console.log('Failed to update company name!', err);
+        console.error('Failed to update company name!', err);
 
         return this.fetchLatestAccountInfo();
       })

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   Title,
 } from '../common';
+import Spinner from '../Spinner';
 import {SmileTwoTone} from '../icons';
 import * as API from '../../api';
 import {BASE_URL} from '../../config';
@@ -21,6 +22,7 @@ type State = {
   companyName: string;
   currentUser: any;
   inviteUrl: string;
+  isLoading: boolean;
   isEditing: boolean;
 };
 
@@ -32,6 +34,7 @@ class AccountOverview extends React.Component<Props, State> {
     companyName: '',
     currentUser: null,
     inviteUrl: '',
+    isLoading: true,
     isEditing: false,
   };
 
@@ -41,7 +44,7 @@ class AccountOverview extends React.Component<Props, State> {
     await this.fetchLatestAccountInfo();
     const currentUser = await API.me();
 
-    this.setState({currentUser});
+    this.setState({currentUser, isLoading: false});
   }
 
   fetchLatestAccountInfo = async () => {
@@ -49,6 +52,12 @@ class AccountOverview extends React.Component<Props, State> {
     const {company_name: companyName} = account;
 
     this.setState({account, companyName});
+  };
+
+  hasAdminRole = () => {
+    const {currentUser} = this.state;
+
+    return !!currentUser && currentUser.role === 'admin';
   };
 
   handleGenerateInviteUrl = async () => {
@@ -163,9 +172,22 @@ class AccountOverview extends React.Component<Props, State> {
   };
 
   render() {
-    const {account, companyName, inviteUrl, isEditing} = this.state;
+    const {account, companyName, inviteUrl, isLoading, isEditing} = this.state;
 
-    if (!account) {
+    if (isLoading) {
+      return (
+        <Flex
+          sx={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Spinner size={40} />
+        </Flex>
+      );
+    } else if (!account) {
       return null;
     }
 
@@ -214,32 +236,34 @@ class AccountOverview extends React.Component<Props, State> {
           )}
         </Box>
 
-        <Box mb={5}>
-          <Title level={4}>Invite new teammate</Title>
+        {this.hasAdminRole() && (
+          <Box mb={5}>
+            <Title level={4}>Invite new teammate</Title>
 
-          <Paragraph>
-            <Text>
-              Generate a unique invitation URL below and send it to your
-              teammate.
-            </Text>
-          </Paragraph>
+            <Paragraph>
+              <Text>
+                Generate a unique invitation URL below and send it to your
+                teammate.
+              </Text>
+            </Paragraph>
 
-          <Flex sx={{maxWidth: 640}}>
-            <Box sx={{flex: 1}} mr={1}>
-              <Input
-                ref={(el) => (this.input = el)}
-                type="text"
-                placeholder="Click the button to generate an invite URL!"
-                value={inviteUrl}
-              ></Input>
-            </Box>
-            <Box>
-              <Button type="primary" onClick={this.handleGenerateInviteUrl}>
-                Generate invite URL
-              </Button>
-            </Box>
-          </Flex>
-        </Box>
+            <Flex sx={{maxWidth: 640}}>
+              <Box sx={{flex: 1}} mr={1}>
+                <Input
+                  ref={(el) => (this.input = el)}
+                  type="text"
+                  placeholder="Click the button to generate an invite URL!"
+                  value={inviteUrl}
+                ></Input>
+              </Box>
+              <Box>
+                <Button type="primary" onClick={this.handleGenerateInviteUrl}>
+                  Generate invite URL
+                </Button>
+              </Box>
+            </Flex>
+          </Box>
+        )}
 
         <Box mb={5}>
           <Title level={4}>Team</Title>

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -5,9 +5,11 @@ import {
   colors,
   notification,
   Button,
+  Divider,
   Input,
   Paragraph,
   Table,
+  Tag,
   Text,
   Title,
 } from '../common';
@@ -95,8 +97,9 @@ class AccountOverview extends React.Component<Props, State> {
 
   renderUsersTable = (users: Array<any>) => {
     const {currentUser} = this.state;
+    // TODO: how should we sort the users?
     const data = users.map((u) => {
-      return {...u, key: u.id, name: '--'};
+      return {...u, key: u.id};
     });
 
     const columns = [
@@ -124,6 +127,11 @@ class AccountOverview extends React.Component<Props, State> {
         title: 'Name',
         dataIndex: 'name',
         key: 'name',
+        render: (value: string, record: any) => {
+          const {full_name: fullName, display_name: displayName} = record;
+
+          return fullName || displayName || '--';
+        },
       },
       {
         title: 'Member since',
@@ -133,6 +141,21 @@ class AccountOverview extends React.Component<Props, State> {
           const formatted = dayjs(value).format('MMMM DD, YYYY');
 
           return formatted;
+        },
+      },
+      {
+        title: 'Role',
+        dataIndex: 'role',
+        key: 'role',
+        render: (value: string) => {
+          switch (value) {
+            case 'admin':
+              return <Tag color={colors.green}>Admin</Tag>;
+            case 'user':
+              return <Tag>Member</Tag>;
+            default:
+              return '--';
+          }
         },
       },
     ];
@@ -195,7 +218,7 @@ class AccountOverview extends React.Component<Props, State> {
 
     return (
       <Box p={4}>
-        <Box mb={5}>
+        <Box mb={4}>
           <Title level={3}>Account Overview</Title>
 
           <Paragraph>
@@ -236,36 +259,41 @@ class AccountOverview extends React.Component<Props, State> {
           )}
         </Box>
 
+        <Divider />
+
         {this.hasAdminRole() && (
-          <Box mb={5}>
-            <Title level={4}>Invite new teammate</Title>
+          <>
+            <Box mb={4}>
+              <Title level={4}>Invite new teammate</Title>
 
-            <Paragraph>
-              <Text>
-                Generate a unique invitation URL below and send it to your
-                teammate.
-              </Text>
-            </Paragraph>
+              <Paragraph>
+                <Text>
+                  Generate a unique invitation URL below and send it to your
+                  teammate.
+                </Text>
+              </Paragraph>
 
-            <Flex sx={{maxWidth: 640}}>
-              <Box sx={{flex: 1}} mr={1}>
-                <Input
-                  ref={(el) => (this.input = el)}
-                  type="text"
-                  placeholder="Click the button to generate an invite URL!"
-                  value={inviteUrl}
-                ></Input>
-              </Box>
-              <Box>
-                <Button type="primary" onClick={this.handleGenerateInviteUrl}>
-                  Generate invite URL
-                </Button>
-              </Box>
-            </Flex>
-          </Box>
+              <Flex sx={{maxWidth: 640}}>
+                <Box sx={{flex: 1}} mr={1}>
+                  <Input
+                    ref={(el) => (this.input = el)}
+                    type="text"
+                    placeholder="Click the button to generate an invite URL!"
+                    value={inviteUrl}
+                  ></Input>
+                </Box>
+                <Box>
+                  <Button type="primary" onClick={this.handleGenerateInviteUrl}>
+                    Generate invite URL
+                  </Button>
+                </Box>
+              </Flex>
+            </Box>
+            <Divider />
+          </>
         )}
 
-        <Box mb={5}>
+        <Box mb={4}>
           <Title level={4}>Team</Title>
           {this.renderUsersTable(users)}
         </Box>

--- a/assets/src/components/account/GettingStartedOverview.tsx
+++ b/assets/src/components/account/GettingStartedOverview.tsx
@@ -114,8 +114,8 @@ class GettingStartedOverview extends React.Component<Props, State> {
       greeting,
       new_message_placeholder: newMessagePlaceholder,
     })
-      .then((res) => console.log('Updated widget settings:', res))
-      .catch((err) => console.log('Error updating widget settings:', err));
+      .then((res) => console.debug('Updated widget settings:', res))
+      .catch((err) => console.error('Error updating widget settings:', err));
   };
 
   generateHtmlCode = () => {

--- a/assets/src/components/account/UserProfile.tsx
+++ b/assets/src/components/account/UserProfile.tsx
@@ -112,12 +112,12 @@ class UserProfile extends React.Component<Props, State> {
       profile_photo_url: profilePhotoUrl,
     })
       .then((profile) => {
-        console.log('Successfully updated profile!', profile);
+        console.debug('Successfully updated profile!', profile);
 
         this.setState({isEditing: false});
       })
       .catch((err) => {
-        console.log('Failed to update profile!', err);
+        console.error('Failed to update profile!', err);
 
         return this.fetchLatestProfile();
       })
@@ -133,7 +133,7 @@ class UserProfile extends React.Component<Props, State> {
     return API.updateUserSettings({
       email_alert_on_new_message: shouldEmailOnNewMessages,
     }).catch((err) => {
-      console.log('Failed to update settings!', err);
+      console.error('Failed to update settings!', err);
       // Reset if fails to actually update
       return this.fetchLatestSettings();
     });

--- a/assets/src/components/auth/AuthProvider.tsx
+++ b/assets/src/components/auth/AuthProvider.tsx
@@ -91,37 +91,37 @@ export class AuthProvider extends React.Component<Props, State> {
     return API.renew(refreshToken)
       .then((tokens) => this.handleAuthSuccess(tokens))
       .catch((err) => {
-        console.log('Invalid session:', err);
+        console.error('Invalid session:', err);
       });
   };
 
   register = async (params: API.RegisterParams): Promise<void> => {
-    console.log('Signing up!');
+    console.debug('Signing up!');
     // Set user, authenticated status, etc
     return API.register(params)
       .then((tokens) => this.handleAuthSuccess(tokens))
       .then(() => {
-        console.log('Successfully signed up!');
+        console.debug('Successfully signed up!');
       });
   };
 
   login = async (params: API.LoginParams): Promise<void> => {
-    console.log('Logging in!');
+    console.debug('Logging in!');
     // Set user, authenticated status, etc
     return API.login(params)
       .then((tokens) => this.handleAuthSuccess(tokens))
       .then(() => {
-        console.log('Successfully logged in!');
+        console.debug('Successfully logged in!');
       });
   };
 
   logout = async (): Promise<void> => {
-    console.log('Logging out!');
+    console.debug('Logging out!');
     // Set user, authenticated status, etc
     return API.logout()
       .then(() => this.handleClearAuth())
       .then(() => {
-        console.log('Successfully logged out!');
+        console.debug('Successfully logged out!');
       });
   };
 

--- a/assets/src/components/auth/Login.tsx
+++ b/assets/src/components/auth/Login.tsx
@@ -45,7 +45,7 @@ class Login extends React.Component<Props, State> {
       .onSubmit({email, password})
       .then(() => this.props.history.push('/conversations'))
       .catch((err) => {
-        console.log('Error!', err);
+        console.error('Error!', err);
         const error =
           err.response?.body?.error?.message || 'Invalid credentials';
 

--- a/assets/src/components/auth/PasswordReset.tsx
+++ b/assets/src/components/auth/PasswordReset.tsx
@@ -89,7 +89,7 @@ class PasswordReset extends React.Component<Props, State> {
       .then(({email}) => this.props.onSubmit({email, password}))
       .then(() => this.props.history.push('/conversations'))
       .catch((err) => {
-        console.log('Error!', err);
+        console.error('Error!', err);
         // TODO: provide more granular error messages?
         const error =
           err.response?.body?.error?.message ||

--- a/assets/src/components/auth/Register.tsx
+++ b/assets/src/components/auth/Register.tsx
@@ -111,7 +111,7 @@ class Register extends React.Component<Props, State> {
       })
       .then(() => this.props.history.push('/conversations'))
       .catch((err) => {
-        console.log('Error!', err);
+        console.error('Error!', err);
         // TODO: provide more granular error messages?
         const error =
           err.response?.body?.error?.message || 'Invalid credentials';

--- a/assets/src/components/auth/RequestPasswordReset.tsx
+++ b/assets/src/components/auth/RequestPasswordReset.tsx
@@ -47,7 +47,7 @@ class RequestPasswordReset extends React.Component<Props, State> {
         }
       })
       .catch((err) => {
-        console.log('Error!', err);
+        console.error('Error!', err);
         const error =
           err.response?.body?.error?.message ||
           'Something went wrong! Try again in a few minutes.';

--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -166,7 +166,7 @@ class BillingOverview extends React.Component<Props, State> {
       subscription_plan: selectedSubscriptionPlan,
     } = await API.fetchBillingInfo();
 
-    console.log({
+    console.debug({
       subscription,
       product,
       numUsers,
@@ -237,7 +237,7 @@ class BillingOverview extends React.Component<Props, State> {
   };
 
   handleSelectSubscriptionPlan = (plan: SubscriptionPlan) => {
-    console.log('Selected plan!', plan);
+    console.debug('Selected plan!', plan);
 
     if (plan === this.state.selectedSubscriptionPlan) {
       this.setState({displayPricingModal: false});

--- a/assets/src/components/billing/PaymentForm.tsx
+++ b/assets/src/components/billing/PaymentForm.tsx
@@ -55,7 +55,7 @@ const PaymentForm = ({onSuccess, onCancel}: Props) => {
     } else if (paymentMethod && paymentMethod.id) {
       try {
         const result = await API.createPaymentMethod(paymentMethod);
-        console.log('Successfully added payment method!', result);
+        console.debug('Successfully added payment method!', result);
 
         if (onSuccess && typeof onSuccess === 'function') {
           await onSuccess(result);
@@ -63,7 +63,7 @@ const PaymentForm = ({onSuccess, onCancel}: Props) => {
 
         cardElement.clear();
       } catch (err) {
-        console.log('Failed to create payment method:', err);
+        console.error('Failed to create payment method:', err);
 
         setErrorMessage(
           err?.response?.body?.error?.message ||

--- a/assets/src/components/billing/PricingOverview.tsx
+++ b/assets/src/components/billing/PricingOverview.tsx
@@ -320,7 +320,7 @@ class PricingOverview extends React.Component<Props, State> {
 
         <PricingOptions />
         <Divider />
-        <PricingOptionsModal selected={null} onSelectPlan={console.log} />
+        <PricingOptionsModal selected={null} onSelectPlan={console.debug} />
       </Box>
     );
   }

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -200,7 +200,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     conversationIds: Array<string>
   ) => {
     if (this.socket && this.socket.disconnect) {
-      console.log('Existing socket:', this.socket);
+      console.debug('Existing socket:', this.socket);
       this.socket.disconnect();
     }
 
@@ -210,7 +210,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     this.socket.connect();
 
     if (this.channel && this.channel.leave) {
-      console.log('Existing channel:', this.channel);
+      console.debug('Existing channel:', this.channel);
       this.channel.leave(); // TODO: what's the best practice here?
     }
 
@@ -249,10 +249,10 @@ export class ConversationsProvider extends React.Component<Props, State> {
     this.channel
       .join()
       .receive('ok', (res) => {
-        console.log('Joined successfully', res);
+        console.debug('Joined successfully', res);
       })
       .receive('error', (err) => {
-        console.log('Unable to join', err);
+        console.error('Unable to join', err);
         // TODO: double check that this works (retries after 10s)
         setTimeout(
           () => this.joinNotificationChannel(accountId, conversationIds),
@@ -284,7 +284,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
   };
 
   handleNewMessage = async (message: Message) => {
-    console.log('New message!', message);
+    console.debug('New message!', message);
 
     const {
       messagesByConversation,
@@ -343,7 +343,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
         conversation_id: conversationId,
       })
       .receive('ok', (res) => {
-        console.log('Marked as read!', {res, conversationId});
+        console.debug('Marked as read!', {res, conversationId});
 
         const {conversationsById} = this.state;
         const current = conversationsById[conversationId];

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -169,13 +169,13 @@ class Demo extends React.Component<Props, State> {
           baseUrl={BASE_URL}
           defaultIsOpen
           showAgentAvailability
-          onChatClosed={() => console.log('Chat closed!')}
-          onChatOpened={() => console.log('Chat opened!')}
+          onChatClosed={() => console.debug('Chat closed!')}
+          onChatOpened={() => console.debug('Chat opened!')}
           onMessageReceived={(message: any) =>
-            console.log('Message received!', message)
+            console.debug('Message received!', message)
           }
           onMessageSent={(message: any) =>
-            console.log('Message sent!', message)
+            console.debug('Message sent!', message)
           }
         />
       </Box>

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -50,7 +50,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
 
       this.setState({integrations, webhooks, loading: false});
     } catch (err) {
-      console.log('Error loading integrations:', err);
+      console.error('Error loading integrations:', err);
 
       this.setState({loading: false});
     }
@@ -116,7 +116,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
         const code = String(q.code);
 
         return API.authorizeSlackIntegration(code).catch((err) =>
-          console.log('Failed to authorize Slack:', err)
+          console.error('Failed to authorize Slack:', err)
         );
       default:
         return null;
@@ -148,7 +148,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
 
       this.setState({webhooks});
     } catch (err) {
-      console.log('Error refreshing event subscriptions:', err);
+      console.error('Error refreshing event subscriptions:', err);
     }
   };
 

--- a/assets/src/components/integrations/NewWebhookModal.tsx
+++ b/assets/src/components/integrations/NewWebhookModal.tsx
@@ -33,11 +33,11 @@ const NewWebhookModal = ({
   const handleChangeUrl = (e: any) => setWebhookUrl(e.target.value);
 
   const handleVerifyUrl = async () => {
-    console.log('Verifying:', url);
+    console.debug('Verifying:', url);
     setIsVerifying(true);
 
     const {verified} = await API.verifyWebhookUrl(url);
-    console.log('Verified?', verified);
+    console.debug('Verified?', verified);
     await sleep(1000);
 
     setIsVerifying(false);
@@ -51,7 +51,7 @@ const NewWebhookModal = ({
   };
 
   const handleSaveWebhook = async () => {
-    console.log('Saving:', url);
+    console.debug('Saving:', url);
     setIsSaving(true);
     const existingWebhookId = webhook && webhook.id;
     const params = {webhook_url: url};

--- a/assets/src/serviceWorker.ts
+++ b/assets/src/serviceWorker.ts
@@ -28,10 +28,7 @@ type Config = {
 export function register(config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(
-      process.env.PUBLIC_URL,
-      window.location.href
-    );
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -49,7 +46,7 @@ export function register(config?: Config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          console.debug(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://bit.ly/CRA-PWA'
           );
@@ -65,7 +62,7 @@ export function register(config?: Config) {
 function registerValidSW(swUrl: string, config?: Config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
@@ -77,7 +74,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              console.debug(
                 'New content is available and will be used when all ' +
                   'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
               );
@@ -90,7 +87,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.debug('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -101,7 +98,7 @@ function registerValidSW(swUrl: string, config?: Config) {
         };
       };
     })
-    .catch(error => {
+    .catch((error) => {
       console.error('Error during service worker registration:', error);
     });
 }
@@ -109,9 +106,9 @@ function registerValidSW(swUrl: string, config?: Config) {
 function checkValidServiceWorker(swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl, {
-    headers: { 'Service-Worker': 'script' }
+    headers: {'Service-Worker': 'script'},
   })
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');
       if (
@@ -119,7 +116,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
         (contentType != null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -130,7 +127,7 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log(
+      console.debug(
         'No internet connection found. App is running in offline mode.'
       );
     });
@@ -139,10 +136,10 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
 export function unregister() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready
-      .then(registration => {
+      .then((registration) => {
         registration.unregister();
       })
-      .catch(error => {
+      .catch((error) => {
         console.error(error.message);
       });
   }

--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -37,7 +37,7 @@ defmodule ChatApi.Accounts do
 
   """
   def get_account!(id) do
-    Account |> Repo.get!(id) |> Repo.preload([:users, :widget_settings])
+    Account |> Repo.get!(id) |> Repo.preload([[users: :profile], :widget_settings])
   end
 
   @doc """

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -55,6 +55,28 @@ defmodule ChatApi.Users do
     |> Repo.update()
   end
 
+  @spec create_admin(map()) :: {:ok, %User{}} | {:error, Ecto.Changeset.User}
+  def create_admin(params) do
+    %User{}
+    |> User.changeset(params)
+    |> User.role_changeset(%{role: "admin"})
+    |> Repo.insert()
+  end
+
+  @spec set_admin_role(%User{}) :: {:ok, %User{}} | {:error, Ecto.Changeset.User}
+  def set_admin_role(user) do
+    user
+    |> User.role_changeset(%{role: "admin"})
+    |> Repo.update()
+  end
+
+  @spec set_user_role(%User{}) :: {:ok, %User{}} | {:error, Ecto.Changeset.User}
+  def set_user_role(user) do
+    user
+    |> User.role_changeset(%{role: "user"})
+    |> Repo.update()
+  end
+
   @doc """
   Gets a single user_profile.
 

--- a/lib/chat_api/users/user.ex
+++ b/lib/chat_api/users/user.ex
@@ -26,7 +26,7 @@ defmodule ChatApi.Users.User do
   def changeset(user_or_changeset, attrs) do
     user_or_changeset
     |> pow_changeset(attrs)
-    |> cast(attrs, [:account_id])
+    |> cast(attrs, [:account_id, :role])
     |> validate_required([:account_id])
   end
 

--- a/lib/chat_api/users/user.ex
+++ b/lib/chat_api/users/user.ex
@@ -11,6 +11,7 @@ defmodule ChatApi.Users.User do
     field(:email_confirmation_token, :string)
     field(:password_reset_token, :string)
     field(:email_confirmed_at, :utc_datetime)
+    field(:role, :string, default: "user")
 
     has_many(:conversations, Conversation, foreign_key: :assignee_id)
     belongs_to(:account, Account, type: :binary_id)
@@ -29,18 +30,31 @@ defmodule ChatApi.Users.User do
     |> validate_required([:account_id])
   end
 
+  @spec role_changeset(Ecto.Schema.t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
+  def role_changeset(user_or_changeset, attrs) do
+    user_or_changeset
+    |> cast(attrs, [:role])
+    |> validate_inclusion(:role, ~w(user admin))
+  end
+
+  @spec email_verification_changeset(Ecto.Schema.t() | Ecto.Changeset.t(), map()) ::
+          Ecto.Changeset.t()
   def email_verification_changeset(user_or_changeset, attrs) do
     user_or_changeset
     |> cast(attrs, [:email_confirmation_token, :email_confirmed_at])
     |> validate_required([])
   end
 
+  @spec password_reset_changeset(Ecto.Schema.t() | Ecto.Changeset.t(), map()) ::
+          Ecto.Changeset.t()
   def password_reset_changeset(user_or_changeset, attrs) do
     user_or_changeset
     |> cast(attrs, [:password_reset_token])
     |> validate_required([])
   end
 
+  @spec password_changeset(Ecto.Schema.t() | Ecto.Changeset.t(), map()) ::
+          Ecto.Changeset.t()
   def password_changeset(user_or_changeset, attrs) do
     user_or_changeset
     |> pow_password_changeset(attrs)

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -62,7 +62,8 @@ defmodule ChatApiWeb.RegistrationController do
       ChatApi.Accounts.create_account(%{company_name: params["company_name"]})
     end)
     |> Ecto.Multi.run(:conn, fn _repo, %{account: account} ->
-      user = Enum.into(params, %{"account_id" => account.id})
+      # Users of new accounts should have the admin role by default
+      user = Enum.into(params, %{"account_id" => account.id, "role" => "admin"})
 
       case Pow.Plug.create_user(conn, user) do
         {:ok, _user, conn} -> {:ok, conn}

--- a/lib/chat_api_web/controllers/session_controller.ex
+++ b/lib/chat_api_web/controllers/session_controller.ex
@@ -61,8 +61,15 @@ defmodule ChatApiWeb.SessionController do
 
   def me(conn, _params) do
     case conn.assigns.current_user do
-      %{id: id, email: email, account_id: account_id} ->
-        json(conn, %{data: %{id: id, email: email, account_id: account_id}})
+      %{id: id, email: email, account_id: account_id, role: role} ->
+        json(conn, %{
+          data: %{
+            id: id,
+            email: email,
+            account_id: account_id,
+            role: role
+          }
+        })
 
       nil ->
         conn

--- a/lib/chat_api_web/controllers/user_invitation_controller.ex
+++ b/lib/chat_api_web/controllers/user_invitation_controller.ex
@@ -4,7 +4,7 @@ defmodule ChatApiWeb.UserInvitationController do
   alias ChatApi.UserInvitations
   alias ChatApi.UserInvitations.UserInvitation
 
-  plug ChatApiWeb.EnsureRolePlug, :user when action in [:index, :create, :update]
+  plug ChatApiWeb.EnsureRolePlug, :admin when action in [:index, :create, :update]
 
   action_fallback ChatApiWeb.FallbackController
 

--- a/lib/chat_api_web/controllers/user_invitation_controller.ex
+++ b/lib/chat_api_web/controllers/user_invitation_controller.ex
@@ -4,6 +4,8 @@ defmodule ChatApiWeb.UserInvitationController do
   alias ChatApi.UserInvitations
   alias ChatApi.UserInvitations.UserInvitation
 
+  plug ChatApiWeb.EnsureRolePlug, :user when action in [:index, :create, :update]
+
   action_fallback ChatApiWeb.FallbackController
 
   def index(conn, _params) do

--- a/lib/chat_api_web/ensure_role_plug.ex
+++ b/lib/chat_api_web/ensure_role_plug.ex
@@ -1,0 +1,47 @@
+defmodule ChatApiWeb.EnsureRolePlug do
+  @moduledoc """
+  This plug ensures that a user has a particular role.
+
+  ## Example
+
+      plug ChatApiWeb.EnsureRolePlug, [:user, :admin]
+
+      plug ChatApiWeb.EnsureRolePlug, :admin
+
+      plug ChatApiWeb.EnsureRolePlug, ~w(user admin)a
+  """
+  import Plug.Conn, only: [halt: 1, put_status: 2]
+
+  alias Phoenix.Controller
+  alias Plug.Conn
+  alias Pow.Plug
+
+  @doc false
+  @spec init(any()) :: any()
+  def init(config), do: config
+
+  @doc false
+  @spec call(Conn.t(), atom() | binary() | [atom()] | [binary()]) :: Conn.t()
+  def call(conn, roles) do
+    conn
+    |> Plug.current_user()
+    |> has_role?(roles)
+    |> maybe_halt(conn)
+  end
+
+  defp has_role?(nil, _roles), do: false
+  defp has_role?(user, roles) when is_list(roles), do: Enum.any?(roles, &has_role?(user, &1))
+  defp has_role?(user, role) when is_atom(role), do: has_role?(user, Atom.to_string(role))
+  defp has_role?(%{role: role}, role), do: true
+  defp has_role?(_user, _role), do: false
+
+  defp maybe_halt(true, conn), do: conn
+
+  defp maybe_halt(_any, conn) do
+    # TODO: figure out a better way to handle this
+    conn
+    |> put_status(401)
+    |> Controller.json(%{error: %{status: 401, message: "Unauthorized access"}})
+    |> halt()
+  end
+end

--- a/lib/chat_api_web/views/user_view.ex
+++ b/lib/chat_api_web/views/user_view.ex
@@ -17,11 +17,17 @@ defmodule ChatApiWeb.UserView do
           created_at: user.inserted_at,
           full_name: profile.full_name,
           display_name: profile.display_name,
-          profile_photo_url: profile.profile_photo_url
+          profile_photo_url: profile.profile_photo_url,
+          role: user.role
         }
 
       _ ->
-        %{id: user.id, email: user.email, created_at: user.inserted_at}
+        %{
+          id: user.id,
+          email: user.email,
+          created_at: user.inserted_at,
+          role: user.role
+        }
     end
   end
 end

--- a/priv/repo/migrations/20200917204123_add_role_to_user.exs
+++ b/priv/repo/migrations/20200917204123_add_role_to_user.exs
@@ -1,0 +1,17 @@
+defmodule ChatApi.Repo.Migrations.AddRoleToUser do
+  use Ecto.Migration
+
+  alias ChatApi.{Users, Repo}
+
+  def change do
+    alter table(:users) do
+      add(:role, :string, default: "user")
+    end
+
+    # Default all current users to admin for now
+    execute(
+      fn -> Repo.update_all(Users.User, set: [role: "admin"]) end,
+      fn -> nil end
+    )
+  end
+end

--- a/test/chat_api_web/controllers/registration_controller_test.exs
+++ b/test/chat_api_web/controllers/registration_controller_test.exs
@@ -81,7 +81,13 @@ defmodule ChatApiWeb.RegistrationControllerTest do
 
     setup %{conn: conn} do
       account = fixture(:account)
-      existing_user = %ChatApi.Users.User{email: "test@example.com", account_id: account.id}
+
+      existing_user = %ChatApi.Users.User{
+        email: "test@example.com",
+        role: "admin",
+        account_id: account.id
+      }
+
       # conn = put_req_header(conn, "accept", "application/json")
       authed_conn = Pow.Plug.assign_current_user(conn, existing_user, [])
 

--- a/test/chat_api_web/controllers/user_invitation_controller_test.exs
+++ b/test/chat_api_web/controllers/user_invitation_controller_test.exs
@@ -20,7 +20,7 @@ defmodule ChatApiWeb.UserInvitationControllerTest do
 
   setup %{conn: conn} do
     account = fixture(:account)
-    user = %ChatApi.Users.User{email: "test@example.com", account_id: account.id}
+    user = %ChatApi.Users.User{email: "test@example.com", role: "admin", account_id: account.id}
     conn = put_req_header(conn, "accept", "application/json")
     authed_conn = Pow.Plug.assign_current_user(conn, user, [])
 

--- a/test/chat_api_web/ensure_role_plug_test.exs
+++ b/test/chat_api_web/ensure_role_plug_test.exs
@@ -1,0 +1,62 @@
+defmodule ChatApiWeb.EnsureRolePlugTest do
+  use ChatApiWeb.ConnCase
+
+  alias ChatApiWeb.EnsureRolePlug
+
+  @opts ~w(admin)a
+  @user %{id: 1, role: "user"}
+  @admin %{id: 2, role: "admin"}
+
+  setup do
+    conn =
+      build_conn()
+      |> Plug.Conn.put_private(:plug_session, %{})
+      |> Plug.Conn.put_private(:plug_session_fetch, :done)
+      |> Pow.Plug.put_config(otp_app: :my_app)
+      |> fetch_flash()
+
+    {:ok, conn: conn}
+  end
+
+  test "call/2 with no user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
+    conn = EnsureRolePlug.call(conn, opts)
+
+    assert conn.halted
+    assert conn.status == 401
+  end
+
+  test "call/2 with non-admin user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
+
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    assert conn.halted
+    assert conn.status == 401
+  end
+
+  test "call/2 with non-admin user and multiple roles", %{conn: conn} do
+    opts = EnsureRolePlug.init(~w(user admin)a)
+
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@user, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    refute conn.halted
+  end
+
+  test "call/2 with admin user", %{conn: conn} do
+    opts = EnsureRolePlug.init(@opts)
+
+    conn =
+      conn
+      |> Pow.Plug.assign_current_user(@admin, otp_app: :my_app)
+      |> EnsureRolePlug.call(opts)
+
+    refute conn.halted
+  end
+end


### PR DESCRIPTION
This will allow us to restrict certain actions in the dashboard to admin users (e.g. inviting teammates, removing teammates)

This PR:
- [x] Adds the `role` field to the `users` table
- [x] Defaults all current users to `admin` role
- [x] Restricts user invitations to admin users
- [x] Updates the Account Overview UI to display user roles

(We'll handle allowing admin users to remove teammates in a future PR)

<img width="1023" alt="Screen Shot 2020-09-18 at 12 50 09 PM" src="https://user-images.githubusercontent.com/5264279/93624035-acae8b80-f9ad-11ea-9549-9e21eb247177.png">
