### PR TITLE
Add time zone to customers table

### DIFF
--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -29,6 +29,7 @@ defmodule ChatApi.Customers.Customer do
     field(:screen_height, :integer)
     field(:screen_width, :integer)
     field(:lib, :string)
+    field(:time_zone, :string)
 
     # Freeform
     field(:metadata, :map)
@@ -66,7 +67,8 @@ defmodule ChatApi.Customers.Customer do
       :pathname,
       :screen_height,
       :screen_width,
-      :lib
+      :lib,
+      :time_zone
     ])
     |> validate_required([:first_seen, :last_seen, :account_id])
   end
@@ -90,7 +92,8 @@ defmodule ChatApi.Customers.Customer do
       :pathname,
       :screen_height,
       :screen_width,
-      :lib
+      :lib,
+      :time_zone
     ])
   end
 end

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -45,7 +45,8 @@ defmodule ChatApiWeb.CustomerView do
       browser: customer.browser,
       os: customer.os,
       ip: customer.ip,
-      metadata: customer.metadata
+      metadata: customer.metadata,
+      time_zone: customer.time_zone
     }
   end
 end

--- a/priv/repo/migrations/20200930190344_add_time_zone_to_customers.exs
+++ b/priv/repo/migrations/20200930190344_add_time_zone_to_customers.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddTimeZoneToCustomers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:customers) do
+      add(:time_zone, :string)
+    end
+  end
+end

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -15,7 +15,8 @@ defmodule ChatApi.CustomersTest do
       last_seen: ~D[2020-01-02],
       name: "Test User",
       email: "user@test.com",
-      phone: "+16501235555"
+      phone: "+16501235555",
+      time_zone: "America/New_York"
     }
     @invalid_attrs %{
       first_seen: 3
@@ -56,6 +57,7 @@ defmodule ChatApi.CustomersTest do
       assert customer.email == @update_attrs.email
       assert customer.name == @update_attrs.name
       assert customer.phone == @update_attrs.phone
+      assert customer.time_zone == @update_attrs.time_zone
     end
 
     test "update_customer_metadata/2 only updates customizable fields", %{customer: customer} do
@@ -67,6 +69,7 @@ defmodule ChatApi.CustomersTest do
       assert customer.email == @update_attrs.email
       assert customer.name == @update_attrs.name
       assert customer.phone == @update_attrs.phone
+      assert customer.time_zone == @update_attrs.time_zone
 
       # `account_id` should not be customizable through this API
       assert customer.account_id != new_account.id

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -12,7 +12,8 @@ defmodule ChatApiWeb.CustomerControllerTest do
     last_seen: ~D[2020-01-02],
     name: "Test User",
     email: "user@test.com",
-    phone: "+16501235555"
+    phone: "+16501235555",
+    time_zone: "America/New_York"
   }
 
   @invalid_attrs %{
@@ -145,11 +146,13 @@ defmodule ChatApiWeb.CustomerControllerTest do
 
       assert %{
                "email" => email,
-               "name" => name
+               "name" => name,
+               "time_zone" => time_zone
              } = json_response(resp, 200)["data"]
 
       assert email == @update_attrs.email
       assert name == @update_attrs.name
+      assert time_zone == @update_attrs.time_zone
     end
 
     test "ensures external_id is a string", %{


### PR DESCRIPTION
### Description

Add `time_zone` field to customers

### Issue

Resolves #261 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
