### PR TITLE
Don't mount volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,10 @@ version: "3.2"
 
 services:
   web:
-    image: papercups
+    image: papercups/papercups:latest
     ports:
       - "3000:3000"
       - "4000:4000"
-    volumes:
-      - type: bind
-        source: .
-        target: /usr/src/app
     command:
       - ./docker-entrypoint.sh
     depends_on:


### PR DESCRIPTION
### Description
Fix docker mounting issue and have it pull from latest. Previously it was mounting from our local code base then compiling it twice. This causes issues if you have a mismatch elixir type and causes build issues

### Issue

Fixes: https://github.com/papercups-io/papercups/issues/294