### PR TITLE
Feature/Enhancement [#285] : Display messages per user breakdown in Pie Chart

### DIFF
--- a/assets/src/components/reporting/MessagesPerUserChart.tsx
+++ b/assets/src/components/reporting/MessagesPerUserChart.tsx
@@ -6,7 +6,6 @@ import {FAKE_DATA_USERS} from './support';
 
 const COLORS = [colors.green, colors.gold, colors.red, colors.volcano];
 
-// TODO: display messages and conversations in this chart with messages broken
 // down by "sent" vs "received" (where "sent" is outbound, "received" is inbound)
 
 const renderActiveShape = (props: any) => {

--- a/assets/src/components/reporting/MessagesPerUserChart.tsx
+++ b/assets/src/components/reporting/MessagesPerUserChart.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {useState} from 'react';
+import {PieChart, Pie, Cell, Sector, ResponsiveContainer} from 'recharts';
+import {colors} from '../common';
+import {FAKE_DATA_USERS} from './support';
+
+const COLORS = [colors.green, colors.gold, colors.red, colors.volcano];
+
+// TODO: display messages and conversations in this chart with messages broken
+// down by "sent" vs "received" (where "sent" is outbound, "received" is inbound)
+
+const renderActiveShape = (props: any) => {
+  const RADIAN = Math.PI / 180;
+  const {
+    cx,
+    cy,
+    midAngle,
+    innerRadius,
+    outerRadius,
+    startAngle,
+    endAngle,
+    fill,
+    value,
+    name,
+  } = props;
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const sx = cx + (outerRadius + 10) * cos;
+  const sy = cy + (outerRadius + 10) * sin;
+  const mx = cx + (outerRadius + 30) * cos;
+  const my = cy + (outerRadius + 30) * sin;
+  const ex = mx + (cos >= 0 ? 1 : -1) * 22;
+  const ey = my;
+  const textAnchor = cos >= 0 ? 'start' : 'end';
+  return (
+    <g>
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius + 10}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+      <Sector
+        cx={cx}
+        cy={cy}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        innerRadius={outerRadius + 6}
+        outerRadius={outerRadius + 10}
+        fill={fill}
+      />
+      <path
+        d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`}
+        stroke={fill}
+        fill="none"
+      />
+      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * 12}
+        y={ey}
+        textAnchor={textAnchor}
+        fill={'#686D76'}
+      >{`${name}`}</text>
+      <text
+        x={ex + (cos >= 0 ? 1 : -1) * 12}
+        y={ey}
+        dy={30}
+        textAnchor={textAnchor}
+        fill={fill}
+      >{`Messages : ${value}`}</text>
+    </g>
+  );
+};
+
+const MessagesPerUserChart = ({data = FAKE_DATA_USERS}: {data: any}) => {
+  const [activeindex, setActiveindex] = useState(-1);
+
+  return (
+    <ResponsiveContainer>
+      <PieChart
+        margin={{
+          top: 8,
+          bottom: 8,
+          left: 10,
+          right: 10,
+        }}
+      >
+        <Pie
+          data={data}
+          innerRadius={60}
+          outerRadius={75}
+          fill="#8884d8"
+          paddingAngle={5}
+          dataKey="value"
+          activeShape={renderActiveShape}
+          onMouseEnter={(data, index) => {
+            setActiveindex(index);
+          }}
+          onMouseLeave={(data, index) => {
+            setActiveindex(-1);
+          }}
+          activeIndex={activeindex}
+        >
+          {data.map((entry: any, index: number) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default MessagesPerUserChart;

--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -4,6 +4,7 @@ import {Box, Flex} from 'theme-ui';
 import * as API from '../../api';
 import {Alert, Paragraph, RangePicker, Text, Title} from '../common';
 import MessagesPerDayChart from './MessagesPerDayChart';
+import MessagesPerUserChart from './MessagesPerUserChart';
 import {ReportingDatum} from './support';
 import logger from '../../logger';
 
@@ -12,12 +13,21 @@ type DateCount = {
   date: string;
 };
 
+type MessageCount = {
+  count: number;
+  user: {
+    email: string;
+    id: number;
+  };
+};
+
 type Props = {};
 type State = {
   fromDate: dayjs.Dayjs;
   toDate: dayjs.Dayjs;
   messagesByDate: Array<DateCount>;
   conversationsByDate: Array<DateCount>;
+  messagesPerUser: Array<MessageCount>;
 };
 
 class ReportingDashboard extends React.Component<Props, State> {
@@ -26,6 +36,7 @@ class ReportingDashboard extends React.Component<Props, State> {
     toDate: dayjs(),
     messagesByDate: [],
     conversationsByDate: [],
+    messagesPerUser: [],
   };
 
   componentDidMount() {
@@ -46,7 +57,16 @@ class ReportingDashboard extends React.Component<Props, State> {
     this.setState({
       messagesByDate: data?.messages_by_date || [],
       conversationsByDate: data?.conversations_by_date || [],
+      messagesPerUser: data?.messages_per_user || [],
     });
+  };
+
+  formatUserStats = () => {
+    const {messagesPerUser = []} = this.state;
+    return messagesPerUser.map((data) => ({
+      name: data.user.email,
+      value: data.count,
+    }));
   };
 
   groupCountByDate = (data: Array<DateCount>) => {
@@ -132,6 +152,13 @@ class ReportingDashboard extends React.Component<Props, State> {
               <Text strong>New messages per day</Text>
             </Box>
             <MessagesPerDayChart data={this.formatDailyStats()} />
+          </Box>
+
+          <Box mb={4} mx={3} sx={{height: 320, flex: 1}}>
+            <Box mb={2}>
+              <Text strong>Messages per user</Text>
+            </Box>
+            <MessagesPerUserChart data={this.formatUserStats()} />
           </Box>
           {/*
           // TODO: implement me!

--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -154,7 +154,7 @@ class ReportingDashboard extends React.Component<Props, State> {
             <MessagesPerDayChart data={this.formatDailyStats()} />
           </Box>
 
-          <Box mb={4} mx={3} sx={{height: 320, flex: 1}}>
+          <Box mb={4} mx={10} sx={{height: 320, flex: 1}}>
             <Box mb={2}>
               <Text strong>Messages per user</Text>
             </Box>
@@ -179,17 +179,6 @@ class ReportingDashboard extends React.Component<Props, State> {
               <Text strong>Messages by day of week</Text>
             </Box>
             <MessagesByDayOfWeekChart data={...} />
-          </Box>
-          */}
-
-          {/*
-          // TODO: implement me!
-
-          <Box mb={4} mx={3} sx={{height: 320, flex: 1}}>
-            <Box mb={2}>
-              <Text strong>Messages per user</Text>
-            </Box>
-            <MessagesPerUserChart data={...} />
           </Box>
           */}
         </Flex>

--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -214,6 +214,9 @@ class ReportingDashboard extends React.Component<Props, State> {
       fromDate: dayjs(fromDate),
       toDate: dayjs(toDate),
     });
+    this.refreshReportingData().catch((err) =>
+      logger.error('Failed to fetch reporting data:', err)
+    );
   };
 
   render() {

--- a/assets/src/components/reporting/support.ts
+++ b/assets/src/components/reporting/support.ts
@@ -8,6 +8,72 @@ export type ReportingDatum = {
 
 // Fake data for testing
 // TODO: replace with real data from API below!
+export const FAKE_DATA_USERS: Array<ReportingDatum> = [
+  {
+    name: 'asdf@gmail.com',
+    value: 4,
+  },
+  {
+    name: 'dddads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'dsads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'ttggdads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'asdf@gmail.com',
+    value: 4,
+  },
+  {
+    name: 'dddads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'dsads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'ttggdads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'asdf@gmail.com',
+    value: 4,
+  },
+  {
+    name: 'dddads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'dsads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'ttggdads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'asdf@gmail.com',
+    value: 4,
+  },
+  {
+    name: 'dddads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'dsads@gmail.com',
+    value: 6,
+  },
+  {
+    name: 'ttggdads@gmail.com',
+    value: 6,
+  },
+];
 export const FAKE_DATA: Array<ReportingDatum> = [
   {
     date: 'Sept 1',


### PR DESCRIPTION
### Description

Added a PieChartWithPaddingAngle in reporting to view messages per user stat

### Issue

[#285 ](https://github.com/papercups-io/papercups/issues/285)

### Screenshots


![image](https://user-images.githubusercontent.com/25644166/95321311-85feb900-08b8-11eb-8428-6fc375147390.png)
![image](https://user-images.githubusercontent.com/25644166/95321360-96af2f00-08b8-11eb-8e45-3e066d91e14c.png)


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
