### PR TITLE
Add basic customer tagging UI

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -163,6 +163,17 @@ export const fetchCustomers = async (token = getAccessToken()) => {
     .then((res) => res.body.data);
 };
 
+export const fetchCustomer = async (id: string, token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/customers/${id}`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const createNewConversation = async (
   accountId: string,
   customerId: string

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import {Box, Flex} from 'theme-ui';
-import {colors, Button, Select, Tag, Text, Tooltip} from '../common';
+import {colors, Tag, Text, Tooltip} from '../common';
 import {
   CalendarOutlined,
   GlobalOutlined,
@@ -10,9 +10,7 @@ import {
   PhoneOutlined,
   UserOutlined,
 } from '../icons';
-import Spinner from '../Spinner';
-import * as API from '../../api';
-import logger from '../../logger';
+import SidebarCustomerTags from './SidebarCustomerTags';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -29,164 +27,6 @@ const DetailsSectionCard = ({children}: {children: any}) => {
       }}
     >
       {children}
-    </Box>
-  );
-};
-
-// TODO: find a way to clean this up a bit...
-// Maybe experiment with `useReducer`, or just avoid using hooks in general?
-const CustomerTags = ({customerId}: {customerId: string}) => {
-  const [isLoading, setLoading] = React.useState(false);
-  const [isEditing, setEditing] = React.useState(false);
-  const [isUpdating, setUpdating] = React.useState(false);
-  const [currentTags, setCurrentTags] = React.useState([]);
-  const [updatedTags, setUpdatedTags] = React.useState([]);
-  const [tagOptions, setTagOptions] = React.useState([]);
-
-  React.useEffect(() => {
-    setLoading(true);
-
-    refreshLatestTags().then(() => setLoading(false));
-    // eslint-disable-next-line
-  }, [customerId]);
-
-  function handleStartEditing() {
-    setEditing(true);
-  }
-
-  function refreshLatestTags() {
-    return Promise.all([API.fetchCustomer(customerId), API.fetchAllTags()])
-      .then(([customer, tags]) => {
-        const {tags: currentTags = []} = customer;
-        const formattedTags = currentTags.map((tag: any) => {
-          return {id: tag.id, label: tag.name, value: tag.name};
-        });
-
-        setCurrentTags(currentTags);
-        setUpdatedTags(formattedTags);
-        setTagOptions(tags);
-      })
-      .catch((err) => {
-        logger.error('Failed to fetch customer details:', err);
-      });
-  }
-
-  function handleChangeTags(values: Array<string>, tags: any) {
-    const updated = tags.map((t: any, idx: number) => {
-      const value = values[idx];
-
-      return {...t, value, label: value};
-    });
-
-    setUpdatedTags(updated);
-  }
-
-  function handleUpdateTags() {
-    setUpdating(true);
-
-    const initialIds = currentTags.map((t: any) => t.id);
-    const remainingIds = updatedTags
-      .filter((t: any) => !!t.id)
-      .map((t: any) => t.id);
-    const newTagsToCreate = updatedTags
-      .filter((t: any) => !t.id)
-      .map((t: any) => t.value);
-    const tagIdsToAdd = remainingIds.filter(
-      (tagId) => tagId && initialIds.indexOf(tagId) === -1
-    );
-    const tagIdsToRemove = initialIds.filter(
-      (tagId) => remainingIds.indexOf(tagId) === -1
-    );
-
-    const promises = [
-      ...newTagsToCreate.map((name) =>
-        API.createTag(name).then(({id: tagId}) =>
-          API.addCustomerTag(customerId, tagId)
-        )
-      ),
-      ...tagIdsToAdd.map((tagId) => API.addCustomerTag(customerId, tagId)),
-      ...tagIdsToRemove.map((tagId) =>
-        API.removeCustomerTag(customerId, tagId)
-      ),
-    ];
-
-    Promise.all(promises)
-      .then((results) => {
-        logger.debug('Successfully updated customer tags:', results);
-      })
-      .catch((err) => {
-        logger.error('Failed to update customer tags:', err);
-      })
-      .then(() => refreshLatestTags())
-      .then(() => {
-        setEditing(false);
-        setUpdating(false);
-      });
-  }
-
-  if (isLoading) {
-    return <Spinner size={16} />;
-  }
-
-  return (
-    <Box>
-      <Box mb={1}>
-        {/* TODO: figure out a nicer design for this */}
-        {isEditing ? (
-          <Select
-            mode="tags"
-            style={{width: '100%'}}
-            placeholder="Add tags"
-            value={updatedTags.map((t: any) => t.value)}
-            onChange={handleChangeTags}
-            options={tagOptions.map((tag: any) => {
-              const {id, name} = tag;
-
-              return {id, key: id, label: name, value: name};
-            })}
-          />
-        ) : (
-          <Flex sx={{flexWrap: 'wrap'}}>
-            {currentTags && currentTags.length ? (
-              currentTags.map((tag: any, idx: number) => {
-                const options = ['magenta', 'red', 'volcano', 'purple', 'blue'];
-                const color = options[idx % 5];
-                const {id, name} = tag;
-
-                return (
-                  <Box key={id} my={1}>
-                    <Tag key={id} color={color}>
-                      {name}
-                    </Tag>
-                  </Box>
-                );
-              })
-            ) : (
-              <Text type="secondary">None</Text>
-            )}
-          </Flex>
-        )}
-      </Box>
-      <Box mb={1}>
-        {isEditing ? (
-          <Button
-            size="small"
-            type="primary"
-            loading={isUpdating}
-            onClick={handleUpdateTags}
-          >
-            Done
-          </Button>
-        ) : (
-          <Button
-            size="small"
-            loading={isUpdating}
-            onClick={handleStartEditing}
-          >
-            {currentTags && currentTags.length ? 'Edit' : 'Add'}
-          </Button>
-        )}
-      </Box>
     </Box>
   );
 };
@@ -374,7 +214,7 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
           <Box mb={2}>
             <Text strong>Tags</Text>
           </Box>
-          <CustomerTags customerId={customerId} />
+          <SidebarCustomerTags customerId={customerId} />
         </DetailsSectionCard>
       </Box>
     </Box>

--- a/assets/src/components/conversations/SidebarCustomerTags.tsx
+++ b/assets/src/components/conversations/SidebarCustomerTags.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Button, Select, Tag, Text} from '../common';
+import Spinner from '../Spinner';
+import * as API from '../../api';
+import logger from '../../logger';
+
+type State = {
+  loading: boolean;
+  editing: boolean;
+  updating: boolean;
+  current: Array<any>;
+  updated: Array<any>;
+  options: Array<any>;
+};
+
+const initial: State = {
+  loading: false,
+  editing: false,
+  updating: false,
+  current: [],
+  updated: [],
+  options: [],
+};
+
+type Action = {
+  type:
+    | 'loading:start'
+    | 'loading:stop'
+    | 'editing:start'
+    | 'updating:start'
+    | 'updating:done'
+    | 'tags:init'
+    | 'tags:update';
+  payload?: any;
+};
+
+const reducer = (state: State, action: Action) => {
+  const {type, payload} = action;
+
+  switch (type) {
+    case 'loading:start':
+      return {...state, loading: true};
+    case 'loading:stop':
+      return {...state, loading: false};
+    case 'editing:start':
+      return {...state, editing: true};
+    case 'updating:start':
+      return {...state, updating: true};
+    case 'updating:done':
+      return {...state, updating: false, editing: false};
+    case 'tags:init':
+      return {
+        ...state,
+        current: payload.current,
+        updated: payload.updated,
+        options: payload.options,
+      };
+    case 'tags:update':
+      return {...state, updated: payload};
+    default:
+      return state;
+  }
+};
+
+// TODO: find a way to clean this up a bit...
+// Maybe experiment with `useReducer`, or just avoid using hooks in general?
+const SidebarCustomerTags = ({customerId}: {customerId: string}) => {
+  const [state, dispatch] = React.useReducer(reducer, initial);
+
+  React.useEffect(() => {
+    dispatch({type: 'loading:start'});
+
+    refreshLatestTags().then(() => dispatch({type: 'loading:stop'}));
+    // eslint-disable-next-line
+  }, [customerId]);
+
+  function handleStartEditing() {
+    dispatch({type: 'editing:start'});
+  }
+
+  async function refreshLatestTags() {
+    return Promise.all([API.fetchCustomer(customerId), API.fetchAllTags()])
+      .then(([customer, tags]) => {
+        dispatch({
+          type: 'tags:init',
+          payload: {
+            current: customer.tags,
+            updated: customer.tags.map((tag: any) => {
+              return {id: tag.id, label: tag.name, value: tag.name};
+            }),
+            options: tags,
+          },
+        });
+      })
+      .catch((err) => {
+        logger.error('Failed to fetch customer details:', err);
+      });
+  }
+
+  function handleChangeTags(values: Array<string>, tags: any) {
+    const updated = tags.map((t: any, idx: number) => {
+      const value = values[idx];
+
+      return {...t, value, label: value};
+    });
+
+    dispatch({type: 'tags:update', payload: updated});
+  }
+
+  function handleUpdateTags() {
+    dispatch({type: 'updating:start'});
+
+    const {current = [], updated = []} = state;
+    const currentIds = current.map((t: any) => t.id);
+    const remainingIds = updated
+      .filter((t: any) => !!t.id)
+      .map((t: any) => t.id);
+    const newTagsToCreate = updated
+      .filter((t: any) => !t.id)
+      .map((t: any) => t.value);
+    const tagIdsToAdd = remainingIds.filter(
+      (tagId: string) => tagId && currentIds.indexOf(tagId) === -1
+    );
+    const tagIdsToRemove = currentIds.filter(
+      (tagId: string) => remainingIds.indexOf(tagId) === -1
+    );
+
+    const promises = [
+      ...newTagsToCreate.map((name: string) =>
+        API.createTag(name).then(({id: tagId}) =>
+          API.addCustomerTag(customerId, tagId)
+        )
+      ),
+      ...tagIdsToAdd.map((tagId: string) =>
+        API.addCustomerTag(customerId, tagId)
+      ),
+      ...tagIdsToRemove.map((tagId: string) =>
+        API.removeCustomerTag(customerId, tagId)
+      ),
+    ];
+
+    Promise.all(promises)
+      .then((results) => {
+        logger.debug('Successfully updated customer tags:', results);
+      })
+      .catch((err) => {
+        logger.error('Failed to update customer tags:', err);
+      })
+      .then(() => refreshLatestTags())
+      .then(() => dispatch({type: 'updating:done'}));
+  }
+
+  if (state.loading) {
+    return <Spinner size={16} />;
+  }
+
+  return (
+    <Box>
+      <Box mb={1}>
+        {/* TODO: figure out a nicer design for this */}
+        {state.editing ? (
+          <Select
+            mode="tags"
+            style={{width: '100%'}}
+            placeholder="Add tags"
+            value={state.updated.map((t: any) => t.value)}
+            onChange={handleChangeTags}
+            options={state.options.map((tag: any) => {
+              const {id, name} = tag;
+
+              return {id, key: id, label: name, value: name};
+            })}
+          />
+        ) : (
+          <Flex sx={{flexWrap: 'wrap'}}>
+            {state.current && state.current.length ? (
+              state.current.map((tag: any, idx: number) => {
+                const options = ['magenta', 'red', 'volcano', 'purple', 'blue'];
+                const color = options[idx % 5];
+                const {id, name} = tag;
+
+                return (
+                  <Box key={id} my={1}>
+                    <Tag key={id} color={color}>
+                      {name}
+                    </Tag>
+                  </Box>
+                );
+              })
+            ) : (
+              <Text type="secondary">None</Text>
+            )}
+          </Flex>
+        )}
+      </Box>
+      <Box mb={1}>
+        {state.editing ? (
+          <Button
+            size="small"
+            type="primary"
+            loading={state.updating}
+            onClick={handleUpdateTags}
+          >
+            Done
+          </Button>
+        ) : (
+          <Button
+            size="small"
+            loading={state.updating}
+            onClick={handleStartEditing}
+          >
+            {state.current && state.current.length ? 'Edit' : 'Add'}
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SidebarCustomerTags;

--- a/assets/src/components/conversations/SidebarCustomerTags.tsx
+++ b/assets/src/components/conversations/SidebarCustomerTags.tsx
@@ -25,13 +25,13 @@ const initial: State = {
 
 type Action = {
   type:
-    | 'loading:start'
-    | 'loading:stop'
-    | 'editing:start'
-    | 'updating:start'
-    | 'updating:done'
-    | 'tags:init'
-    | 'tags:update';
+    | 'loading/start'
+    | 'loading/stop'
+    | 'editing/start'
+    | 'updating/start'
+    | 'updating/done'
+    | 'tags/init'
+    | 'tags/update';
   payload?: any;
 };
 
@@ -39,24 +39,24 @@ const reducer = (state: State, action: Action) => {
   const {type, payload} = action;
 
   switch (type) {
-    case 'loading:start':
+    case 'loading/start':
       return {...state, loading: true};
-    case 'loading:stop':
+    case 'loading/stop':
       return {...state, loading: false};
-    case 'editing:start':
+    case 'editing/start':
       return {...state, editing: true};
-    case 'updating:start':
+    case 'updating/start':
       return {...state, updating: true};
-    case 'updating:done':
+    case 'updating/done':
       return {...state, updating: false, editing: false};
-    case 'tags:init':
+    case 'tags/init':
       return {
         ...state,
         current: payload.current,
         updated: payload.updated,
         options: payload.options,
       };
-    case 'tags:update':
+    case 'tags/update':
       return {...state, updated: payload};
     default:
       return state;
@@ -69,21 +69,21 @@ const SidebarCustomerTags = ({customerId}: {customerId: string}) => {
   const [state, dispatch] = React.useReducer(reducer, initial);
 
   React.useEffect(() => {
-    dispatch({type: 'loading:start'});
+    dispatch({type: 'loading/start'});
 
-    refreshLatestTags().then(() => dispatch({type: 'loading:stop'}));
+    refreshLatestTags().then(() => dispatch({type: 'loading/stop'}));
     // eslint-disable-next-line
   }, [customerId]);
 
   function handleStartEditing() {
-    dispatch({type: 'editing:start'});
+    dispatch({type: 'editing/start'});
   }
 
   async function refreshLatestTags() {
     return Promise.all([API.fetchCustomer(customerId), API.fetchAllTags()])
       .then(([customer, tags]) => {
         dispatch({
-          type: 'tags:init',
+          type: 'tags/init',
           payload: {
             current: customer.tags,
             updated: customer.tags.map((tag: any) => {
@@ -105,11 +105,11 @@ const SidebarCustomerTags = ({customerId}: {customerId: string}) => {
       return {...t, value, label: value};
     });
 
-    dispatch({type: 'tags:update', payload: updated});
+    dispatch({type: 'tags/update', payload: updated});
   }
 
   function handleUpdateTags() {
-    dispatch({type: 'updating:start'});
+    dispatch({type: 'updating/start'});
 
     const {current = [], updated = []} = state;
     const currentIds = current.map((t: any) => t.id);
@@ -148,7 +148,7 @@ const SidebarCustomerTags = ({customerId}: {customerId: string}) => {
         logger.error('Failed to update customer tags:', err);
       })
       .then(() => refreshLatestTags())
-      .then(() => dispatch({type: 'updating:done'}));
+      .then(() => dispatch({type: 'updating/done'}));
   }
 
   if (state.loading) {

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -171,7 +171,7 @@ defmodule ChatApi.SlackTest do
       primary_user = user_fixture(account)
 
       # Make sure that secondary_user is inserted later.
-      :timer.sleep(100)
+      :timer.sleep(500)
       secondary_user = user_fixture(account)
 
       users = [disabled_user, secondary_user, primary_user]


### PR DESCRIPTION
### Description

Users can now add "tags" to their customers in the sidebar. This will be used in the future for customer search and segmentation.

### Issue

https://github.com/papercups-io/papercups/issues/266

### Screenshots

Tags:
<img width="690" alt="Screen Shot 2020-10-08 at 5 43 57 PM" src="https://user-images.githubusercontent.com/5264279/95516983-25da4680-098e-11eb-93c5-d04d222aa5f0.png">

Edit mode:
<img width="688" alt="Screen Shot 2020-10-08 at 5 44 05 PM" src="https://user-images.githubusercontent.com/5264279/95516982-2541b000-098e-11eb-9005-33eabf0364da.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
