### PR TITLE
Add tests for CSVHelpers module and refine docs

### DIFF
--- a/lib/chat_api_web/views/csv_helpers.ex
+++ b/lib/chat_api_web/views/csv_helpers.ex
@@ -8,8 +8,13 @@ defmodule ChatApiWeb.CSVHelpers do
   @doc """
   Dumps an enumerable of maps or structs into a csv string
   using the given fields with respective order.
+
+  ## Examples
+      
+      iex> CSVHelpers.dump_csv_rfc4180([%{name: "Papercups", awesome: true}], [:name, :awesome])
+      "name,awesome\\r\\n\\"Papercups\\",\\"true\\""
   """
-  @spec dump_csv_rfc4180(map() | struct(), list()) :: String.t()
+  @spec dump_csv_rfc4180([map() | struct()], list()) :: String.t()
   def dump_csv_rfc4180(rows, fields) when is_list(rows) and is_list(fields) do
     rows
     |> Enum.map(fn row ->

--- a/test/chat_api_web/views/csv_helpers_test.exs
+++ b/test/chat_api_web/views/csv_helpers_test.exs
@@ -1,0 +1,56 @@
+defmodule ChatApiWeb.CSVHelpersTest do
+  use ExUnit.Case
+  alias ChatApiWeb.CSVHelpers
+  doctest CSVHelpers
+
+  test "Column with newline encodes correctly" do
+    data =
+      CSVHelpers.dump_csv_rfc4180(
+        [
+          %{column1: "This is \n an \r\nanomoly", column2: "This is not!"},
+          %{column1: "This is normal", column2: "Also this"}
+        ],
+        [:column1, :column2]
+      )
+
+    assert data ==
+             "column1,column2\r\n" <>
+               "\"This is \n" <>
+               " an \r\n" <>
+               "anomoly\",\"This is not!\"\r\n" <>
+               "\"This is normal\",\"Also this\""
+  end
+
+  test "Columns with double-quotes encode correctly" do
+    data =
+      CSVHelpers.dump_csv_rfc4180(
+        [
+          %{column1: "This is \" an \"anomoly", column2: "This is not!"},
+          %{column1: "This is normal", column2: "Also this"}
+        ],
+        [:column1, :column2]
+      )
+
+    assert data ==
+             "column1,column2\r\n" <>
+               "\"This is \"\" an \"\"anomoly\",\"This is not!\"\r\n" <>
+               "\"This is normal\",\"Also this\""
+  end
+
+  test "nil columns should encode as empty string" do
+    data = CSVHelpers.dump_csv_rfc4180([%{data: nil, name: "papercups"}], [:name, :data])
+
+    assert data ==
+             "name,data\r\n" <>
+               "\"papercups\",\"\""
+  end
+
+  test "unreferenced columns should not get encoded" do
+    data =
+      CSVHelpers.dump_csv_rfc4180([%{public: "This is public", private: "This is PRIVATE"}], [
+        :public
+      ])
+
+    assert data == "public\r\n\"This is public\""
+  end
+end


### PR DESCRIPTION
### Description

 - Added tests for CSVHelpers with anomolies.
 - Fix typespec of the `dump_csv_rfc4180` function.
 - Add Example in `dump_csv_rfc4180` documentation.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
