### PR TITLE
[Reporting - API] Add method to calculate average/total received messages by day of the week

### DIFF
--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -37,4 +37,30 @@ defmodule ChatApi.Reporting do
     |> select([r], %{date: fragment("date(?)", field(r, ^field)), count: count(r.id)})
     |> order_by([r], asc: fragment("date(?)", field(r, ^field)))
   end
+
+  def messages_by_weekday(account_id) do
+    Message
+    |> where(account_id: ^account_id)
+    |> where([m], not is_nil(m.customer_id))
+    |> count_grouped_by_date()
+    |> select_merge([m], %{day: fragment("to_char(date(?), 'Day')", m.inserted_at)})
+    |> Repo.all()
+    |> Enum.group_by(&String.trim(&1.day))
+    |> compute_weekday_aggregates()
+  end
+
+  defp compute_weekday_aggregates(grouped) do
+    Enum.map(weekdays(), fn weekday ->
+      records = Map.get(grouped, weekday, [])
+      total = Enum.reduce(records, 0, fn x, acc -> x.count + acc end)
+
+      %{
+        day: weekday,
+        average: total / max(length(records), 1),
+        total: total
+      }
+    end)
+  end
+
+  defp weekdays, do: ~w(Monday Tuesday Wednesday Thursday Friday Saturday Sunday)
 end

--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -52,7 +52,7 @@ defmodule ChatApi.Reporting do
     |> order_by([r], asc: fragment("date(?)", field(r, ^field)))
   end
 
-  def messages_by_weekday(account_id) do
+  def count_messages_by_weekday(account_id) do
     Message
     |> where(account_id: ^account_id)
     |> where([m], not is_nil(m.customer_id))

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -194,8 +194,17 @@ defmodule ChatApi.ReportingTest do
                %{date: ~D[2020-09-03], count: 1}
              ] = Reporting.count_received_messages_by_date()
     end
+  end
 
-    test "messages_by_weekday/1 correctly calculates total and avg of customer messages per day",
+  describe "count_messages_by_weekday/1" do
+    setup do
+      account = account_fixture()
+      customer = customer_fixture(account)
+
+      {:ok, account: account, customer: customer}
+    end
+
+    test "correctly calculates total and avg of customer messages per day",
          %{
            account: account,
            customer: customer
@@ -255,10 +264,10 @@ defmodule ChatApi.ReportingTest do
                %{day: "Friday", average: 1.0, total: 1},
                %{day: "Saturday", average: 1.0, total: 1},
                %{day: "Sunday", average: 1.0, total: 1}
-             ] = Reporting.messages_by_weekday(account.id)
+             ] = Reporting.count_messages_by_weekday(account.id)
     end
 
-    test "messages_by_weekday/1 includes zero day counts for weekdays with no messages", %{
+    test "includes zero day counts for weekdays with no messages", %{
       account: account,
       customer: customer
     } do
@@ -277,10 +286,10 @@ defmodule ChatApi.ReportingTest do
                %{day: "Friday", average: 0.0, total: 0},
                %{day: "Saturday", average: 0.0, total: 0},
                %{day: "Sunday", average: 0.0, total: 0}
-             ] = Reporting.messages_by_weekday(account.id)
+             ] = Reporting.count_messages_by_weekday(account.id)
     end
 
-    test "messages_by_weekday/1 doesn't count messages without a customer", %{
+    test "doesn't count messages without a customer", %{
       account: account,
       customer: customer
     } do
@@ -296,10 +305,10 @@ defmodule ChatApi.ReportingTest do
                %{day: "Friday", average: 0.0, total: 0},
                %{day: "Saturday", average: 0.0, total: 0},
                %{day: "Sunday", average: 0.0, total: 0}
-             ] = Reporting.messages_by_weekday(account.id)
+             ] = Reporting.count_messages_by_weekday(account.id)
     end
 
