### PR TITLE
Only display live sessions in the Sessions UI

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1,4 +1,5 @@
 import request from 'superagent';
+import qs from 'query-string';
 import {getAuthTokens} from './storage';
 import {Conversation, User} from './types';
 
@@ -745,13 +746,17 @@ export const removeCustomerTag = (
     .then((res) => res.body.data);
 };
 
-export const fetchBrowserSessions = async (token = getAccessToken()) => {
+export const fetchBrowserSessions = async (
+  sessionIds: Array<string> = [],
+  token = getAccessToken()
+) => {
   if (!token) {
     throw new Error('Invalid token!');
   }
 
   return request
     .get(`/api/browser_sessions`)
+    .query(qs.stringify({ids: sessionIds}, {arrayFormat: 'bracket'}))
     .set('Authorization', token)
     .then((res) => res.body.data);
 };

--- a/assets/src/components/sessions/SessionsOverview.tsx
+++ b/assets/src/components/sessions/SessionsOverview.tsx
@@ -1,53 +1,96 @@
 import React from 'react';
-import {Box, Flex} from 'theme-ui';
+import {Box} from 'theme-ui';
+import {Channel, Socket, Presence} from 'phoenix';
 import {Alert, Paragraph, Text, Title} from '../common';
 import * as API from '../../api';
+import {SOCKET_URL} from '../../socket';
 import {BrowserSession} from '../../types';
-import Spinner from '../Spinner';
 import SessionsTable from './SessionsTable';
 import logger from '../../logger';
 
 type Props = {};
 type State = {
   loading: boolean;
+  error: any;
   sessions: Array<BrowserSession>;
+  sessionIds: Array<string>;
 };
 
 class SessionsOverview extends React.Component<Props, State> {
+  socket: Socket | null = null;
+  channel: Channel | null = null;
+
   state: State = {
     loading: true,
+    error: null,
     sessions: [],
+    sessionIds: [],
   };
 
   async componentDidMount() {
     try {
-      const sessions = await API.fetchBrowserSessions();
+      const {id: accountId} = await API.fetchAccountInfo();
 
-      this.setState({sessions, loading: false});
+      this.connectToSocket(accountId);
     } catch (err) {
       logger.error('Error loading browser sessions!', err);
 
-      this.setState({loading: false});
+      this.setState({error: err, loading: false});
     }
   }
 
+  connectToSocket = async (accountId: string) => {
+    this.socket = new Socket(SOCKET_URL, {
+      params: {token: API.getAccessToken()},
+    });
+
+    this.socket.connect();
+    this.channel = this.socket.channel(`events:admin:${accountId}:all`, {});
+
+    this.channel
+      .join()
+      .receive('ok', (res: any) => {
+        logger.debug('Joined event channel successfully!', res);
+      })
+      .receive('error', (err: any) => {
+        logger.debug('Unable to join event channel!', err);
+      });
+
+    const presence = new Presence(this.channel);
+
+    presence.onSync(() => {
+      const sessionIds = presence
+        .list()
+        .map(({metas}) => {
+          const [info] = metas;
+
+          return info.session_id;
+        })
+        .filter((sessionId) => !!sessionId);
+
+      this.setState(
+        {
+          sessionIds: sessionIds,
+        },
+        () => this.refreshBrowserSessions(sessionIds)
+      );
+    });
+  };
+
+  refreshBrowserSessions = async (sessionIds: Array<string>) => {
+    this.setState({loading: true});
+
+    try {
+      const sessions = await API.fetchBrowserSessions(sessionIds);
+
+      this.setState({sessions, loading: false});
+    } catch (err) {
+      this.setState({error: err, loading: false});
+    }
+  };
+
   render() {
     const {loading, sessions = []} = this.state;
-
-    if (loading) {
-      return (
-        <Flex
-          sx={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Spinner size={40} />
-        </Flex>
-      );
-    }
 
     return (
       <Box p={4}>
@@ -71,7 +114,7 @@ class SessionsOverview extends React.Component<Props, State> {
             />
           </Box>
 
-          <SessionsTable sessions={sessions} />
+          <SessionsTable loading={loading} sessions={sessions} />
         </Box>
       </Box>
     );

--- a/lib/chat_api/browser_sessions.ex
+++ b/lib/chat_api/browser_sessions.ex
@@ -18,6 +18,17 @@ defmodule ChatApi.BrowserSessions do
     |> Repo.preload([:customer])
   end
 
+  @spec list_browser_sessions(binary(), list()) :: [BrowserSession.t()]
+  def list_browser_sessions(account_id, ids) do
+    # TODO: include customer and count of events
+    BrowserSession
+    |> where(account_id: ^account_id)
+    |> where([s], s.id in ^ids)
+    |> order_by(desc: :inserted_at)
+    |> Repo.all()
+    |> Repo.preload([:customer])
+  end
+
   @doc """
   Gets a single browser_session.
 

--- a/lib/chat_api_web/controllers/browser_session_controller.ex
+++ b/lib/chat_api_web/controllers/browser_session_controller.ex
@@ -7,9 +7,17 @@ defmodule ChatApiWeb.BrowserSessionController do
   action_fallback ChatApiWeb.FallbackController
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def index(conn, _params) do
+  def index(conn, params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
-      browser_sessions = BrowserSessions.list_browser_sessions(account_id)
+      browser_sessions =
+        case params do
+          %{"ids" => ids} when is_list(ids) ->
+            BrowserSessions.list_browser_sessions(account_id, ids)
+
+          _ ->
+            BrowserSessions.list_browser_sessions(account_id)
+        end
+
       render(conn, "index.json", browser_sessions: browser_sessions)
     end
   end

--- a/lib/chat_api_web/views/browser_session_view.ex
+++ b/lib/chat_api_web/views/browser_session_view.ex
@@ -3,7 +3,7 @@ defmodule ChatApiWeb.BrowserSessionView do
   alias ChatApiWeb.{BrowserSessionView, BrowserReplayEventView, CustomerView}
 
   def render("index.json", %{browser_sessions: browser_sessions}) do
-    %{data: render_many(browser_sessions, BrowserSessionView, "basic.json")}
+    %{data: render_many(browser_sessions, BrowserSessionView, "preview.json")}
   end
 
   def render("create.json", %{browser_session: browser_session}) do
@@ -22,6 +22,18 @@ defmodule ChatApiWeb.BrowserSessionView do
       metadata: browser_session.metadata,
       started_at: browser_session.started_at,
       finished_at: browser_session.finished_at
+    }
+  end
+
+  def render("preview.json", %{browser_session: browser_session}) do
+    %{
+      id: browser_session.id,
+      account_id: browser_session.account_id,
+      customer_id: browser_session.customer_id,
+      metadata: browser_session.metadata,
+      started_at: browser_session.started_at,
+      finished_at: browser_session.finished_at,
+      customer: render_one(browser_session.customer, CustomerView, "basic.json")
     }
   end
 

--- a/lib/workers/save_browser_replay_event.ex
+++ b/lib/workers/save_browser_replay_event.ex
@@ -5,8 +5,15 @@ defmodule ChatApi.Workers.SaveBrowserReplayEvent do
 
   require Logger
 
+  @admin_account_id System.get_env("REACT_APP_ADMIN_ACCOUNT_ID")
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: params}) do
-    ChatApi.BrowserReplayEvents.create_browser_replay_event(params)
+    # Only save for admin account ID for now
+    if params["account_id"] == @admin_account_id do
+      ChatApi.BrowserReplayEvents.create_browser_replay_event(params)
+    else
+      :ok
+    end
   end
 end


### PR DESCRIPTION
### Description

Showing all sessions is very expensive, so let's just display "live" sessions for now.

### Screenshots

<img width="1200" alt="Screen Shot 2020-10-19 at 4 51 22 PM" src="https://user-images.githubusercontent.com/5264279/96510332-5aba8900-122b-11eb-85b1-ad166a213b30.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
