### PR TITLE
Add count messages per user function

### DIFF
--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -4,13 +4,22 @@ defmodule ChatApi.Reporting do
   """
 
   import Ecto.Query, warn: false
-  alias ChatApi.{Repo, Conversations.Conversation, Messages.Message}
+  alias ChatApi.{Repo, Conversations.Conversation, Messages.Message, Users.User}
 
   # TODO: filter by records created between a given `from_date` and `to_date`
   def messages_by_date(account_id) do
     Message
     |> where(account_id: ^account_id)
     |> count_grouped_by_date()
+    |> Repo.all()
+  end
+
+  def count_messages_per_user(account_id) do
+    Message
+    |> where(account_id: ^account_id)
+    |> join(:inner, [m], u in User, on: m.user_id == u.id)
+    |> select([m, u], %{user: %{id: u.id, email: u.email}, count: count(m.user_id)})
+    |> group_by([m, u], [m.user_id, u.id])
     |> Repo.all()
   end
 

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -42,6 +42,38 @@ defmodule ChatApi.ReportingTest do
              ] = Reporting.messages_by_date(account.id)
     end
 
+    test "count_messages_per_user/1 should return correct number of messages sent per user on team",
+         %{
+           account: account,
+           customer: customer
+         } do
+      account_2 = account_fixture()
+      account_3 = account_fixture()
+      user_2 = user_fixture(account_2)
+      user_3 = user_fixture(account_3)
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-01 12:00:00],
+        user_id: user_2.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-02 12:00:00],
+        user_id: user_2.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-03 12:00:00],
+        user_id: user_3.id
+      })
+
+      assert [
+               %{count: 2},
+               %{count: 1}
+             ] = Reporting.messages_count_by_date(account.id)
+    end
+
     test "messages_by_date/1 only fetches messages by the given account id", %{
       account: account,
       customer: customer

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -47,10 +47,8 @@ defmodule ChatApi.ReportingTest do
            account: account,
            customer: customer
          } do
-      account_2 = account_fixture()
-      account_3 = account_fixture()
-      user_2 = user_fixture(account_2)
-      user_3 = user_fixture(account_3)
+      user_2 = user_fixture(account)
+      user_3 = user_fixture(account)
       conversation = conversation_fixture(account, customer)
 
       message_fixture(account, conversation, %{
@@ -71,7 +69,7 @@ defmodule ChatApi.ReportingTest do
       assert [
                %{count: 2},
                %{count: 1}
-             ] = Reporting.messages_count_by_date(account.id)
+             ] = Reporting.count_messages_per_user(account.id)
     end
 
     test "messages_by_date/1 only fetches messages by the given account id", %{


### PR DESCRIPTION
### Description

Add method to determine breakdown of messages sent per user on team.
Basically I added `count_messages_per_user` function that returns all messages grouped by the user_id.

### Issue

Resolves #257 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
