### PR TITLE
Migrate widget_settings table `pathname` fields from `string` to `text` type

### DIFF
--- a/priv/repo/migrations/20201022165122_change_pathname_field_type_to_text.exs
+++ b/priv/repo/migrations/20201022165122_change_pathname_field_type_to_text.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.ChangePathnameFieldTypeToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:widget_settings) do
+      modify :pathname, :text
+    end
+  end
+end

--- a/test/chat_api/widget_settings_test.exs
+++ b/test/chat_api/widget_settings_test.exs
@@ -17,7 +17,7 @@ defmodule ChatApi.WidgetSettingsTest do
       subtitle: "some updated subtitle",
       title: "some updated title",
       pathname:
-      "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe"
+        "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe"
     }
 
     @valid_metadata %{"host" => "app.papercups.io", "pathname" => "/"}

--- a/test/chat_api/widget_settings_test.exs
+++ b/test/chat_api/widget_settings_test.exs
@@ -6,21 +6,19 @@ defmodule ChatApi.WidgetSettingsTest do
   describe "widget_settings" do
     alias ChatApi.WidgetSettings.WidgetSetting
 
-    def valid_attrs() do
-      %{
-        color: "some color",
-        subtitle: "some subtitle",
-        title: "some title"
-      }
-    end
+    @valid_attrs %{
+      color: "some color",
+      subtitle: "some subtitle",
+      title: "some title"
+    }
 
-    def update_attrs() do
-      %{
-        color: "some updated color",
-        subtitle: "some updated subtitle",
-        title: "some updated title"
-      }
-    end
+    @update_attrs %{
+      color: "some updated color",
+      subtitle: "some updated subtitle",
+      title: "some updated title",
+      pathname:
+      "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe"
+    }
 
     @valid_metadata %{"host" => "app.papercups.io", "pathname" => "/"}
 
@@ -49,11 +47,12 @@ defmodule ChatApi.WidgetSettingsTest do
       setting: widget_setting
     } do
       assert {:ok, %WidgetSetting{} = widget_setting} =
-               WidgetSettings.update_widget_setting(widget_setting, update_attrs())
+               WidgetSettings.update_widget_setting(widget_setting, @update_attrs)
 
-      assert widget_setting.color == "some updated color"
-      assert widget_setting.subtitle == "some updated subtitle"
-      assert widget_setting.title == "some updated title"
+      assert widget_setting.color == @update_attrs.color
+      assert widget_setting.subtitle == @update_attrs.subtitle
+      assert widget_setting.title == @update_attrs.title
+      assert widget_setting.pathname == @update_attrs.pathname
     end
 
     test "update_widget_metadata/2 with valid data updates the metadata if no settings exist yet",


### PR DESCRIPTION
### Problem

The pathname field on the widget_settings table is sometimes longer than the max character limit for DB fields of type "string".

### Solution

Migrate the `pathname` fields on the `widget_settings` table from type "string" to type "text.
Created a migration script and updated this fields at the database level.

### Issue

[#329 ](https://github.com/papercups-io/papercups/issues/329)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
