### PR TITLE
Add chat to live session viewer

### DIFF
--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -35,13 +35,7 @@ const DetailsSectionCard = ({children}: {children: any}) => {
   );
 };
 
-type Props = {
-  customer: Customer;
-  conversation: Conversation;
-};
-
-const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
-  const {id: conversationId, status} = conversation;
+const CustomerDetails = ({customer}: {customer: Customer}) => {
   const {
     email,
     name,
@@ -63,6 +57,168 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
     timezone && timezone.length ? timezone.split('_').join(' ') : null;
 
   return (
+    <Box px={2} py={3}>
+      <Box px={2} mb={3}>
+        <Text strong>Customer details</Text>
+      </Box>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>{name || 'Anonymous User'}</Text>
+        </Box>
+
+        <Flex mb={1} sx={{alignItems: 'center'}}>
+          <MailOutlined style={{color: colors.primary}} />
+          <Box ml={2}>{email || 'Unknown'}</Box>
+        </Flex>
+        <Flex mb={1} sx={{alignItems: 'center'}}>
+          <PhoneOutlined style={{color: colors.primary}} />
+          <Box ml={2}>{phone || 'Unknown'}</Box>
+        </Flex>
+        <Flex mb={1} sx={{alignItems: 'center'}}>
+          <UserOutlined style={{color: colors.primary}} />
+          <Box
+            ml={2}
+            sx={{
+              maxWidth: '100%',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            <Text type="secondary">ID:</Text>{' '}
+            <Tooltip title={externalId || customerId} placement="left">
+              {externalId || customerId}
+            </Tooltip>
+          </Box>
+        </Flex>
+      </DetailsSectionCard>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>Last seen</Text>
+        </Box>
+        <Box mb={1}>
+          <CalendarOutlined />{' '}
+          {lastUpdatedAt
+            ? dayjs.utc(lastUpdatedAt).format('MMMM DD, YYYY')
+            : 'N/A'}{' '}
+          <Text type="secondary">at</Text>
+        </Box>
+        <Box mb={1}>
+          {lastSeenUrl ? (
+            <Tooltip title={lastSeenUrl}>
+              <a href={lastSeenUrl} target="_blank" rel="noopener noreferrer">
+                {pathname && pathname.length > 1 ? pathname : lastSeenUrl}
+              </a>
+            </Tooltip>
+          ) : (
+            <Text>Unknown URL</Text>
+          )}
+        </Box>
+      </DetailsSectionCard>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>First seen</Text>
+        </Box>
+        <Box>
+          <CalendarOutlined />{' '}
+          {createdAt ? dayjs.utc(createdAt).format('MMMM DD, YYYY') : 'N/A'}
+        </Box>
+      </DetailsSectionCard>
+
+      {hasMetadata && (
+        <DetailsSectionCard>
+          <Box mb={2}>
+            <Text strong>Metadata</Text>
+          </Box>
+
+          {Object.entries(metadata).map(([key, value]) => {
+            return (
+              <Box key={key} mb={1}>
+                <Text type="secondary">{key}:</Text> {String(value)}
+              </Box>
+            );
+          })}
+        </DetailsSectionCard>
+      )}
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>Device</Text>
+        </Box>
+        {formattedTimezone && (
+          <Box mb={1}>
+            <GlobalOutlined /> {formattedTimezone}
+          </Box>
+        )}
+        <Box mb={1}>
+          {[os, browser].filter(Boolean).join(' · ') || 'Unknown'}
+        </Box>
+        <Box mb={1}>
+          <Text type="secondary">IP:</Text> {lastIpAddress || 'Unknown'}
+        </Box>
+      </DetailsSectionCard>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>Customer Tags</Text>
+        </Box>
+        <SidebarCustomerTags customerId={customerId} />
+      </DetailsSectionCard>
+    </Box>
+  );
+};
+
+const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
+  const {id: conversationId, status} = conversation;
+
+  return (
+    <Box px={2} py={3} sx={{borderTop: '1px solid rgba(0,0,0,.06)'}}>
+      <Box px={2} mb={3}>
+        <Text strong>Conversation details</Text>
+      </Box>
+
+      <Box
+        px={2}
+        mb={1}
+        sx={{
+          maxWidth: '100%',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        <Text type="secondary">ID:</Text>{' '}
+        <Tooltip title={conversationId.toLowerCase()} placement="left">
+          <Text>{conversationId.toLowerCase()}</Text>
+        </Tooltip>
+      </Box>
+      <Box px={2} mb={3}>
+        <Text type="secondary">Status:</Text>{' '}
+        <Tag color={status === 'open' ? colors.primary : colors.red}>
+          {status}
+        </Tag>
+      </Box>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>Conversation Tags</Text>
+        </Box>
+        <SidebarConversationTags conversationId={conversationId} />
+      </DetailsSectionCard>
+    </Box>
+  );
+};
+
+type Props = {
+  customer: Customer;
+  conversation?: Conversation;
+};
+
+const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
+  return (
     <Box
       sx={{
         width: '100%',
@@ -73,152 +229,8 @@ const ConversationDetailsSidebar = ({customer, conversation}: Props) => {
         flex: 1,
       }}
     >
-      <Box px={2} py={3}>
-        <Box px={2} mb={3}>
-          <Text strong>Customer details</Text>
-        </Box>
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>{name || 'Anonymous User'}</Text>
-          </Box>
-
-          <Flex mb={1} sx={{alignItems: 'center'}}>
-            <MailOutlined style={{color: colors.primary}} />
-            <Box ml={2}>{email || 'Unknown'}</Box>
-          </Flex>
-          <Flex mb={1} sx={{alignItems: 'center'}}>
-            <PhoneOutlined style={{color: colors.primary}} />
-            <Box ml={2}>{phone || 'Unknown'}</Box>
-          </Flex>
-          <Flex mb={1} sx={{alignItems: 'center'}}>
-            <UserOutlined style={{color: colors.primary}} />
-            <Box
-              ml={2}
-              sx={{
-                maxWidth: '100%',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              <Text type="secondary">ID:</Text>{' '}
-              <Tooltip title={externalId || customerId} placement="left">
-                {externalId || customerId}
-              </Tooltip>
-            </Box>
-          </Flex>
-        </DetailsSectionCard>
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>Last seen</Text>
-          </Box>
-          <Box mb={1}>
-            <CalendarOutlined />{' '}
-            {lastUpdatedAt
-              ? dayjs.utc(lastUpdatedAt).format('MMMM DD, YYYY')
-              : 'N/A'}{' '}
-            <Text type="secondary">at</Text>
-          </Box>
-          <Box mb={1}>
-            {lastSeenUrl ? (
-              <Tooltip title={lastSeenUrl}>
-                <a href={lastSeenUrl} target="_blank" rel="noopener noreferrer">
-                  {pathname && pathname.length > 1 ? pathname : lastSeenUrl}
-                </a>
-              </Tooltip>
-            ) : (
-              <Text>Unknown URL</Text>
-            )}
-          </Box>
-        </DetailsSectionCard>
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>First seen</Text>
-          </Box>
-          <Box>
-            <CalendarOutlined />{' '}
-            {createdAt ? dayjs.utc(createdAt).format('MMMM DD, YYYY') : 'N/A'}
-          </Box>
-        </DetailsSectionCard>
-
-        {hasMetadata && (
-          <DetailsSectionCard>
-            <Box mb={2}>
-              <Text strong>Metadata</Text>
-            </Box>
-
-            {Object.entries(metadata).map(([key, value]) => {
-              return (
-                <Box key={key} mb={1}>
-                  <Text type="secondary">{key}:</Text> {String(value)}
-                </Box>
-              );
-            })}
-          </DetailsSectionCard>
-        )}
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>Device</Text>
-          </Box>
-          {formattedTimezone && (
-            <Box mb={1}>
-              <GlobalOutlined /> {formattedTimezone}
-            </Box>
-          )}
-          <Box mb={1}>
-            {[os, browser].filter(Boolean).join(' · ') || 'Unknown'}
-          </Box>
-          <Box mb={1}>
-            <Text type="secondary">IP:</Text> {lastIpAddress || 'Unknown'}
-          </Box>
-        </DetailsSectionCard>
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>Customer Tags</Text>
-          </Box>
-          <SidebarCustomerTags customerId={customerId} />
-        </DetailsSectionCard>
-      </Box>
-
-      <Box px={2} py={3} sx={{borderTop: '1px solid rgba(0,0,0,.06)'}}>
-        <Box px={2} mb={3}>
-          <Text strong>Conversation details</Text>
-        </Box>
-
-        <Box
-          px={2}
-          mb={1}
-          sx={{
-            maxWidth: '100%',
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          <Text type="secondary">ID:</Text>{' '}
-          <Tooltip title={conversationId.toLowerCase()} placement="left">
-            <Text>{conversationId.toLowerCase()}</Text>
-          </Tooltip>
-        </Box>
-        <Box px={2} mb={3}>
-          <Text type="secondary">Status:</Text>{' '}
-          <Tag color={status === 'open' ? colors.primary : colors.red}>
-            {status}
-          </Tag>
-        </Box>
-
-        <DetailsSectionCard>
-          <Box mb={2}>
-            <Text strong>Conversation Tags</Text>
-          </Box>
-          <SidebarConversationTags conversationId={conversationId} />
-        </DetailsSectionCard>
-      </Box>
+      <CustomerDetails customer={customer} />
+      {conversation && <ConversationDetails conversation={conversation} />}
     </Box>
   );
 };

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -3,8 +3,10 @@ import {Box, Flex} from 'theme-ui';
 import {colors, Button, TextArea} from '../common';
 
 const ConversationFooter = ({
+  sx = {},
   onSendMessage,
 }: {
+  sx?: any;
   onSendMessage: (message: string) => void;
 }) => {
   const [message, setMessage] = React.useState('');
@@ -28,7 +30,7 @@ const ConversationFooter = ({
 
   return (
     <Box style={{flex: '0 0 auto'}}>
-      <Box px={4} pt={0} pb={4} backgroundColor={colors.white}>
+      <Box sx={{bg: colors.white, px: 4, pt: 0, pb: 4, ...sx}}>
         <Box
           p={2}
           sx={{

--- a/assets/src/components/conversations/ConversationMessages.tsx
+++ b/assets/src/components/conversations/ConversationMessages.tsx
@@ -44,14 +44,16 @@ const ConversationMessages = ({
   loading,
   isClosing,
   showGetStarted,
+  sx = {},
   setScrollRef,
 }: {
   messages: Array<Message>;
   currentUser: User;
   customer: Customer | null;
-  loading: boolean;
-  isClosing: boolean;
-  showGetStarted: boolean;
+  loading?: boolean;
+  isClosing?: boolean;
+  showGetStarted?: boolean;
+  sx?: any;
   setScrollRef: (el: any) => void;
 }) => {
   return (
@@ -74,7 +76,10 @@ const ConversationMessages = ({
           <Spinner size={40} />
         </Flex>
       ) : (
-        <Box p={4} backgroundColor={colors.white} sx={{minHeight: '100%'}}>
+        <Box
+          backgroundColor={colors.white}
+          sx={{minHeight: '100%', p: 4, ...sx}}
+        >
           {messages.length ? (
             messages.map((msg: Message, key: number) => {
               // Slight hack

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -50,7 +50,7 @@ class ConversationsContainer extends React.Component<Props, State> {
         this.handleSelectConversation(first);
         this.setupKeyboardShortcuts();
       })
-      .then(() => this.scrollToEl.scrollIntoView());
+      .then(() => this.scrollIntoView());
   }
 
   componentWillUnmount() {
@@ -71,7 +71,7 @@ class ConversationsContainer extends React.Component<Props, State> {
     const messages = messagesByConversation[selected] || [];
 
     if (messages.length > prevMessages.length) {
-      this.scrollToEl.scrollIntoView();
+      this.scrollIntoView();
     }
   }
 
@@ -81,6 +81,10 @@ class ConversationsContainer extends React.Component<Props, State> {
 
   removeKeyboardShortcuts = () => {
     window.removeEventListener('keydown', this.handleKeyboardShortcut);
+  };
+
+  scrollIntoView = () => {
+    this.scrollToEl && this.scrollToEl.scrollIntoView();
   };
 
   handleKeyboardShortcut = (e: any) => {
@@ -194,7 +198,7 @@ class ConversationsContainer extends React.Component<Props, State> {
 
   handleSelectConversation = (id: string | null) => {
     this.setState({selected: id}, () => {
-      this.scrollToEl.scrollIntoView();
+      this.scrollIntoView();
     });
 
     this.props.onSelectConversation(id);
@@ -276,7 +280,7 @@ class ConversationsContainer extends React.Component<Props, State> {
     }
 
     this.props.onSendMessage(message, conversationId, () => {
-      this.scrollToEl.scrollIntoView();
+      this.scrollIntoView();
     });
   };
 

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -36,6 +36,8 @@ export const ConversationsContext = React.createContext<{
   fetchMyConversations: () => Promise<Array<string>>;
   fetchPriorityConversations: () => Promise<Array<string>>;
   fetchClosedConversations: () => Promise<Array<string>>;
+  // TODO: should this be different?
+  fetchConversationById: (conversationId: string) => Promise<Array<string>>;
 }>({
   loading: true,
   account: null,
@@ -59,6 +61,7 @@ export const ConversationsContext = React.createContext<{
   fetchMyConversations: () => Promise.resolve([]),
   fetchPriorityConversations: () => Promise.resolve([]),
   fetchClosedConversations: () => Promise.resolve([]),
+  fetchConversationById: () => Promise.resolve([]),
 });
 
 export const useConversations = () => useContext(ConversationsContext);
@@ -584,6 +587,18 @@ export class ConversationsProvider extends React.Component<Props, State> {
     return conversationIds;
   };
 
+  fetchConversationById = async (
+    conversationId: string
+  ): Promise<Array<string>> => {
+    const conversation = await API.fetchConversation(conversationId);
+    const conversations = [conversation];
+    const {conversationIds} = this.formatConversationState(conversations);
+
+    this.updateConversationState(conversations, 'all');
+
+    return conversationIds;
+  };
+
   fetchMyConversations = async (): Promise<Array<string>> => {
     const {currentUser} = this.state;
 
@@ -673,6 +688,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
           onSendMessage: this.handleSendMessage,
 
           fetchAllConversations: this.fetchAllConversations,
+          fetchConversationById: this.fetchConversationById,
           fetchMyConversations: this.fetchMyConversations,
           fetchPriorityConversations: this.fetchPriorityConversations,
           fetchClosedConversations: this.fetchClosedConversations,

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {Flex} from 'theme-ui';
+import {colors} from '../common';
+import {useConversations} from '../conversations/ConversationsProvider';
+import ConversationMessages from '../conversations/ConversationMessages';
+import ConversationFooter from '../conversations/ConversationFooter';
+import {Conversation, Message, User} from '../../types';
+import 'rrweb/dist/replay/rrweb-replay.min.css';
+
+type Props = {
+  conversation: Conversation;
+  currentUser: User;
+  messages: Array<Message>;
+  onSendMessage: (
+    message: string,
+    conversationId: string,
+    cb: () => void
+  ) => void;
+};
+
+class ConversationSidebar extends React.Component<Props, any> {
+  scrollToEl: any;
+
+  componentDidMount() {
+    this.scrollToEl.scrollIntoView();
+  }
+
+  handleSendMessage = (message: string) => {
+    const {id: conversationId} = this.props.conversation;
+
+    if (!conversationId) {
+      return null;
+    }
+
+    this.props.onSendMessage(message, conversationId, () => {
+      this.scrollToEl.scrollIntoView();
+    });
+  };
+
+  render() {
+    const {conversation, currentUser, messages = []} = this.props;
+    const {customer} = conversation;
+
+    return (
+      <Flex
+        className="rr-block"
+        sx={{
+          width: '100%',
+          height: '100%',
+          flexDirection: 'column',
+          bg: colors.white,
+          border: `1px solid rgba(0,0,0,.06)`,
+          boxShadow: 'rgba(0, 0, 0, 0.1) 0px 0px 4px',
+          flex: 1,
+        }}
+      >
+        <ConversationMessages
+          sx={{p: 3}}
+          messages={messages}
+          currentUser={currentUser}
+          customer={customer}
+          setScrollRef={(el) => (this.scrollToEl = el)}
+        />
+
+        <ConversationFooter
+          sx={{px: 3, pb: 3}}
+          onSendMessage={this.handleSendMessage}
+        />
+      </Flex>
+    );
+  }
+}
+
+const ConversationsSidebarWrapper = ({
+  conversationId,
+}: {
+  conversationId: string;
+}) => {
+  const {
+    loading,
+    currentUser,
+    conversationsById = {},
+    messagesByConversation = {},
+    fetchConversationById,
+    onSendMessage,
+    onSelectConversation,
+  } = useConversations();
+
+  React.useEffect(() => {
+    fetchConversationById(conversationId).then(() =>
+      onSelectConversation(conversationId)
+    );
+  }, [conversationId]);
+
+  if (loading) {
+    return null;
+  }
+
+  const conversation = conversationsById[conversationId];
+  const messages = messagesByConversation[conversationId];
+
+  return (
+    <ConversationSidebar
+      conversation={conversation}
+      messages={messages}
+      currentUser={currentUser}
+      onSendMessage={onSendMessage}
+    />
+  );
+};
+
+export default ConversationsSidebarWrapper;

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -103,6 +103,7 @@ const ConversationsSidebarWrapper = ({
     fetchConversationById(conversationId).then(() =>
       onSelectConversation(conversationId)
     );
+    // eslint-disable-next-line
   }, [conversationId]);
 
   if (loading) {

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -5,7 +5,6 @@ import {useConversations} from '../conversations/ConversationsProvider';
 import ConversationMessages from '../conversations/ConversationMessages';
 import ConversationFooter from '../conversations/ConversationFooter';
 import {Conversation, Message, User} from '../../types';
-import 'rrweb/dist/replay/rrweb-replay.min.css';
 
 type Props = {
   conversation: Conversation;

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -22,8 +22,21 @@ class ConversationSidebar extends React.Component<Props, any> {
   scrollToEl: any;
 
   componentDidMount() {
-    this.scrollToEl.scrollIntoView();
+    this.scrollIntoView();
   }
+
+  componentDidUpdate(prev: Props) {
+    const {messages: previousMessages} = prev;
+    const {messages} = this.props;
+
+    if (messages.length > previousMessages.length) {
+      this.scrollIntoView();
+    }
+  }
+
+  scrollIntoView = () => {
+    this.scrollToEl && this.scrollToEl.scrollIntoView();
+  };
 
   handleSendMessage = (message: string) => {
     const {id: conversationId} = this.props.conversation;
@@ -33,7 +46,7 @@ class ConversationSidebar extends React.Component<Props, any> {
     }
 
     this.props.onSendMessage(message, conversationId, () => {
-      this.scrollToEl.scrollIntoView();
+      this.scrollIntoView();
     });
   };
 

--- a/assets/src/logger.tsx
+++ b/assets/src/logger.tsx
@@ -71,13 +71,13 @@ export class Logger {
   listen() {
     window.onerror = (msg, url, lineNo, columnNo, error) => {
       const stack = error?.stack || '';
-      const line = stack.split('\n')[1].trim();
+      const line = stack.split('\n')[1]?.trim();
       this.error(msg, line);
     };
 
     window.addEventListener('unhandledrejection', (event) => {
       const {message, stack} = event.reason;
-      const line = stack.split('\n')[1].trim();
+      const line = stack.split('\n')[1]?.trim();
       this.error(message, line);
     });
   }


### PR DESCRIPTION
### Description

Users should be able to chat with their customers while viewing their screen.

(This PR just handles the happy path, but there are edge cases that need to be handled in future PRs)

### Screenshots
<img width="1335" alt="Screen Shot 2020-10-20 at 4 54 07 PM" src="https://user-images.githubusercontent.com/5264279/96642973-e5b38600-12f4-11eb-9cf7-0573de0caab0.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
