### PR TITLE
Fix `SetMessagesSeenAt` migration

### DIFF
--- a/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
+++ b/priv/repo/migrations/20200831011352_set_messages_seen_at.exs
@@ -9,6 +9,7 @@ defmodule ChatApi.Repo.Migrations.SetMessagesSeenAt do
 
   def up do
     Conversation
+    |> select([:id])
     |> preload(:messages)
     |> Repo.all()
     |> Enum.map(fn conv -> mark_messages_seen(conv) end)

--- a/priv/repo/migrations/20201026201955_add_archived_at_field_to_conversations.exs
+++ b/priv/repo/migrations/20201026201955_add_archived_at_field_to_conversations.exs
@@ -3,7 +3,7 @@ defmodule ChatApi.Repo.Migrations.AddArchivedAtFieldToConversations do
 
   def change do
     alter table(:conversations) do
-      add :archived_at, :utc_datetime
+      add(:archived_at, :utc_datetime)
     end
   end
 end


### PR DESCRIPTION
### Description

Fixes the `SetMessagesSeenAt` migration

### Issue

Fixes https://github.com/papercups-io/papercups/issues/362

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
