### PR TITLE
Set up internal Slack notifications

### DIFF
--- a/lib/chat_api/slack.ex
+++ b/lib/chat_api/slack.ex
@@ -59,6 +59,25 @@ defmodule ChatApi.Slack do
     end
   end
 
+  def log(message) do
+    case System.get_env("PAPERCUPS_SLACK_WEBHOOK_URL") do
+      "https://hooks.slack.com/services/" <> _rest = url ->
+        log(message, url)
+
+      _ ->
+        Logger.info("Slack log: #{inspect(message)}")
+    end
+  end
+
+  def log(message, webhook_url) do
+    [
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers, [{"content-type", "application/json"}]}
+    ]
+    |> Tesla.client()
+    |> Tesla.post(webhook_url, %{"text" => message})
+  end
+
   def should_execute?(access_token) do
     Mix.env() != :test && is_valid_access_token?(access_token)
   end


### PR DESCRIPTION
### Description

Using the `PAPERCUPS_SLACK_WEBHOOK_URL` environment variable to send internal notifications to Slack (e.g. every time a new user signs up, it would be nice to get alerted)

### Issue

None, just for internal purposes.

### Screenshots

<img width="616" alt="Screen Shot 2020-10-05 at 6 13 38 PM" src="https://user-images.githubusercontent.com/5264279/95137643-8707dd00-0736-11eb-8e75-f1a31fab1049.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
