### PR TITLE
fix: migrate customers table `current_url`/`pathname` fields from `string` to `text` types

### DIFF
--- a/priv/repo/migrations/20201019210311_change_current_url_and_pathname_fields_type_to_text.exs
+++ b/priv/repo/migrations/20201019210311_change_current_url_and_pathname_fields_type_to_text.exs
@@ -1,0 +1,10 @@
+defmodule ChatApi.Repo.Migrations.ChangeCurrentUrlAndPathnameFieldsTypeToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:customers) do
+      modify :current_url, :text
+      modify :pathname, :text
+    end
+  end
+end

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -16,7 +16,11 @@ defmodule ChatApi.CustomersTest do
       name: "Test User",
       email: "user@test.com",
       phone: "+16501235555",
-      time_zone: "America/New_York"
+      time_zone: "America/New_York",
+      current_url:
+        "http://test.com/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe",
+      pathname:
+        "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe"
     }
     @invalid_attrs %{
       first_seen: 3
@@ -60,6 +64,8 @@ defmodule ChatApi.CustomersTest do
       assert customer.name == @update_attrs.name
       assert customer.phone == @update_attrs.phone
       assert customer.time_zone == @update_attrs.time_zone
+      assert customer.current_url == @update_attrs.current_url
+      assert customer.pathname == @update_attrs.pathname
     end
 
     test "update_customer_metadata/2 only updates customizable fields", %{customer: customer} do


### PR DESCRIPTION
### Problem

The current_url and pathname fields on the Customers table are sometimes longer than the max character limit for DB fields of type "string".

### Solution

Migrate the following fields on the Customers table from type "string" to type "text".
Created a migration script and updated this fields at the database level

### Note

`:text` type can be used in migration, but not the schema. In the database `:string` type will be mapped to `text` column type.

### Issue

[#328 ](https://github.com/papercups-io/papercups/issues/328)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
