### PR TITLE
Tags API boilerplate

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -635,6 +635,91 @@ export const enableAccountUser = async (
     .then((res) => res.body.data);
 };
 
+export const fetchAllTags = (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/tags`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const createTag = (name: string, token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/tags`)
+    .send({tag: {name}})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const addConversationTag = (
+  conversationId: string,
+  tagId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/conversations/${conversationId}/tags`)
+    .send({tag_id: tagId})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const removeConversationTag = (
+  conversationId: string,
+  tagId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/conversations/${conversationId}/tags/${tagId}`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const addCustomerTag = (
+  customerId: string,
+  tagId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/customers/${customerId}/tags`)
+    .send({tag_id: tagId})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const removeCustomerTag = (
+  customerId: string,
+  tagId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/customers/${customerId}/tags/${tagId}`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 type ReportingFilters = {
   from_date?: string | null;
   to_date?: string | null;

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -229,20 +229,31 @@ defmodule ChatApi.Conversations do
     end
   end
 
-  def add_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
-    %ConversationTag{}
-    |> ConversationTag.changeset(%{
-      conversation_id: id,
-      tag_id: tag_id,
-      account_id: account_id
-    })
-    |> Repo.insert()
-  end
-
-  def remove_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
+  def get_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
     ConversationTag
     |> where(account_id: ^account_id, conversation_id: ^id, tag_id: ^tag_id)
     |> Repo.one()
+  end
+
+  def add_tag(%Conversation{id: id, account_id: account_id} = conversation, tag_id) do
+    case get_tag(conversation, tag_id) do
+      nil ->
+        %ConversationTag{}
+        |> ConversationTag.changeset(%{
+          conversation_id: id,
+          tag_id: tag_id,
+          account_id: account_id
+        })
+        |> Repo.insert()
+
+      tag ->
+        {:ok, tag}
+    end
+  end
+
+  def remove_tag(%Conversation{} = conversation, tag_id) do
+    conversation
+    |> get_tag(tag_id)
     |> Repo.delete()
   end
 end

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -8,6 +8,7 @@ defmodule ChatApi.Conversations do
 
   alias ChatApi.Conversations.Conversation
   alias ChatApi.Messages.Message
+  alias ChatApi.Tags.ConversationTag
 
   @doc """
   Returns the list of conversations.
@@ -216,5 +217,32 @@ defmodule ChatApi.Conversations do
   """
   def change_conversation(%Conversation{} = conversation, attrs \\ %{}) do
     Conversation.changeset(conversation, attrs)
+  end
+
+  def list_tags(id) do
+    # TODO: optimize this query
+    Conversation
+    |> Repo.get(id)
+    |> case do
+      nil -> []
+      found -> found |> Repo.preload(:tags) |> Map.get(:tags)
+    end
+  end
+
+  def add_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
+    %ConversationTag{}
+    |> ConversationTag.changeset(%{
+      conversation_id: id,
+      tag_id: tag_id,
+      account_id: account_id
+    })
+    |> Repo.insert()
+  end
+
+  def remove_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
+    ConversationTag
+    |> where(account_id: ^account_id, conversation_id: ^id, tag_id: ^tag_id)
+    |> Repo.one()
+    |> Repo.delete()
   end
 end

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -86,7 +86,9 @@ defmodule ChatApi.Conversations do
 
   """
   def get_conversation!(id) do
-    Conversation |> Repo.get!(id) |> Repo.preload([:customer, messages: [user: :profile]])
+    Conversation
+    |> Repo.get!(id)
+    |> Repo.preload([:customer, :tags, messages: [user: :profile]])
   end
 
   def get_conversation(id) do

--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -2,10 +2,13 @@ defmodule ChatApi.Conversations.Conversation do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias ChatApi.Messages.Message
-  alias ChatApi.Users.User
-  alias ChatApi.Accounts.Account
-  alias ChatApi.Customers.Customer
+  alias ChatApi.{
+    Accounts.Account,
+    Customers.Customer,
+    Messages.Message,
+    Tags.ConversationTag,
+    Users.User
+  }
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -18,6 +21,9 @@ defmodule ChatApi.Conversations.Conversation do
     belongs_to(:assignee, User, foreign_key: :assignee_id, references: :id, type: :integer)
     belongs_to(:account, Account)
     belongs_to(:customer, Customer)
+
+    has_many(:conversation_tags, ConversationTag)
+    has_many(:tags, through: [:conversation_tags, :tag])
 
     timestamps()
   end

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -172,20 +172,31 @@ defmodule ChatApi.Customers do
     end
   end
 
-  def add_tag(%Customer{id: id, account_id: account_id} = _customer, tag_id) do
-    %CustomerTag{}
-    |> CustomerTag.changeset(%{
-      customer_id: id,
-      tag_id: tag_id,
-      account_id: account_id
-    })
-    |> Repo.insert()
-  end
-
-  def remove_tag(%Customer{id: id, account_id: account_id} = _customer, tag_id) do
+  def get_tag(%Customer{id: id, account_id: account_id} = _customer, tag_id) do
     CustomerTag
     |> where(account_id: ^account_id, customer_id: ^id, tag_id: ^tag_id)
     |> Repo.one()
+  end
+
+  def add_tag(%Customer{id: id, account_id: account_id} = customer, tag_id) do
+    case get_tag(customer, tag_id) do
+      nil ->
+        %CustomerTag{}
+        |> CustomerTag.changeset(%{
+          customer_id: id,
+          tag_id: tag_id,
+          account_id: account_id
+        })
+        |> Repo.insert()
+
+      tag ->
+        {:ok, tag}
+    end
+  end
+
+  def remove_tag(%Customer{} = customer, tag_id) do
+    customer
+    |> get_tag(tag_id)
     |> Repo.delete()
   end
 end

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -36,7 +36,9 @@ defmodule ChatApi.Customers do
       ** (Ecto.NoResultsError)
 
   """
-  def get_customer!(id), do: Repo.get!(Customer, id)
+  def get_customer!(id) do
+    Customer |> Repo.get!(id) |> Repo.preload(:tags)
+  end
 
   def find_by_external_id(external_id, account_id) when is_binary(external_id) do
     Customer

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -2,9 +2,12 @@ defmodule ChatApi.Customers.Customer do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias ChatApi.Conversations.Conversation
-  alias ChatApi.Messages.Message
-  alias ChatApi.Accounts.Account
+  alias ChatApi.{
+    Accounts.Account,
+    Conversations.Conversation,
+    Messages.Message,
+    Tags.CustomerTag
+  }
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -37,6 +40,9 @@ defmodule ChatApi.Customers.Customer do
     has_many(:messages, Message)
     has_many(:conversations, Conversation)
     belongs_to(:account, Account)
+
+    has_many(:customer_tags, CustomerTag)
+    has_many(:tags, through: [:customer_tags, :tag])
 
     timestamps()
   end

--- a/lib/chat_api/tags.ex
+++ b/lib/chat_api/tags.ex
@@ -1,0 +1,108 @@
+defmodule ChatApi.Tags do
+  @moduledoc """
+  The Tags context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.Tags.Tag
+
+  @doc """
+  Returns the list of tags.
+
+  ## Examples
+
+      iex> list_tags()
+      [%Tag{}, ...]
+
+  """
+  def list_tags do
+    Repo.all(Tag)
+  end
+
+  def list_tags(account_id) do
+    Tag |> where(account_id: ^account_id) |> Repo.all()
+  end
+
+  @doc """
+  Gets a single tag.
+
+  Raises `Ecto.NoResultsError` if the Tag does not exist.
+
+  ## Examples
+
+      iex> get_tag!(123)
+      %Tag{}
+
+      iex> get_tag!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Creates a tag.
+
+  ## Examples
+
+      iex> create_tag(%{field: value})
+      {:ok, %Tag{}}
+
+      iex> create_tag(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_tag(attrs \\ %{}) do
+    %Tag{}
+    |> Tag.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a tag.
+
+  ## Examples
+
+      iex> update_tag(tag, %{field: new_value})
+      {:ok, %Tag{}}
+
+      iex> update_tag(tag, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_tag(%Tag{} = tag, attrs) do
+    tag
+    |> Tag.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a tag.
+
+  ## Examples
+
+      iex> delete_tag(tag)
+      {:ok, %Tag{}}
+
+      iex> delete_tag(tag)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_tag(%Tag{} = tag) do
+    Repo.delete(tag)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking tag changes.
+
+  ## Examples
+
+      iex> change_tag(tag)
+      %Ecto.Changeset{data: %Tag{}}
+
+  """
+  def change_tag(%Tag{} = tag, attrs \\ %{}) do
+    Tag.changeset(tag, attrs)
+  end
+end

--- a/lib/chat_api/tags/conversation_tag.ex
+++ b/lib/chat_api/tags/conversation_tag.ex
@@ -1,0 +1,24 @@
+defmodule ChatApi.Tags.ConversationTag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.{Accounts.Account, Conversations.Conversation, Tags.Tag, Users.User}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "conversation_tags" do
+    belongs_to(:account, Account)
+    belongs_to(:conversation, Conversation)
+    belongs_to(:tag, Tag)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:account_id, :conversation_id, :tag_id, :creator_id])
+    |> validate_required([:account_id, :conversation_id, :tag_id])
+  end
+end

--- a/lib/chat_api/tags/customer_tag.ex
+++ b/lib/chat_api/tags/customer_tag.ex
@@ -1,0 +1,24 @@
+defmodule ChatApi.Tags.CustomerTag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.{Accounts.Account, Customers.Customer, Tags.Tag, Users.User}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "customer_tags" do
+    belongs_to(:account, Account)
+    belongs_to(:customer, Customer)
+    belongs_to(:tag, Tag)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:account_id, :customer_id, :tag_id, :creator_id])
+    |> validate_required([:account_id, :customer_id, :tag_id])
+  end
+end

--- a/lib/chat_api/tags/tag.ex
+++ b/lib/chat_api/tags/tag.ex
@@ -1,0 +1,33 @@
+defmodule ChatApi.Tags.Tag do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Tags.{ConversationTag, CustomerTag}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "tags" do
+    field(:name, :string, null: false)
+    field(:description, :string)
+    field(:color, :string)
+
+    belongs_to(:account, Account)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+
+    has_many(:conversation_tags, ConversationTag)
+    has_many(:conversations, through: [:conversation_tags, :conversation])
+    has_many(:customer_tags, CustomerTag)
+    has_many(:customers, through: [:customer_tags, :customer])
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tag, attrs) do
+    tag
+    |> cast(attrs, [:name, :account_id, :description, :color, :creator_id])
+    |> validate_required([:name, :account_id])
+    |> unique_constraint(:name)
+  end
+end

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -151,4 +151,22 @@ defmodule ChatApiWeb.ConversationController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  @spec add_tag(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def add_tag(conn, %{"conversation_id" => id, "tag_id" => tag_id}) do
+    conversation = Conversations.get_conversation!(id)
+
+    with {:ok, _result} <- Conversations.add_tag(conversation, tag_id) do
+      json(conn, %{data: %{ok: true}})
+    end
+  end
+
+  @spec remove_tag(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def remove_tag(conn, %{"conversation_id" => id, "tag_id" => tag_id}) do
+    conversation = Conversations.get_conversation!(id)
+
+    with {:ok, _result} <- Conversations.remove_tag(conversation, tag_id) do
+      json(conn, %{data: %{ok: true}})
+    end
+  end
 end

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -6,6 +6,7 @@ defmodule ChatApiWeb.CustomerController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  @spec index(Plug.Conn.t(), map) :: Plug.Conn.t()
   def index(conn, _params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
       customers = Customers.list_customers(account_id)
@@ -13,6 +14,7 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  @spec create(Plug.Conn.t(), map) :: Plug.Conn.t()
   def create(conn, %{"customer" => customer_params}) do
     params =
       customer_params
@@ -30,11 +32,13 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  @spec show(Plug.Conn.t(), map) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     customer = Customers.get_customer!(id)
     render(conn, "show.json", customer: customer)
   end
 
+  @spec identify(Plug.Conn.t(), map) :: Plug.Conn.t()
   def identify(conn, %{
         "external_id" => external_id,
         "account_id" => account_id
@@ -52,6 +56,7 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  @spec update(Plug.Conn.t(), map) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "customer" => customer_params}) do
     customer = Customers.get_customer!(id)
 
@@ -60,6 +65,7 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  @spec update_metadata(Plug.Conn.t(), map) :: Plug.Conn.t()
   def update_metadata(conn, %{"id" => id, "metadata" => metadata}) do
     customer = Customers.get_customer!(id)
 
@@ -76,11 +82,30 @@ defmodule ChatApiWeb.CustomerController do
     end
   end
 
+  @spec delete(Plug.Conn.t(), map) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     customer = Customers.get_customer!(id)
 
     with {:ok, %Customer{}} <- Customers.delete_customer(customer) do
       send_resp(conn, :no_content, "")
+    end
+  end
+
+  @spec add_tag(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def add_tag(conn, %{"customer_id" => id, "tag_id" => tag_id}) do
+    customer = Customers.get_customer!(id)
+
+    with {:ok, _result} <- Customers.add_tag(customer, tag_id) do
+      json(conn, %{data: %{ok: true}})
+    end
+  end
+
+  @spec remove_tag(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def remove_tag(conn, %{"customer_id" => id, "tag_id" => tag_id}) do
+    customer = Customers.get_customer!(id)
+
+    with {:ok, _result} <- Customers.remove_tag(customer, tag_id) do
+      json(conn, %{data: %{ok: true}})
     end
   end
 end

--- a/lib/chat_api_web/controllers/tag_controller.ex
+++ b/lib/chat_api_web/controllers/tag_controller.ex
@@ -1,0 +1,53 @@
+defmodule ChatApiWeb.TagController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.Tags
+  alias ChatApi.Tags.Tag
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(%{assigns: %{current_user: %{account_id: account_id}}} = conn, _params) do
+    tags = Tags.list_tags(account_id)
+
+    render(conn, "index.json", tags: tags)
+  end
+
+  def create(%{assigns: %{current_user: %{account_id: account_id, id: creator_id}}} = conn, %{
+        "tag" => tag_params
+      }) do
+    with {:ok, %Tag{} = tag} <-
+           tag_params
+           |> Map.merge(%{"creator_id" => creator_id, "account_id" => account_id})
+           |> Tags.create_tag() do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.tag_path(conn, :show, tag))
+      |> render("show.json", tag: tag)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tag = Tags.get_tag!(id)
+    render(conn, "show.json", tag: tag)
+  end
+
+  def update(%{assigns: %{current_user: %{account_id: account_id}}} = conn, %{
+        "id" => id,
+        "tag" => tag_params
+      }) do
+    tag = Tags.get_tag!(id)
+
+    with updates <- Map.merge(tag_params, %{"account_id" => account_id}),
+         {:ok, %Tag{} = tag} <- Tags.update_tag(tag, updates) do
+      render(conn, "show.json", tag: tag)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tag = Tags.get_tag!(id)
+
+    with {:ok, %Tag{}} <- Tags.delete_tag(tag) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -85,6 +85,8 @@ defmodule ChatApiWeb.Router do
     resources("/conversations", ConversationController, except: [:new, :edit, :create])
     resources("/customers", CustomerController, except: [:new, :edit, :create])
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
+    resources("/tags", TagController, except: [:new, :edit])
+
     post("/event_subscriptions/verify", EventSubscriptionController, :verify)
   end
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -87,6 +87,10 @@ defmodule ChatApiWeb.Router do
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
     resources("/tags", TagController, except: [:new, :edit])
 
+    post("/conversations/:conversation_id/tags", ConversationController, :add_tag)
+    delete("/conversations/:conversation_id/tags/:tag_id", ConversationController, :remove_tag)
+    post("/customers/:customer_id/tags", CustomerController, :add_tag)
+    delete("/customers/:customer_id/tags/:tag_id", CustomerController, :remove_tag)
     post("/event_subscriptions/verify", EventSubscriptionController, :verify)
   end
 

--- a/lib/chat_api_web/views/conversation_view.ex
+++ b/lib/chat_api_web/views/conversation_view.ex
@@ -1,6 +1,6 @@
 defmodule ChatApiWeb.ConversationView do
   use ChatApiWeb, :view
-  alias ChatApiWeb.{ConversationView, MessageView, CustomerView}
+  alias ChatApiWeb.{ConversationView, MessageView, CustomerView, TagView}
 
   def render("index.json", %{conversations: conversations}) do
     %{data: render_many(conversations, ConversationView, "expanded.json")}
@@ -42,7 +42,14 @@ defmodule ChatApiWeb.ConversationView do
       customer_id: conversation.customer_id,
       assignee_id: conversation.assignee_id,
       customer: render_one(conversation.customer, CustomerView, "customer.json"),
-      messages: render_many(conversation.messages, MessageView, "expanded.json")
+      messages: render_many(conversation.messages, MessageView, "expanded.json"),
+      tags: render_tags(conversation.tags)
     }
   end
+
+  defp render_tags([_ | _] = tags) do
+    render_many(tags, TagView, "tag.json")
+  end
+
+  defp render_tags(_tags), do: []
 end

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -46,7 +46,7 @@ defmodule ChatApiWeb.CustomerView do
       os: customer.os,
       ip: customer.ip,
       metadata: customer.metadata,
-      time_zone: customer.time_zone
+      time_zone: customer.time_zone,
       tags: render_tags(customer.tags)
     }
   end

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -1,6 +1,6 @@
 defmodule ChatApiWeb.CustomerView do
   use ChatApiWeb, :view
-  alias ChatApiWeb.CustomerView
+  alias ChatApiWeb.{CustomerView, TagView}
 
   def render("index.json", %{customers: customers}) do
     %{data: render_many(customers, CustomerView, "customer.json")}
@@ -47,6 +47,13 @@ defmodule ChatApiWeb.CustomerView do
       ip: customer.ip,
       metadata: customer.metadata,
       time_zone: customer.time_zone
+      tags: render_tags(customer.tags)
     }
   end
+
+  defp render_tags([_ | _] = tags) do
+    render_many(tags, TagView, "tag.json")
+  end
+
+  defp render_tags(_tags), do: []
 end

--- a/lib/chat_api_web/views/tag_view.ex
+++ b/lib/chat_api_web/views/tag_view.ex
@@ -1,0 +1,17 @@
+defmodule ChatApiWeb.TagView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.TagView
+
+  def render("index.json", %{tags: tags}) do
+    %{data: render_many(tags, TagView, "tag.json")}
+  end
+
+  def render("show.json", %{tag: tag}) do
+    %{data: render_one(tag, TagView, "tag.json")}
+  end
+
+  def render("tag.json", %{tag: tag}) do
+    %{id: tag.id,
+      name: tag.name}
+  end
+end

--- a/lib/chat_api_web/views/tag_view.ex
+++ b/lib/chat_api_web/views/tag_view.ex
@@ -11,7 +11,11 @@ defmodule ChatApiWeb.TagView do
   end
 
   def render("tag.json", %{tag: tag}) do
-    %{id: tag.id,
-      name: tag.name}
+    %{
+      id: tag.id,
+      name: tag.name,
+      description: tag.description,
+      color: tag.color
+    }
   end
 end

--- a/priv/repo/migrations/20201001165426_create_tags.exs
+++ b/priv/repo/migrations/20201001165426_create_tags.exs
@@ -1,0 +1,53 @@
+defmodule ChatApi.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:name, :string, null: false)
+      add(:description, :string)
+      add(:color, :string)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(unique_index(:tags, [:name]))
+    create(index(:tags, [:account_id]))
+    create(index(:tags, [:creator_id]))
+
+    create table(:conversation_tags, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:conversation_id, references(:conversations, type: :uuid, on_delete: :delete_all))
+      add(:tag_id, references(:tags, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(index(:conversation_tags, [:account_id]))
+    create(index(:conversation_tags, [:creator_id]))
+    create(index(:conversation_tags, [:conversation_id]))
+    create(index(:conversation_tags, [:tag_id]))
+
+    create table(:customer_tags, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:customer_id, references(:customers, type: :uuid, on_delete: :delete_all))
+      add(:tag_id, references(:tags, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(index(:customer_tags, [:account_id]))
+    create(index(:customer_tags, [:creator_id]))
+    create(index(:customer_tags, [:customer_id]))
+    create(index(:customer_tags, [:tag_id]))
+  end
+end

--- a/priv/repo/migrations/20201001165426_create_tags.exs
+++ b/priv/repo/migrations/20201001165426_create_tags.exs
@@ -29,6 +29,7 @@ defmodule ChatApi.Repo.Migrations.CreateTags do
       timestamps()
     end
 
+    create(unique_index(:conversation_tags, [:account_id, :conversation_id, :tag_id]))
     create(index(:conversation_tags, [:account_id]))
     create(index(:conversation_tags, [:creator_id]))
     create(index(:conversation_tags, [:conversation_id]))
@@ -45,6 +46,7 @@ defmodule ChatApi.Repo.Migrations.CreateTags do
       timestamps()
     end
 
+    create(unique_index(:customer_tags, [:account_id, :customer_id, :tag_id]))
     create(index(:customer_tags, [:account_id]))
     create(index(:customer_tags, [:creator_id]))
     create(index(:customer_tags, [:customer_id]))

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -30,7 +30,9 @@ defmodule ChatApi.CustomersTest do
     end
 
     test "list_customers/1 returns all customers", %{account: account, customer: customer} do
-      assert Customers.list_customers(account.id) == [customer]
+      customer_ids = Customers.list_customers(account.id) |> Enum.map(& &1.id)
+
+      assert customer_ids == [customer.id]
     end
 
     test "get_customer!/1 returns the customer with given id", %{customer: customer} do

--- a/test/chat_api/tags_test.exs
+++ b/test/chat_api/tags_test.exs
@@ -1,0 +1,62 @@
+defmodule ChatApi.TagsTest do
+  use ChatApi.DataCase
+
+  alias ChatApi.Tags
+
+  describe "tags" do
+    alias ChatApi.Tags.Tag
+
+    @valid_attrs %{name: "some name"}
+    @update_attrs %{name: "some updated name"}
+    @invalid_attrs %{name: nil}
+
+    setup do
+      account = account_fixture()
+
+      {:ok, account: account}
+    end
+
+    test "list_tags/0 returns all tags", %{account: account} do
+      tag = tag_fixture(account)
+      assert Tags.list_tags(account.id) == [tag]
+    end
+
+    test "get_tag!/1 returns the tag with given id", %{account: account} do
+      tag = tag_fixture(account)
+      assert Tags.get_tag!(tag.id) == tag
+    end
+
+    test "create_tag/1 with valid data creates a tag", %{account: account} do
+      params = Map.merge(@valid_attrs, %{account_id: account.id})
+      assert {:ok, %Tag{} = tag} = Tags.create_tag(params)
+      assert tag.name == "some name"
+    end
+
+    test "create_tag/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Tags.create_tag(@invalid_attrs)
+    end
+
+    test "update_tag/2 with valid data updates the tag", %{account: account} do
+      tag = tag_fixture(account)
+      assert {:ok, %Tag{} = tag} = Tags.update_tag(tag, @update_attrs)
+      assert tag.name == "some updated name"
+    end
+
+    test "update_tag/2 with invalid data returns error changeset", %{account: account} do
+      tag = tag_fixture(account)
+      assert {:error, %Ecto.Changeset{}} = Tags.update_tag(tag, @invalid_attrs)
+      assert tag == Tags.get_tag!(tag.id)
+    end
+
+    test "delete_tag/1 deletes the tag", %{account: account} do
+      tag = tag_fixture(account)
+      assert {:ok, %Tag{}} = Tags.delete_tag(tag)
+      assert_raise Ecto.NoResultsError, fn -> Tags.get_tag!(tag.id) end
+    end
+
+    test "change_tag/1 returns a tag changeset", %{account: account} do
+      tag = tag_fixture(account)
+      assert %Ecto.Changeset{} = Tags.change_tag(tag)
+    end
+  end
+end

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -99,4 +99,45 @@ defmodule ChatApiWeb.ConversationControllerTest do
       end)
     end
   end
+
+  # TODO: add some more tests!
+  describe "adding/removing tags" do
+    test "adds a tag", %{authed_conn: authed_conn, conversation: conversation, account: account} do
+      tag = tag_fixture(account, %{name: "Test Tag"})
+
+      resp =
+        post(authed_conn, Routes.conversation_path(authed_conn, :add_tag, conversation),
+          tag_id: tag.id
+        )
+
+      assert json_response(resp, 200)["data"]["ok"]
+      resp = get(authed_conn, Routes.conversation_path(authed_conn, :show, conversation.id))
+
+      assert %{
+               "tags" => tags
+             } = json_response(resp, 200)["data"]
+
+      assert [%{"name" => "Test Tag"}] = tags
+    end
+
+    test "removes a tag", %{
+      authed_conn: authed_conn,
+      conversation: conversation,
+      account: account
+    } do
+      tag = tag_fixture(account, %{name: "Test Tag"})
+
+      resp =
+        post(authed_conn, Routes.conversation_path(authed_conn, :add_tag, conversation),
+          tag_id: tag.id
+        )
+
+      assert json_response(resp, 200)["data"]["ok"]
+
+      resp =
+        delete(authed_conn, Routes.conversation_path(authed_conn, :remove_tag, conversation, tag))
+
+      assert json_response(resp, 200)["data"]["ok"]
+    end
+  end
 end

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -131,6 +131,36 @@ defmodule ChatApiWeb.CustomerControllerTest do
     end
   end
 
+  # TODO: add some more tests!
+  describe "adding/removing tags" do
+    test "adds a tag", %{authed_conn: authed_conn, customer: customer, account: account} do
+      tag = tag_fixture(account, %{name: "Test Tag"})
+
+      resp =
+        post(authed_conn, Routes.customer_path(authed_conn, :add_tag, customer), tag_id: tag.id)
+
+      assert json_response(resp, 200)["data"]["ok"]
+      resp = get(authed_conn, Routes.customer_path(authed_conn, :show, customer.id))
+
+      assert %{
+               "tags" => tags
+             } = json_response(resp, 200)["data"]
+
+      assert [%{"name" => "Test Tag"}] = tags
+    end
+
+    test "removes a tag", %{authed_conn: authed_conn, customer: customer, account: account} do
+      tag = tag_fixture(account, %{name: "Test Tag"})
+
+      resp =
+        post(authed_conn, Routes.customer_path(authed_conn, :add_tag, customer), tag_id: tag.id)
+
+      assert json_response(resp, 200)["data"]["ok"]
+      resp = delete(authed_conn, Routes.customer_path(authed_conn, :remove_tag, customer, tag))
+      assert json_response(resp, 200)["data"]["ok"]
+    end
+  end
+
   describe "update customer metadata" do
     test "renders customer when data is valid", %{
       conn: conn,

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -1,0 +1,89 @@
+defmodule ChatApiWeb.TagControllerTest do
+  use ChatApiWeb.ConnCase
+
+  alias ChatApi.Tags.Tag
+
+  @create_attrs %{
+    name: "some name"
+  }
+  @update_attrs %{
+    name: "some updated name"
+  }
+  @invalid_attrs %{name: nil}
+
+  setup %{conn: conn} do
+    account = account_fixture()
+    user = user_fixture(account)
+
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account}
+  end
+
+  describe "index" do
+    test "lists all tags", %{authed_conn: authed_conn} do
+      resp = get(authed_conn, Routes.tag_path(authed_conn, :index))
+      assert json_response(resp, 200)["data"] == []
+    end
+  end
+
+  describe "create tag" do
+    test "renders tag when data is valid", %{authed_conn: authed_conn} do
+      resp = post(authed_conn, Routes.tag_path(authed_conn, :create), tag: @create_attrs)
+      assert %{"id" => id} = json_response(resp, 201)["data"]
+
+      resp = get(authed_conn, Routes.tag_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "name" => "some name"
+             } = json_response(resp, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      resp = post(authed_conn, Routes.tag_path(authed_conn, :create), tag: @invalid_attrs)
+      assert json_response(resp, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update tag" do
+    setup [:create_tag]
+
+    test "renders tag when data is valid", %{authed_conn: authed_conn, tag: %Tag{id: id} = tag} do
+      conn = put(authed_conn, Routes.tag_path(authed_conn, :update, tag), tag: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.tag_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn, tag: tag} do
+      conn = put(authed_conn, Routes.tag_path(authed_conn, :update, tag), tag: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete tag" do
+    setup [:create_tag]
+
+    test "deletes chosen tag", %{authed_conn: authed_conn, tag: tag} do
+      conn = delete(authed_conn, Routes.tag_path(authed_conn, :delete, tag))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(authed_conn, Routes.tag_path(authed_conn, :show, tag))
+      end
+    end
+  end
+
+  defp create_tag(%{account: account}) do
+    tag = tag_fixture(account)
+
+    %{tag: tag}
+  end
+end

--- a/test/support/test_fixture_helpers.ex
+++ b/test/support/test_fixture_helpers.ex
@@ -61,7 +61,7 @@ defmodule ChatApi.TestFixtureHelpers do
       |> Enum.into(attrs)
       |> Customers.create_customer()
 
-    customer
+    customer |> Repo.preload([:tags])
   end
 
   def conversation_fixture(
@@ -78,7 +78,7 @@ defmodule ChatApi.TestFixtureHelpers do
       |> Enum.into(attrs)
       |> Conversations.create_test_conversation()
 
-    conversation |> Repo.preload([:customer, messages: [user: :profile]])
+    conversation |> Repo.preload([:customer, :tags, messages: [user: :profile]])
   end
 
   def message_fixture(

--- a/test/support/test_fixture_helpers.ex
+++ b/test/support/test_fixture_helpers.ex
@@ -10,6 +10,7 @@ defmodule ChatApi.TestFixtureHelpers do
     EventSubscriptions,
     Messages,
     SlackAuthorizations,
+    Tags,
     WidgetSettings,
     UserInvitations
   }
@@ -96,6 +97,21 @@ defmodule ChatApi.TestFixtureHelpers do
 
     Messages.get_message!(message.id)
     |> Repo.preload([:conversation, :customer, [user: :profile]])
+  end
+
+  def tag_fixture(
+        %Accounts.Account{} = account,
+        attrs \\ %{}
+      ) do
+    {:ok, tag} =
+      attrs
+      |> Enum.into(%{
+        name: "some tag name",
+        account_id: account.id
+      })
+      |> Tags.create_tag()
+
+    tag
   end
 
   def slack_conversation_thread_fixture(


### PR DESCRIPTION
### Description

This PR just sets up the schema and boilerplate for the `tags` API.

- [x] Add `tags` table
  - fields: `id, name, account_id, description?, creator_id, color?, timestamps`
  - `name` should be unique by `account_id`
- [x] Add `conversation_tags` table
  - many-to-many table between conversations and tags
  - fields: `id, conversation_id, tag_id, account_id, creator_id, timestamps`
- [x] Add `customer_tags` table
  - many-to-many table between customers and tags
  - fields: `id, customer_id, tag_id, account_id, creator_id, timestamps`
- [x] Set up `/api/tags` routes to handle all CRUD operations
- [x] Set up `/api/conversations/:id/tags` operations to handle tagging a conversation (or removing a tag)
- [x] Set up `/api/customers/:id/tags` operations to handle tagging a customer (or removing a tag)

### Issue

https://github.com/papercups-io/papercups/issues/266

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
