### PR TITLE
Notify internal Slack of customer Oauth of Slack and Gmail - Issue #282

### DIFF
--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -113,7 +113,7 @@ defmodule ChatApiWeb.GmailController do
         ChatApi.Slack.log("#{email} successfully linked Gmail!")
       end)
     end
+
     conn
   end
-
 end

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -75,6 +75,7 @@ defmodule ChatApiWeb.GmailController do
       )
       |> case do
         {:ok, result} ->
+          notify_slack(conn)
           json(conn, %{ok: true, data: result})
 
         error ->
@@ -102,4 +103,17 @@ defmodule ChatApiWeb.GmailController do
 
     json(conn, %{data: %{url: url}})
   end
+
+  @spec notify_slack(Conn.t()) :: Conn.t()
+  defp notify_slack(conn) do
+    with %{email: email} <- conn.assigns.current_user do
+      # Putting in an async Task for now, since we don't care if this succeeds
+      # or fails (and we also don't want it to block anything)
+      Task.start(fn ->
+        ChatApi.Slack.log("#{email} successfully linked Gmail!")
+      end)
+    end
+    conn
+  end
+
 end

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -75,9 +75,9 @@ defmodule ChatApiWeb.GmailController do
       )
       |> case do
         {:ok, result} ->
-          notify_slack(conn)
-          json(conn, %{ok: true, data: result})
-
+          conn
+          |> notify_slack()
+          |> json(%{ok: true, data: result})
         error ->
           Logger.error("Error sending email via gmail: #{inspect(error)}")
 

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -162,7 +162,7 @@ defmodule ChatApiWeb.SlackController do
         ChatApi.Slack.log("#{email} successfully linked Slack!")
       end)
     end
+
     conn
   end
-
 end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -60,7 +60,7 @@ defmodule ChatApiWeb.SlackController do
         }
 
         SlackAuthorizations.create_or_update(account_id, params)
-
+        notify_slack(conn)
         json(conn, %{data: %{ok: true}})
       else
         _ ->
@@ -152,4 +152,17 @@ defmodule ChatApiWeb.SlackController do
       _ -> {:error, "Not found"}
     end
   end
+
+  @spec notify_slack(Conn.t()) :: Conn.t()
+  defp notify_slack(conn) do
+    with %{email: email} <- conn.assigns.current_user do
+      # Putting in an async Task for now, since we don't care if this succeeds
+      # or fails (and we also don't want it to block anything)
+      Task.start(fn ->
+        ChatApi.Slack.log("#{email} successfully linked Slack!")
+      end)
+    end
+    conn
+  end
+
 end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -60,8 +60,10 @@ defmodule ChatApiWeb.SlackController do
         }
 
         SlackAuthorizations.create_or_update(account_id, params)
-        notify_slack(conn)
-        json(conn, %{data: %{ok: true}})
+
+        conn
+        |> notify_slack()
+        |> json(%{data: %{ok: true}})
       else
         _ ->
           raise "Unrecognized OAuth response"


### PR DESCRIPTION
### Description

Notify's Papercups internal Slack if a customer performs an oauth flow on Slack and Gmail.

### Issue

_https://github.com/papercups-io/papercups/issues/282_

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
