### PR TITLE
#281 - Add a count for customers created per day

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -70,6 +70,12 @@ defmodule ChatApi.Customers do
     |> Repo.insert()
   end
 
+  def create_test_customer(attrs \\ %{}) do
+    %Customer{}
+    |> Customer.test_changeset(attrs)
+    |> Repo.insert()
+  end
+
   @doc """
   Updates a customer.
 

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -102,4 +102,10 @@ defmodule ChatApi.Customers.Customer do
       :time_zone
     ])
   end
+
+  def test_changeset(message, attrs) do
+    message
+    |> cast(attrs, [:inserted_at])
+    |> changeset(attrs)
+  end
 end

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -103,8 +103,8 @@ defmodule ChatApi.Customers.Customer do
     ])
   end
 
-  def test_changeset(message, attrs) do
-    message
+  def test_changeset(customer, attrs) do
+    customer
     |> cast(attrs, [:inserted_at])
     |> changeset(attrs)
   end

--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -4,7 +4,7 @@ defmodule ChatApi.Reporting do
   """
 
   import Ecto.Query, warn: false
-  alias ChatApi.{Repo, Conversations.Conversation, Messages.Message, Users.User}
+  alias ChatApi.{Repo, Conversations.Conversation, Messages.Message, Users.User, Customers.Customer}
 
   def count_messages_by_date(account_id, filters \\ %{}) do
     Message
@@ -27,6 +27,17 @@ defmodule ChatApi.Reporting do
 
   def count_conversations_by_date(account_id, from_date, to_date),
     do: count_conversations_by_date(account_id, %{from_date: from_date, to_date: to_date})
+
+  def count_customers_by_date(account_id, filters \\ %{}) do
+    Customer
+    |> where(account_id: ^account_id)
+    |> where(^filter_where(filters))
+    |> count_grouped_by_date()
+    |> Repo.all()
+  end
+
+  def count_customers_by_date(account_id, from_date, to_date),
+    do: count_customers_by_date(account_id, %{from_date: from_date, to_date: to_date})
 
   def count_messages_per_user(account_id, filters \\ %{}) do
     Message

--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -4,7 +4,14 @@ defmodule ChatApi.Reporting do
   """
 
   import Ecto.Query, warn: false
-  alias ChatApi.{Repo, Conversations.Conversation, Messages.Message, Users.User, Customers.Customer}
+
+  alias ChatApi.{
+    Repo,
+    Conversations.Conversation,
+    Messages.Message,
+    Users.User,
+    Customers.Customer
+  }
 
   def count_messages_by_date(account_id, filters \\ %{}) do
     Message

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -381,4 +381,76 @@ defmodule ChatApi.ReportingTest do
              ] = Reporting.count_messages_by_weekday(account.id)
     end
   end
+
+  describe "count_customers_by_date/1" do
+    setup do
+      account = account_fixture()
+
+      {:ok, account: account}
+    end
+
+    test "it groups by date correctly", %{
+      account: account
+    } do
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-12 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-11 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-10 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-12 12:00:00]
+      })
+
+      assert [
+               %{date: ~D[2020-10-10], count: 1},
+               %{date: ~D[2020-10-11], count: 1},
+               %{date: ~D[2020-10-12], count: 2}
+             ] = Reporting.count_customers_by_date(account.id)
+    end
+  end
+
+  describe "count_customers_by_date/3" do
+    setup do
+      account = account_fixture()
+
+      {:ok, account: account}
+    end
+
+    test "Fetches customers between two dates", %{
+      account: account
+    } do
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-12 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-11 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-10 12:00:00]
+      })
+
+      customer_fixture(account, %{
+        inserted_at: ~N[2020-10-13 12:00:00]
+      })
+
+      assert [
+          %{date: ~D[2020-10-10], count: 1},
+          %{date: ~D[2020-10-11], count: 1},
+          %{date: ~D[2020-10-12], count: 1},
+        ] = Reporting.count_customers_by_date(
+          account.id,
+          ~N[2020-10-10 11:00:00],
+          ~N[2020-10-12 13:00:00]
+        )
+    end
+  end
 end

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -443,14 +443,15 @@ defmodule ChatApi.ReportingTest do
       })
 
       assert [
-          %{date: ~D[2020-10-10], count: 1},
-          %{date: ~D[2020-10-11], count: 1},
-          %{date: ~D[2020-10-12], count: 1},
-        ] = Reporting.count_customers_by_date(
-          account.id,
-          ~N[2020-10-10 11:00:00],
-          ~N[2020-10-12 13:00:00]
-        )
+               %{date: ~D[2020-10-10], count: 1},
+               %{date: ~D[2020-10-11], count: 1},
+               %{date: ~D[2020-10-12], count: 1}
+             ] =
+               Reporting.count_customers_by_date(
+                 account.id,
+                 ~N[2020-10-10 11:00:00],
+                 ~N[2020-10-12 13:00:00]
+               )
     end
   end
 end

--- a/test/support/test_fixture_helpers.ex
+++ b/test/support/test_fixture_helpers.ex
@@ -59,7 +59,7 @@ defmodule ChatApi.TestFixtureHelpers do
         account_id: account.id
       }
       |> Enum.into(attrs)
-      |> Customers.create_customer()
+      |> Customers.create_test_customer()
 
     customer |> Repo.preload([:tags])
   end


### PR DESCRIPTION

### Description
Adds methods in Reporting to get the number of customers created per day.

Also:
- Add a customer test_changeset. This allows us to modify the `inserted_at` column in tests.
- Add tests for count_customers_by_date methods. Separated from the other test blocks because
  we don't need to create a customer during the setup.

### Issue
https://github.com/papercups-io/papercups/issues/281

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
