### PR TITLE
Display conversation/customer details in sidebar by default

### DIFF
--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -43,8 +43,10 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
     <Box
       sx={{
         width: '100%',
+        minHeight: '100%',
         bg: 'rgb(245, 245, 245)',
         border: `1px solid rgba(0,0,0,.06)`,
+        boxShadow: 'inset rgba(0, 0, 0, 0.1) 0px 0px 4px',
         flex: 1,
       }}
     >
@@ -118,18 +120,17 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
             <PhoneOutlined style={{color: colors.primary}} />
             <Box ml={2}>{phone || 'Unknown'}</Box>
           </Flex>
-          <Flex
-            mb={1}
-            sx={{
-              alignItems: 'center',
-              maxWidth: '100%',
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-            }}
-          >
+          <Flex mb={1} sx={{alignItems: 'center'}}>
             <UserOutlined style={{color: colors.primary}} />
-            <Box ml={2}>
+            <Box
+              ml={2}
+              sx={{
+                maxWidth: '100%',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              }}
+            >
               <Text type="secondary">ID:</Text>{' '}
               <Tooltip title={externalId || customerId} placement="left">
                 {externalId || customerId}

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -199,7 +199,9 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
               <GlobalOutlined /> {formattedTimezone}
             </Box>
           )}
-          <Box mb={1}>{[os, browser].join(' · ') || 'Unknown'}</Box>
+          <Box mb={1}>
+            {[os, browser].filter(Boolean).join(' · ') || 'Unknown'}
+          </Box>
           <Box mb={1}>
             <Text type="secondary">IP:</Text> {lastIpAddress || 'Unknown'}
           </Box>

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -14,6 +14,22 @@ import {
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
 
+const DetailsSectionCard = ({children}: {children: any}) => {
+  return (
+    <Box
+      my={2}
+      p={2}
+      sx={{
+        bg: colors.white,
+        border: '1px solid rgba(0,0,0,.06)',
+        borderRadius: 4,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
 type Props = {
   customer: any;
   conversation: any;
@@ -35,7 +51,9 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
     current_url: lastSeenUrl,
     time_zone: timezone,
     ip: lastIpAddress,
+    metadata = {},
   } = customer;
+  const hasMetadata = !!metadata && Object.keys(metadata).length > 0;
   const formattedTimezone =
     timezone && timezone.length ? timezone.split('_').join(' ') : null;
 
@@ -77,22 +95,14 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
           </Tag>
         </Box>
 
-        {/*
-          <Box
-            mt={2}
-            p={2}
-            sx={{
-              bg: colors.white,
-              border: '1px solid rgba(0,0,0,.06)',
-              borderRadius: 4,
-            }}
-          >
+        {false && (
+          <DetailsSectionCard>
             <Box mb={2}>
               <Text strong>Tags</Text>
             </Box>
             <Box>Conversation tags</Box>
-          </Box>
-          */}
+          </DetailsSectionCard>
+        )}
       </Box>
 
       <Box px={2} py={3}>
@@ -100,18 +110,11 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
           <Text strong>Customer details</Text>
         </Box>
 
-        <Box
-          my={2}
-          p={2}
-          sx={{
-            bg: colors.white,
-            border: '1px solid rgba(0,0,0,.06)',
-            borderRadius: 4,
-          }}
-        >
+        <DetailsSectionCard>
           <Box mb={2}>
             <Text strong>{name || 'Anonymous User'}</Text>
           </Box>
+
           <Flex mb={1} sx={{alignItems: 'center'}}>
             <MailOutlined style={{color: colors.primary}} />
             <Box ml={2}>{email || 'Unknown'}</Box>
@@ -137,17 +140,9 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
               </Tooltip>
             </Box>
           </Flex>
-        </Box>
+        </DetailsSectionCard>
 
-        <Box
-          my={2}
-          p={2}
-          sx={{
-            bg: colors.white,
-            border: '1px solid rgba(0,0,0,.06)',
-            borderRadius: 4,
-          }}
-        >
+        <DetailsSectionCard>
           <Box mb={2}>
             <Text strong>Last seen</Text>
           </Box>
@@ -167,17 +162,9 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
               <Text>Unknown URL</Text>
             )}
           </Box>
-        </Box>
+        </DetailsSectionCard>
 
-        <Box
-          my={2}
-          p={2}
-          sx={{
-            bg: colors.white,
-            border: '1px solid rgba(0,0,0,.06)',
-            borderRadius: 4,
-          }}
-        >
+        <DetailsSectionCard>
           <Box mb={2}>
             <Text strong>First seen</Text>
           </Box>
@@ -185,17 +172,25 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
             <CalendarOutlined />{' '}
             {createdAt ? dayjs.utc(createdAt).format('MMMM DD, YYYY') : 'N/A'}
           </Box>
-        </Box>
+        </DetailsSectionCard>
 
-        <Box
-          my={2}
-          p={2}
-          sx={{
-            bg: colors.white,
-            border: '1px solid rgba(0,0,0,.06)',
-            borderRadius: 4,
-          }}
-        >
+        {hasMetadata && (
+          <DetailsSectionCard>
+            <Box mb={2}>
+              <Text strong>Metadata</Text>
+            </Box>
+
+            {Object.entries(metadata).map(([key, value]) => {
+              return (
+                <Box key={key} mb={1}>
+                  <Text type="secondary">{key}:</Text> {String(value)}
+                </Box>
+              );
+            })}
+          </DetailsSectionCard>
+        )}
+
+        <DetailsSectionCard>
           <Box mb={2}>
             <Text strong>Device</Text>
           </Box>
@@ -208,24 +203,16 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
           <Box mb={1}>
             <Text type="secondary">IP:</Text> {lastIpAddress || 'Unknown'}
           </Box>
-        </Box>
+        </DetailsSectionCard>
 
-        {/*
-          <Box
-            my={2}
-            p={2}
-            sx={{
-              bg: colors.white,
-              border: '1px solid rgba(0,0,0,.06)',
-              borderRadius: 4,
-            }}
-          >
+        {false && (
+          <DetailsSectionCard>
             <Box mb={2}>
               <Text strong>Tags</Text>
             </Box>
             <Box>Customer tags</Box>
-          </Box>
-          */}
+          </DetailsSectionCard>
+        )}
       </Box>
     </Box>
   );

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -155,9 +155,11 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
           </Box>
           <Box mb={1}>
             {lastSeenUrl ? (
-              <a href={lastSeenUrl} target="_blank" rel="noopener noreferrer">
-                {pathname && pathname.length > 1 ? pathname : lastSeenUrl}
-              </a>
+              <Tooltip title={lastSeenUrl}>
+                <a href={lastSeenUrl} target="_blank" rel="noopener noreferrer">
+                  {pathname && pathname.length > 1 ? pathname : lastSeenUrl}
+                </a>
+              </Tooltip>
             ) : (
               <Text>Unknown URL</Text>
             )}

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Box, Flex} from 'theme-ui';
-import {colors, Button, Footer, TextArea} from '../common';
+import {colors, Button, TextArea} from '../common';
 
 const ConversationFooter = ({
   onSendMessage,
@@ -27,7 +27,7 @@ const ConversationFooter = ({
   };
 
   return (
-    <Footer style={{padding: 0}}>
+    <Box style={{flex: '0 0 auto'}}>
       <Box px={4} pt={0} pb={4} backgroundColor={colors.white}>
         <Box
           p={2}
@@ -57,7 +57,7 @@ const ConversationFooter = ({
           </form>
         </Box>
       </Box>
-    </Footer>
+    </Box>
   );
 };
 

--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -268,7 +268,8 @@ const ConversationHeader = ({
         </Flex>
       </Flex>
 
-      {hasCustomerMetadata(customer) && (
+      {/* NB: just hiding this for now */}
+      {false && hasCustomerMetadata(customer) && (
         <Box
           py={2}
           mx={4}

--- a/assets/src/components/conversations/ConversationMessages.tsx
+++ b/assets/src/components/conversations/ConversationMessages.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {Box, Flex} from 'theme-ui';
+import {Button, colors, Result} from '../common';
+import {SmileOutlined} from '../icons';
+import Spinner from '../Spinner';
+import ChatMessage from './ChatMessage';
+
+const EmptyMessagesPlaceholder = () => {
+  return (
+    <Box my={4}>
+      <Result
+        status="success"
+        title="No messages"
+        subTitle="Nothing to show here! Take a well-earned break 😊"
+      />
+    </Box>
+  );
+};
+
+const GettingStartedRedirect = () => {
+  return (
+    <Box my={4}>
+      <Result
+        icon={<SmileOutlined />}
+        title="No messages"
+        subTitle="It looks like your widget hasn't been set up yet!"
+        extra={
+          <Link to="/account/getting-started">
+            <Button type="primary">Get Started</Button>
+          </Link>
+        }
+      />
+      ,
+    </Box>
+  );
+};
+
+const ConversationMessages = ({
+  messages,
+  currentUser,
+  customer,
+  loading,
+  isClosing,
+  showGetStarted,
+  setScrollRef,
+}: {
+  messages: Array<any>;
+  currentUser: any;
+  customer: any;
+  loading: boolean;
+  isClosing: boolean;
+  showGetStarted: boolean;
+  setScrollRef: (el: any) => void;
+}) => {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        overflowY: 'scroll',
+        opacity: isClosing ? 0.6 : 1,
+      }}
+    >
+      {loading ? (
+        <Flex
+          sx={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Spinner size={40} />
+        </Flex>
+      ) : (
+        <Box p={4} backgroundColor={colors.white} sx={{minHeight: '100%'}}>
+          {messages.length ? (
+            messages.map((msg: any, key: number) => {
+              // Slight hack
+              const next = messages[key + 1];
+              const isMe = msg.user_id && msg.user_id === currentUser.id;
+              const isLastInGroup = next
+                ? msg.customer_id !== next.customer_id
+                : true;
+
+              // TODO: fix `isMe` logic for multiple agents
+              return (
+                <ChatMessage
+                  key={key}
+                  message={msg}
+                  customer={customer}
+                  isMe={isMe}
+                  isLastInGroup={isLastInGroup}
+                  shouldDisplayTimestamp={isLastInGroup}
+                />
+              );
+            })
+          ) : showGetStarted ? (
+            <GettingStartedRedirect />
+          ) : (
+            <EmptyMessagesPlaceholder />
+          )}
+          <div ref={setScrollRef} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ConversationMessages;

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box} from 'theme-ui';
+import {Box, Flex} from 'theme-ui';
 import {colors, Layout, notification, Sider, Text, Title} from '../common';
 import {sleep} from '../../utils';
 import ConversationHeader from './ConversationHeader';
@@ -7,6 +7,7 @@ import ConversationItem from './ConversationItem';
 import ConversationClosing from './ConversationClosing';
 import ConversationMessages from './ConversationMessages';
 import ConversationFooter from './ConversationFooter';
+import ConversationDetailsSidebar from './ConversationDetailsSidebar';
 
 type Props = {
   title?: string;
@@ -380,27 +381,52 @@ class ConversationsContainer extends React.Component<Props, State> {
             onReopenConversation={this.handleReopenConversation}
             onDeleteConversation={this.handleDeleteConversation}
           />
-
-          <ConversationMessages
-            messages={messages}
-            currentUser={currentUser}
-            customer={selectedCustomer}
-            loading={loading}
-            isClosing={isClosingSelected}
-            showGetStarted={showGetStarted}
-            setScrollRef={(el) => (this.scrollToEl = el)}
-          />
-
-          {selectedConversation && (
-            // NB: the `key` forces a rerender so the input can clear
-            // any text from the last conversation and trigger autofocus
-            <ConversationFooter
-              key={selectedConversation.id}
-              onSendMessage={this.handleSendMessage}
+          <Flex
+            sx={{
+              position: 'relative',
+              flex: 1,
+              flexDirection: 'column',
+              minHeight: 0,
+              minWidth: 640,
+              pr: 240, // TODO: animate this if we make it toggle-able
+            }}
+          >
+            <ConversationMessages
+              messages={messages}
+              currentUser={currentUser}
+              customer={selectedCustomer}
+              loading={loading}
+              isClosing={isClosingSelected}
+              showGetStarted={showGetStarted}
+              setScrollRef={(el) => (this.scrollToEl = el)}
             />
-          )}
 
-          {/* <Box sx={{width: 240, border: '1px solid black'}}>Test?</Box> */}
+            {selectedConversation && (
+              // NB: the `key` forces a rerender so the input can clear
+              // any text from the last conversation and trigger autofocus
+              <ConversationFooter
+                key={selectedConversation.id}
+                onSendMessage={this.handleSendMessage}
+              />
+            )}
+
+            {selectedConversation && (
+              <Box
+                sx={{
+                  width: 240,
+                  height: '100%',
+                  overflowY: 'scroll',
+                  position: 'absolute',
+                  right: 0,
+                }}
+              >
+                <ConversationDetailsSidebar
+                  customer={selectedCustomer}
+                  conversation={selectedConversation}
+                />
+              </Box>
+            )}
+          </Flex>
         </Layout>
       </Layout>
     );

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -1,55 +1,12 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
-import {Box, Flex} from 'theme-ui';
-import {
-  Button,
-  colors,
-  Content,
-  Layout,
-  notification,
-  Result,
-  Sider,
-  Text,
-  Title,
-} from '../common';
-import {SmileOutlined} from '../icons';
+import {Box} from 'theme-ui';
+import {colors, Layout, notification, Sider, Text, Title} from '../common';
 import {sleep} from '../../utils';
-import Spinner from '../Spinner';
-import ChatMessage from './ChatMessage';
 import ConversationHeader from './ConversationHeader';
 import ConversationItem from './ConversationItem';
 import ConversationClosing from './ConversationClosing';
+import ConversationMessages from './ConversationMessages';
 import ConversationFooter from './ConversationFooter';
-
-const EmptyMessagesPlaceholder = () => {
-  return (
-    <Box my={4}>
-      <Result
-        status="success"
-        title="No messages"
-        subTitle="Nothing to show here! Take a well-earned break 😊"
-      />
-    </Box>
-  );
-};
-
-const GettingStartedRedirect = () => {
-  return (
-    <Box my={4}>
-      <Result
-        icon={<SmileOutlined />}
-        title="No messages"
-        subTitle="It looks like your widget hasn't been set up yet!"
-        extra={
-          <Link to="/account/getting-started">
-            <Button type="primary">Get Started</Button>
-          </Link>
-        }
-      />
-      ,
-    </Box>
-  );
-};
 
 type Props = {
   title?: string;
@@ -346,7 +303,8 @@ class ConversationsContainer extends React.Component<Props, State> {
 
     const loading = this.props.loading || this.state.loading;
     const isClosingSelected =
-      selectedConversationId && closing.indexOf(selectedConversationId) !== -1;
+      !!selectedConversationId &&
+      closing.indexOf(selectedConversationId) !== -1;
 
     return (
       <Layout style={{background: colors.white}}>
@@ -423,56 +381,15 @@ class ConversationsContainer extends React.Component<Props, State> {
             onDeleteConversation={this.handleDeleteConversation}
           />
 
-          <Content
-            style={{overflowY: 'scroll', opacity: isClosingSelected ? 0.6 : 1}}
-          >
-            {loading ? (
-              <Flex
-                sx={{
-                  flex: 1,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  height: '100%',
-                }}
-              >
-                <Spinner size={40} />
-              </Flex>
-            ) : (
-              <Box
-                p={4}
-                backgroundColor={colors.white}
-                sx={{minHeight: '100%'}}
-              >
-                {messages.length ? (
-                  messages.map((msg: any, key: number) => {
-                    // Slight hack
-                    const next = messages[key + 1];
-                    const isMe = msg.user_id && msg.user_id === currentUser.id;
-                    const isLastInGroup = next
-                      ? msg.customer_id !== next.customer_id
-                      : true;
-
-                    // TODO: fix `isMe` logic for multiple agents
-                    return (
-                      <ChatMessage
-                        key={key}
-                        message={msg}
-                        customer={selectedCustomer}
-                        isMe={isMe}
-                        isLastInGroup={isLastInGroup}
-                        shouldDisplayTimestamp={isLastInGroup}
-                      />
-                    );
-                  })
-                ) : showGetStarted ? (
-                  <GettingStartedRedirect />
-                ) : (
-                  <EmptyMessagesPlaceholder />
-                )}
-                <div ref={(el) => (this.scrollToEl = el)} />
-              </Box>
-            )}
-          </Content>
+          <ConversationMessages
+            messages={messages}
+            currentUser={currentUser}
+            customer={selectedCustomer}
+            loading={loading}
+            isClosing={isClosingSelected}
+            showGetStarted={showGetStarted}
+            setScrollRef={(el) => (this.scrollToEl = el)}
+          />
 
           {selectedConversation && (
             // NB: the `key` forces a rerender so the input can clear
@@ -482,6 +399,8 @@ class ConversationsContainer extends React.Component<Props, State> {
               onSendMessage={this.handleSendMessage}
             />
           )}
+
+          {/* <Box sx={{width: 240, border: '1px solid black'}}>Test?</Box> */}
         </Layout>
       </Layout>
     );

--- a/assets/src/components/customers/CustomerDetailsModal.tsx
+++ b/assets/src/components/customers/CustomerDetailsModal.tsx
@@ -15,7 +15,11 @@ export const CustomerMetadataSection = ({
 }) => {
   return !metadata ? null : (
     <React.Fragment>
-      <Box mb={2}>
+      <Box
+        mb={2}
+        py={2}
+        sx={{borderTop: '1px solid #f0f0f0', borderBottom: '1px solid #f0f0f0'}}
+      >
         <Box>
           <Text strong>Custom metadata</Text>
         </Box>


### PR DESCRIPTION
### Description

Sets up sidebar with conversation/customer details:
<img width="1258" alt="Screen Shot 2020-10-08 at 11 10 10 AM" src="https://user-images.githubusercontent.com/5264279/95478407-7aae9a80-0957-11eb-844f-72dafd6e1b3e.png">

For now it's displayed by default, but in the future we might make it possible to open/hide it (depending on feedback).

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
