### PR TITLE
Add page for getting started with Storytime plugin

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -27,7 +27,7 @@ import {BASE_URL, isDev} from '../config';
 import {useAuth} from './auth/AuthProvider';
 import AccountOverview from './account/AccountOverview';
 import UserProfile from './account/UserProfile';
-import GettingStartedWithChat from './account/GettingStartedOverview';
+import GettingStartedOverview from './account/GettingStartedOverview';
 import {
   ConversationsProvider,
   useConversations,
@@ -40,7 +40,7 @@ import IntegrationsOverview from './integrations/IntegrationsOverview';
 import BillingOverview from './billing/BillingOverview';
 import CustomersPage from './customers/CustomersPage';
 import SessionsOverview from './sessions/SessionsOverview';
-import GettingStartedWithStorytime from './sessions/GettingStartedOverview';
+import InstallingStorytime from './sessions/InstallingStorytime';
 import LiveSessionViewer from './sessions/LiveSessionViewer';
 import ReportingDashboard from './reporting/ReportingDashboard';
 
@@ -282,7 +282,7 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/account/profile" component={UserProfile} />
           <Route
             path="/account/getting-started"
-            component={GettingStartedWithChat}
+            component={GettingStartedOverview}
           />
           <Route path="/account*" component={AccountOverview} />
           <Route path="/customers" component={CustomersPage} />
@@ -304,7 +304,7 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/sessions/list" component={SessionsOverview} />
           <Route
             path="/sessions/getting-started"
-            component={GettingStartedWithStorytime}
+            component={InstallingStorytime}
           />
           <Route path="/sessions*" component={SessionsOverview} />
           <Route path="*" render={() => <Redirect to="/conversations/all" />} />

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -27,7 +27,7 @@ import {BASE_URL, isDev} from '../config';
 import {useAuth} from './auth/AuthProvider';
 import AccountOverview from './account/AccountOverview';
 import UserProfile from './account/UserProfile';
-import GettingStartedOverview from './account/GettingStartedOverview';
+import GettingStartedWithChat from './account/GettingStartedOverview';
 import {
   ConversationsProvider,
   useConversations,
@@ -40,7 +40,7 @@ import IntegrationsOverview from './integrations/IntegrationsOverview';
 import BillingOverview from './billing/BillingOverview';
 import CustomersPage from './customers/CustomersPage';
 import SessionsOverview from './sessions/SessionsOverview';
-import SessionReplay from './sessions/SessionReplay';
+import GettingStartedWithStorytime from './sessions/GettingStartedOverview';
 import LiveSessionViewer from './sessions/LiveSessionViewer';
 import ReportingDashboard from './reporting/ReportingDashboard';
 
@@ -213,19 +213,24 @@ const Dashboard = (props: RouteComponentProps) => {
                   <Link to="/conversations/closed">Closed</Link>
                 </Menu.Item>
               </Menu.SubMenu>
+              <Menu.SubMenu
+                key="sessions"
+                icon={<VideoCameraOutlined />}
+                title="Sessions"
+              >
+                <Menu.Item key="list">
+                  <Link to="/sessions/list">Live sessions</Link>
+                </Menu.Item>
+                <Menu.Item key="getting-started">
+                  <Link to="/sessions/getting-started">Getting started</Link>
+                </Menu.Item>
+              </Menu.SubMenu>
               <Menu.Item
                 title="Customers"
                 icon={<TeamOutlined />}
                 key="customers"
               >
                 <Link to="/customers">Customers</Link>
-              </Menu.Item>
-              <Menu.Item
-                title="Sessions"
-                icon={<VideoCameraOutlined />}
-                key="sessions"
-              >
-                <Link to="/sessions">Sessions</Link>
               </Menu.Item>
               <Menu.Item
                 title="Integrations"
@@ -277,7 +282,7 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/account/profile" component={UserProfile} />
           <Route
             path="/account/getting-started"
-            component={GettingStartedOverview}
+            component={GettingStartedWithChat}
           />
           <Route path="/account*" component={AccountOverview} />
           <Route path="/customers" component={CustomersPage} />
@@ -296,8 +301,12 @@ const Dashboard = (props: RouteComponentProps) => {
           )}
           <Route path="/reporting" component={ReportingDashboard} />
           <Route path="/sessions/live/:session" component={LiveSessionViewer} />
-          <Route path="/sessions/:session" component={SessionReplay} />
-          <Route path="/sessions" component={SessionsOverview} />
+          <Route path="/sessions/list" component={SessionsOverview} />
+          <Route
+            path="/sessions/getting-started"
+            component={GettingStartedWithStorytime}
+          />
+          <Route path="/sessions*" component={SessionsOverview} />
           <Route path="*" render={() => <Redirect to="/conversations/all" />} />
         </Switch>
       </Layout>

--- a/assets/src/components/sessions/GettingStartedOverview.tsx
+++ b/assets/src/components/sessions/GettingStartedOverview.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import {atomOneLight} from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import * as API from '../../api';
+import {User} from '../../types';
+import {Paragraph, Input, colors, Text, Title} from '../common';
+import {BASE_URL} from '../../config';
+import logger from '../../logger';
+
+type Props = {};
+type State = {
+  accountId: string | null;
+  currentUser: User | null;
+};
+
+class GettingStartedOverview extends React.Component<Props, State> {
+  state: State = {
+    accountId: null,
+    currentUser: null,
+  };
+
+  async componentDidMount() {
+    const currentUser = await API.me();
+    const account = await API.fetchAccountInfo();
+    const {id: accountId} = account;
+
+    this.setState({
+      accountId,
+      currentUser,
+    });
+  }
+
+  generateHtmlCode = () => {
+    const {accountId} = this.state;
+
+    return `
+<script>
+  // NOTE: DO NOT copy the window.Papercups.config again if you
+  // have already installed the chat widget — otherwise it will
+  // override your chat widget settings and cause problems!
+  window.Papercups = {
+    config: {
+      accountId: "${accountId}",
+
+      // Optionally pass in metadata to identify the customer
+      // customer: {
+      //  name: "Test User",
+      //  email: "test@test.com",
+      //  external_id: "123",
+      // },
+
+      // Optionally specify the base URL
+      baseUrl: "${BASE_URL}"
+    },
+  };
+</script>
+<script
+  type="text/javascript"
+  async
+  defer
+  src="${BASE_URL}/storytime.js"
+></script>
+  `.trim();
+  };
+
+  generateSimpleHtmlCode = () => {
+    return `
+<script
+  type="text/javascript"
+  async
+  defer
+  src="${BASE_URL}/storytime.js"
+></script>
+  `.trim();
+  };
+
+  generateModuleCode = () => {
+    const {accountId} = this.state;
+
+    return `
+import {Storytime} from '@papercups-io/storytime';
+
+const st = Storytime.init({
+  accountId: '${accountId}',
+  // Optionally specify the base URL
+  baseUrl: '${BASE_URL}',
+});
+
+// If you want to stop the session recording manually, you can call:
+// st.finish();
+
+// Otherwise, the recording will stop as soon as the user exits your website.
+  `.trim();
+  };
+
+  render() {
+    const {accountId} = this.state;
+
+    if (!accountId) {
+      return null; // TODO: better loading state
+    }
+
+    return (
+      <Box
+        p={4}
+        sx={{
+          maxWidth: 720,
+        }}
+      >
+        <Box mb={4}>
+          <Title>Getting Started</Title>
+          <Paragraph>
+            <Text>
+              Before you can start viewing your customers' sessions, you'll need
+              to install our plugin on your website.
+            </Text>
+          </Paragraph>
+        </Box>
+
+        <Box mb={4}>
+          <Title level={3}>Installing the plugin</Title>
+          <Paragraph>
+            <Text>
+              There are two ways you can install the plugin: in HTML, or via
+              importing as a module.
+            </Text>
+          </Paragraph>
+        </Box>
+
+        <Box mb={4}>
+          <Title level={3}>Usage in HTML</Title>
+          <Paragraph>
+            <Text>
+              Paste the code below between your <Text code>{'<head>'}</Text> and{' '}
+              <Text code>{'</head>'}</Text> tags:
+            </Text>
+          </Paragraph>
+
+          <SyntaxHighlighter language="html" style={atomOneLight}>
+            {this.generateHtmlCode()}
+          </SyntaxHighlighter>
+
+          <Paragraph>
+            <Text strong mark>
+              Note that if you've already installed the chat widget, you will
+              only need to add this script below it:
+            </Text>
+          </Paragraph>
+
+          <SyntaxHighlighter language="html" style={atomOneLight}>
+            {this.generateSimpleHtmlCode()}
+          </SyntaxHighlighter>
+        </Box>
+
+        <Box mb={4}>
+          <Title level={3}>Usage with NPM module</Title>
+          <Paragraph>
+            <Text>
+              First, install the <Text code>@papercups-io/storytime</Text>{' '}
+              package:
+            </Text>
+          </Paragraph>
+
+          <Paragraph>
+            <pre
+              style={{
+                backgroundColor: '#f6f8fa',
+                color: colors.black,
+                fontSize: 12,
+              }}
+            >
+              <Box p={3}>npm install --save @papercups-io/storytime</Box>
+            </pre>
+          </Paragraph>
+
+          <Paragraph>
+            <Text>
+              Your account token has been prefilled in the code below. Simply
+              copy and paste the code into the root of your app, or into
+              whichever components you would like to track!
+            </Text>
+          </Paragraph>
+
+          <SyntaxHighlighter language="typescript" style={atomOneLight}>
+            {this.generateModuleCode()}
+          </SyntaxHighlighter>
+        </Box>
+
+        <Title level={3}>Learn more</Title>
+        <Paragraph>
+          <Text>
+            See the code and star our{' '}
+            <a
+              href="https://github.com/papercups-io/storytime"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Github repo
+            </a>
+            .
+          </Text>
+        </Paragraph>
+      </Box>
+    );
+  }
+}
+
+export default GettingStartedOverview;

--- a/assets/src/components/sessions/InstallingStorytime.tsx
+++ b/assets/src/components/sessions/InstallingStorytime.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import {Box} from 'theme-ui';
+import {Box, Image} from 'theme-ui';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import {atomOneLight} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import * as API from '../../api';
 import {User} from '../../types';
-import {Paragraph, Input, colors, Text, Title} from '../common';
+import {Paragraph, colors, Text, Title} from '../common';
 import {BASE_URL} from '../../config';
-import logger from '../../logger';
 
 type Props = {};
 type State = {
@@ -14,7 +13,7 @@ type State = {
   currentUser: User | null;
 };
 
-class GettingStartedOverview extends React.Component<Props, State> {
+class InstallingStorytime extends React.Component<Props, State> {
   state: State = {
     accountId: null,
     currentUser: null,
@@ -116,6 +115,10 @@ const st = Storytime.init({
               to install our plugin on your website.
             </Text>
           </Paragraph>
+
+          <Box>
+            <Image src="https://user-images.githubusercontent.com/5264279/96898977-56c27d00-145e-11eb-907b-ca8db13a0fa0.gif" />
+          </Box>
         </Box>
 
         <Box mb={4}>
@@ -206,4 +209,4 @@ const st = Storytime.init({
   }
 }
 
-export default GettingStartedOverview;
+export default InstallingStorytime;

--- a/assets/src/components/sessions/LiveSessionViewer.tsx
+++ b/assets/src/components/sessions/LiveSessionViewer.tsx
@@ -190,7 +190,7 @@ class LiveSessionViewer extends React.Component<Props, State> {
           <Box mb={4}>
             <Box mb={3}>
               <Paragraph>
-                <Link to="/sessions">
+                <Link to="/sessions/list">
                   <Button icon={<ArrowLeftOutlined />}>
                     Back to all sessions
                   </Button>

--- a/assets/src/components/sessions/SessionsOverview.tsx
+++ b/assets/src/components/sessions/SessionsOverview.tsx
@@ -95,11 +95,11 @@ class SessionsOverview extends React.Component<Props, State> {
     return (
       <Box p={4}>
         <Box mb={5}>
-          <Title level={3}>Browser Sessions (beta)</Title>
+          <Title level={3}>Live Sessions (beta)</Title>
 
           <Box mb={4}>
             <Paragraph>
-              View how recent vistors have interacted with your website.
+              View how vistors are interacting with your website.
             </Paragraph>
 
             <Alert


### PR DESCRIPTION
### Description

Add docs to dashboard so users know how to get started with Storytime plugin.

### Screenshots
<img width="978" alt="Screen Shot 2020-10-27 at 9 17 43 AM" src="https://user-images.githubusercontent.com/5264279/97306773-4f6fea80-1835-11eb-9d80-2cbcfc8881a5.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
