### PR TITLE
Fix: Reject disabled users when auto assigning.

### DIFF
--- a/lib/chat_api/slack.ex
+++ b/lib/chat_api/slack.ex
@@ -338,11 +338,18 @@ defmodule ChatApi.Slack do
     conversation
     |> Map.get(:account)
     |> Map.get(:users)
+    |> fetch_valid_user()
+  end
+
+  def fetch_valid_user([]),
+    do: raise("No users associated with the conversation's account")
+
+  def fetch_valid_user(users) do
+    users
+    |> Enum.reject(& &1.disabled_at)
+    |> Enum.sort_by(& &1.inserted_at)
     |> List.first()
-    |> case do
-      nil -> raise "No users associated with the conversation's account"
-      user -> user.id
-    end
+    |> Map.get(:id)
   end
 
   def is_valid_access_token?(token) do

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -6,7 +6,8 @@ defmodule ChatApi.SlackTest do
   alias ChatApi.{
     Conversations,
     Slack,
-    SlackConversationThreads
+    SlackConversationThreads,
+    Users
   }
 
   describe "slack" do
@@ -158,6 +159,23 @@ defmodule ChatApi.SlackTest do
       conversation = Conversations.get_conversation!(id)
 
       assert conversation.assignee_id == primary_user.id
+    end
+
+    test "fetch_valid_user/1 reject disabled users and fetch the oldest user.",
+         %{account: account} do
+      {:ok, disabled_user} =
+        account
+        |> user_fixture()
+        |> Users.disable_user()
+
+      primary_user = user_fixture(account)
+
+      # Make sure that secondary_user is inserted later.
+      :timer.sleep(1000)
+      secondary_user = user_fixture(account)
+
+      users = [disabled_user, secondary_user, primary_user]
+      assert primary_user.id === Slack.fetch_valid_user(users)
     end
 
     test "create_new_slack_conversation_thread/2 raises if no primary user exists", %{

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -171,7 +171,7 @@ defmodule ChatApi.SlackTest do
       primary_user = user_fixture(account)
 
       # Make sure that secondary_user is inserted later.
-      :timer.sleep(1000)
+      :timer.sleep(100)
       secondary_user = user_fixture(account)
 
       users = [disabled_user, secondary_user, primary_user]


### PR DESCRIPTION
### Description

This commit does:
- Rejects users which have a non-nil value assigned to `deleted_at`.
- Sorts the users by `inserted_at`, and gets the oldest users.

### Issue
Resolves: #286 

### Screenshots

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [?] No frontend compilation warnings
