### PR TITLE
Add customer metadata in customer details modal (#260)

### DIFF
--- a/assets/src/components/customers/CustomerDetailsModal.tsx
+++ b/assets/src/components/customers/CustomerDetailsModal.tsx
@@ -2,10 +2,42 @@ import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import {capitalize} from 'lodash';
 import {Button, Modal, Paragraph, Text} from '../common';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
+
+export const CustomerMetadataSection = ({
+  metadata,
+}: {
+  metadata: Record<string, string>;
+}) => {
+  return !metadata ? null : (
+    <React.Fragment>
+      <Box mb={2}>
+        <Box>
+          <Text strong>Custom metadata</Text>
+        </Box>
+      </Box>
+
+      <Flex sx={{justifyContent: 'space-between', flexWrap: 'wrap'}}>
+        {Object.entries(metadata).map(([key, value]: any) => {
+          const label = capitalize(key).split('_').join(' ');
+          return (
+            <Box mb={2} sx={{flex: '0 50%'}} key={key}>
+              <Box>
+                <Text strong>{label}</Text>
+              </Box>
+
+              <Paragraph>{value.toString()}</Paragraph>
+            </Box>
+          );
+        })}
+      </Flex>
+    </React.Fragment>
+  );
+};
 
 export const CustomerDetailsContent = ({customer}: {customer: any}) => {
   const {
@@ -105,45 +137,7 @@ export const CustomerDetailsContent = ({customer}: {customer: any}) => {
         </Box>
       </Flex>
 
-      <Box mb={2}>
-        <Box>
-          <Text strong>Metadata</Text>
-        </Box>
-        {Object.entries(metadata).map(([key, value]: any) => {
-          // Note: the array below contains the date formats that will be captured and formatted by dayjs
-          // This approach is based on the examples found here: https://day.js.org/docs/en/parse/string-format
-          const dateFormatsArr = [
-            'YYYY-MM-DD',
-            'MM-DD-YYYY',
-            'MM-DD-YY',
-            'DD-MM-YYYY',
-            'DD-MM-YY',
-            'YYYY/MM/DD',
-            'MM/DD/YYYY',
-            'MM/DD/YY',
-            'DD/MM/YYYY',
-            'DD/MM/YY',
-          ];
-          if (dayjs(value, dateFormatsArr).isValid() === true) {
-            const formattedDate = dayjs.utc(value).format('MMMM DD, YYYY');
-            return (
-              <Paragraph key={key}>
-                {key.charAt(0).toUpperCase() +
-                  key.slice(1).split('_').join(' ')}
-                : {formattedDate}
-              </Paragraph>
-            );
-          } else {
-            return (
-              <Paragraph key={key}>
-                {key.charAt(0).toUpperCase() +
-                  key.slice(1).split('_').join(' ')}
-                : {value.toString()}
-              </Paragraph>
-            );
-          }
-        })}
-      </Box>
+      <CustomerMetadataSection metadata={metadata} />
     </Box>
   );
 };

--- a/assets/src/components/customers/CustomerDetailsModal.tsx
+++ b/assets/src/components/customers/CustomerDetailsModal.tsx
@@ -19,6 +19,7 @@ export const CustomerDetailsContent = ({customer}: {customer: any}) => {
     updated_at: lastUpdatedAt,
     current_url: lastSeenUrl,
     ip: lastIpAddress,
+    metadata,
   } = customer;
 
   return (
@@ -103,6 +104,46 @@ export const CustomerDetailsContent = ({customer}: {customer: any}) => {
           </Paragraph>
         </Box>
       </Flex>
+
+      <Box mb={2}>
+        <Box>
+          <Text strong>Metadata</Text>
+        </Box>
+        {Object.entries(metadata).map(([key, value]: any) => {
+          // Note: the array below contains the date formats that will be captured and formatted by dayjs
+          // This approach is based on the examples found here: https://day.js.org/docs/en/parse/string-format
+          const dateFormatsArr = [
+            'YYYY-MM-DD',
+            'MM-DD-YYYY',
+            'MM-DD-YY',
+            'DD-MM-YYYY',
+            'DD-MM-YY',
+            'YYYY/MM/DD',
+            'MM/DD/YYYY',
+            'MM/DD/YY',
+            'DD/MM/YYYY',
+            'DD/MM/YY',
+          ];
+          if (dayjs(value, dateFormatsArr).isValid() === true) {
+            const formattedDate = dayjs.utc(value).format('MMMM DD, YYYY');
+            return (
+              <Paragraph key={key}>
+                {key.charAt(0).toUpperCase() +
+                  key.slice(1).split('_').join(' ')}
+                : {formattedDate}
+              </Paragraph>
+            );
+          } else {
+            return (
+              <Paragraph key={key}>
+                {key.charAt(0).toUpperCase() +
+                  key.slice(1).split('_').join(' ')}
+                : {value.toString()}
+              </Paragraph>
+            );
+          }
+        })}
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
### Description

Adds the ad hoc customer metadata to the bottom of the customer details modal. More info on how users can add this metadata is available in the September 18, 2020 [entry](https://github.com/papercups-io/papercups/wiki/Changelog#friday-18-september) of the changelog.

### Issue

#260 - Display customer metadata in customer details modal

### Screenshots

Note the highlighted sections, which show that the user can add non-standard date formats. I used the date formats array pattern of Day.js to check whether a valid date is present in each metadata key. More formats can be added to this array over time, if necessary (e.g., accounting for internationalization). I included the most common date formats that came to mind but am happy to adjust.

![image](https://user-images.githubusercontent.com/33970417/95261861-1f669600-07f9-11eb-8954-22d2ef872d65.png)

## Checklist

- [X] Everything passes when running `mix test` - 218 tests completed in 34 seconds
- [X] Ran `mix format`
- [X] No frontend compilation warnings
