### PR TITLE
add delete_all option to conversation association on slack_conversation_threads

### DIFF
--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -2,7 +2,16 @@ import React, {Fragment} from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import {colors, Button, Drawer, Select, Text, Title, Tooltip} from '../common';
+import {
+  colors,
+  Button,
+  Popconfirm,
+  Drawer,
+  Select,
+  Text,
+  Title,
+  Tooltip,
+} from '../common';
 import {
   CheckOutlined,
   StarOutlined,
@@ -12,6 +21,7 @@ import {
 } from '../icons';
 import {Customer, Conversation, User} from '../../types';
 import ConversationDetailsSidebar from './ConversationDetailsSidebar';
+import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -230,30 +240,24 @@ const ConversationHeader = ({
                   />
                 </Tooltip>
               </Box>
-              {/*
-
-              FIXME: there's an issue deleting conversations that have associated
-              Slack conversations:
-                ** (Ecto.ConstraintError) constraint error when attempting to delete struct:
-                * slack_conversation_threads_conversation_id_fkey (foreign_key_constraint)
-
-              Need to fix that before uncommenting this.
-
-              <Box mx={1}>
-                <Popconfirm
-                  title="Are you sure you want to delete this conversation?"
-                  okText="Yes"
-                  cancelText="No"
-                  placement="leftBottom"
-                  onConfirm={() => onDeleteConversation(conversationId)}
-                >
-                  <Tooltip title="Delete conversation" placement="bottomRight">
-                    <Button icon={<DeleteOutlined />} />
-                  </Tooltip>
-                </Popconfirm>
-              </Box>
-
-              */}
+              {
+                <Box mx={1}>
+                  <Popconfirm
+                    title="Are you sure you want to delete this conversation?"
+                    okText="Yes"
+                    cancelText="No"
+                    placement="leftBottom"
+                    onConfirm={() => onDeleteConversation(conversationId)}
+                  >
+                    <Tooltip
+                      title="Delete conversation"
+                      placement="bottomRight"
+                    >
+                      <Button icon={<DeleteOutlined />} />
+                    </Tooltip>
+                  </Popconfirm>
+                </Box>
+              }
             </Fragment>
           ) : (
             <Box mx={1}>

--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -240,24 +240,19 @@ const ConversationHeader = ({
                   />
                 </Tooltip>
               </Box>
-              {
-                <Box mx={1}>
-                  <Popconfirm
-                    title="Are you sure you want to delete this conversation?"
-                    okText="Yes"
-                    cancelText="No"
-                    placement="leftBottom"
-                    onConfirm={() => onDeleteConversation(conversationId)}
-                  >
-                    <Tooltip
-                      title="Delete conversation"
-                      placement="bottomRight"
-                    >
-                      <Button icon={<DeleteOutlined />} />
-                    </Tooltip>
-                  </Popconfirm>
-                </Box>
-              }
+              <Box mx={1}>
+                <Popconfirm
+                  title="Are you sure you want to delete this conversation?"
+                  okText="Yes"
+                  cancelText="No"
+                  placement="leftBottom"
+                  onConfirm={() => onDeleteConversation(conversationId)}
+                >
+                  <Tooltip title="Delete conversation" placement="bottomRight">
+                    <Button icon={<DeleteOutlined />} />
+                  </Tooltip>
+                </Popconfirm>
+              </Box>
             </Fragment>
           ) : (
             <Box mx={1}>

--- a/priv/repo/migrations/20201019091633_add_on_delete_to_conversation_constraint_on_slack_conversation_threads.exs
+++ b/priv/repo/migrations/20201019091633_add_on_delete_to_conversation_constraint_on_slack_conversation_threads.exs
@@ -2,15 +2,21 @@ defmodule ChatApi.Repo.Migrations.AddOnDeleteToConversationConstraintOnSlackConv
   use Ecto.Migration
 
   def up do
-    drop(constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey"))
+    drop(
+      constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey")
+    )
 
     alter table(:slack_conversation_threads) do
-      modify(:conversation_id, references(:conversations, type: :uuid, on_delete: :delete_all), null: false)
+      modify(:conversation_id, references(:conversations, type: :uuid, on_delete: :delete_all),
+        null: false
+      )
     end
   end
 
   def down do
-    drop(constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey"))
+    drop(
+      constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey")
+    )
 
     alter table(:slack_conversation_threads) do
       modify(:conversation_id, references(:conversations, type: :uuid), null: false)

--- a/priv/repo/migrations/20201019091633_add_on_delete_to_conversation_constraint_on_slack_conversation_threads.exs
+++ b/priv/repo/migrations/20201019091633_add_on_delete_to_conversation_constraint_on_slack_conversation_threads.exs
@@ -1,0 +1,19 @@
+defmodule ChatApi.Repo.Migrations.AddOnDeleteToConversationConstraintOnSlackConversationThreads do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey"))
+
+    alter table(:slack_conversation_threads) do
+      modify(:conversation_id, references(:conversations, type: :uuid, on_delete: :delete_all), null: false)
+    end
+  end
+
+  def down do
+    drop(constraint(:slack_conversation_threads, "slack_conversation_threads_conversation_id_fkey"))
+
+    alter table(:slack_conversation_threads) do
+      modify(:conversation_id, references(:conversations, type: :uuid), null: false)
+    end
+  end
+end

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -98,13 +98,20 @@ defmodule ChatApi.ConversationsTest do
         account_id: valid_create_attrs().account_id
       }
 
-      assert {:ok, %SlackConversationThread{}} =
+      assert {:ok, %SlackConversationThread{} = slack_conversation_thread} =
                SlackConversationThreads.create_slack_conversation_thread(
                  slack_conversation_thread_attrs
                )
 
       assert {:ok, %Conversation{}} = Conversations.delete_conversation(conversation)
-      assert_raise Ecto.NoResultsError, fn -> Conversations.get_conversation!(conversation.id) end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Conversations.get_conversation!(conversation.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SlackConversationThreads.get_slack_conversation_thread!(slack_conversation_thread.id)
+      end
     end
 
     test "change_conversation/1 returns a conversation changeset", %{conversation: conversation} do


### PR DESCRIPTION
### Description

- Create migration to add `on_delete: :delete_all` with `up` and `down` functions so rollbacks are possible
- Add test case
- Uncomment delete-conversation-button in `ConversationHeader.tsx`

### Issue

#330 

### Screenshots

![image](https://user-images.githubusercontent.com/19915462/96447710-a14fb980-1212-11eb-8e0f-cccc57186778.png)

![Screenshot_2020-10-19 Papercups(1)](https://user-images.githubusercontent.com/19915462/96445924-f7236200-1210-11eb-8906-097f375a838f.png)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