-    test "messages_by_weekday/1 doesn't count messages from other accounts", %{
+    test "doesn't count messages from other accounts", %{
       account: account,
       customer: customer
     } do
@@ -319,7 +328,7 @@ defmodule ChatApi.ReportingTest do
                %{day: "Friday", average: 0.0, total: 0},
                %{day: "Saturday", average: 0.0, total: 0},
                %{day: "Sunday", average: 0.0, total: 0}
-             ] = Reporting.messages_by_weekday(account.id)
+             ] = Reporting.count_messages_by_weekday(account.id)
     end
   end
 end

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -115,5 +115,132 @@ defmodule ChatApi.ReportingTest do
                %{date: ~D[2020-09-03], count: 1}
              ] = Reporting.conversations_by_date(account.id)
     end
+
+    test "messages_by_weekday/1 correctly calculates total and avg of customer messages per day",
+         %{
+           account: account,
+           customer: customer
+         } do
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-28 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-29 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-29 12:01:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-30 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-10-01 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-10-02 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-10-03 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-10-04 12:00:00],
+        customer_id: customer.id
+      })
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-10-05 12:00:00],
+        customer_id: customer.id
+      })
+
+      assert [
+               %{day: "Monday", average: 1.0, total: 2},
+               %{day: "Tuesday", average: 2.0, total: 2},
+               %{day: "Wednesday", average: 1.0, total: 1},
+               %{day: "Thursday", average: 1.0, total: 1},
+               %{day: "Friday", average: 1.0, total: 1},
+               %{day: "Saturday", average: 1.0, total: 1},
+               %{day: "Sunday", average: 1.0, total: 1}
+             ] = Reporting.messages_by_weekday(account.id)
+    end
+
+    test "messages_by_weekday/1 includes zero day counts for weekdays with no messages", %{
+      account: account,
+      customer: customer
+    } do
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{
+        inserted_at: ~N[2020-09-28 12:00:00],
+        customer_id: customer.id
+      })
+
+      assert [
+               %{day: "Monday", average: 1.0, total: 1},
+               %{day: "Tuesday", average: 0.0, total: 0},
+               %{day: "Wednesday", average: 0.0, total: 0},
+               %{day: "Thursday", average: 0.0, total: 0},
+               %{day: "Friday", average: 0.0, total: 0},
+               %{day: "Saturday", average: 0.0, total: 0},
+               %{day: "Sunday", average: 0.0, total: 0}
+             ] = Reporting.messages_by_weekday(account.id)
+    end
+
+    test "messages_by_weekday/1 doesn't count messages without a customer", %{
+      account: account,
+      customer: customer
+    } do
+      conversation = conversation_fixture(account, customer)
+
+      message_fixture(account, conversation, %{inserted_at: ~N[2020-09-28 12:00:00]})
+
+      assert [
+               %{day: "Monday", average: 0.0, total: 0},
+               %{day: "Tuesday", average: 0.0, total: 0},
+               %{day: "Wednesday", average: 0.0, total: 0},
+               %{day: "Thursday", average: 0.0, total: 0},
+               %{day: "Friday", average: 0.0, total: 0},
+               %{day: "Saturday", average: 0.0, total: 0},
+               %{day: "Sunday", average: 0.0, total: 0}
+             ] = Reporting.messages_by_weekday(account.id)
+    end
+
+    test "messages_by_weekday/1 doesn't count messages from other accounts", %{
+      account: account,
+      customer: customer
+    } do
+      different_account = account_fixture()
+      conversation = conversation_fixture(different_account, customer)
+
+      message_fixture(different_account, conversation, %{
+        inserted_at: ~N[2020-09-28 12:00:00],
+        customer_id: customer.id
+      })
+
+      assert [
+               %{day: "Monday", average: 0.0, total: 0},
+               %{day: "Tuesday", average: 0.0, total: 0},
+               %{day: "Wednesday", average: 0.0, total: 0},
+               %{day: "Thursday", average: 0.0, total: 0},
+               %{day: "Friday", average: 0.0, total: 0},
+               %{day: "Saturday", average: 0.0, total: 0},
+               %{day: "Sunday", average: 0.0, total: 0}
+             ] = Reporting.messages_by_weekday(account.id)
+    end
   end
 end


### PR DESCRIPTION
### Description

This PR introduces a function in `reporting.ex` to calculate the average and total of messages per day of week for a given account that have a `customer_id`.

I'm unsure about having a function produce the list of weekdays, I can revisit if necessary.

Added tests for a couple of scenarios.

### Issue

https://github.com/papercups-io/papercups/issues/256

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
