### PR TITLE
Fix Slack thread if user changes integration to different channel

### DIFF
--- a/lib/chat_api/slack.ex
+++ b/lib/chat_api/slack.ex
@@ -130,14 +130,15 @@ defmodule ChatApi.Slack do
   @spec send_conversation_message_alert(binary(), binary(), keyword()) ::
           Tesla.Env.result() | nil | :ok
   def send_conversation_message_alert(conversation_id, text, type: type) do
-    # Check if a Slack thread already exists for this conversation.
-    # If one exists, send followup messages as replies; otherwise, start a new thread
-    thread = SlackConversationThreads.get_thread_by_conversation_id(conversation_id)
-
     %{account_id: account_id, customer: customer} =
       Conversations.get_conversation_with!(conversation_id, :customer)
 
-    %{access_token: access_token, channel: channel} = get_slack_authorization(account_id)
+    %{access_token: access_token, channel: channel, channel_id: channel_id} =
+      get_slack_authorization(account_id)
+
+    # Check if a Slack thread already exists for this conversation.
+    # If one exists, send followup messages as replies; otherwise, start a new thread
+    thread = SlackConversationThreads.get_thread_by_conversation_id(conversation_id, channel_id)
 
     # TODO: use a struct here?
     %{

--- a/lib/chat_api/slack_conversation_threads.ex
+++ b/lib/chat_api/slack_conversation_threads.ex
@@ -39,10 +39,11 @@ defmodule ChatApi.SlackConversationThreads do
   """
   def get_slack_conversation_thread!(id), do: Repo.get!(SlackConversationThread, id)
 
-  @spec get_thread_by_conversation_id(binary()) :: SlackConversationThread.t() | nil
-  def get_thread_by_conversation_id(conversation_id) do
+  @spec get_thread_by_conversation_id(binary(), binary()) :: SlackConversationThread.t() | nil
+  def get_thread_by_conversation_id(conversation_id, slack_channel) do
     SlackConversationThread
     |> where(conversation_id: ^conversation_id)
+    |> where(slack_channel: ^slack_channel)
     |> preload(:conversation)
     |> Repo.one()
   end

--- a/test/chat_api/slack_conversation_threads_test.exs
+++ b/test/chat_api/slack_conversation_threads_test.exs
@@ -28,9 +28,9 @@ defmodule ChatApi.SlackConversationThreadsTest do
       account = account_fixture()
       customer = customer_fixture(account)
       conversation = conversation_fixture(account, customer)
-
       slack_conversation_thread = slack_conversation_thread_fixture(conversation)
-      {:ok, slack_conversation_thread: slack_conversation_thread}
+
+      {:ok, conversation: conversation, slack_conversation_thread: slack_conversation_thread}
     end
 
     test "list_slack_conversation_threads/0 returns all slack_conversation_threads", %{
@@ -114,6 +114,38 @@ defmodule ChatApi.SlackConversationThreadsTest do
                SlackConversationThreads.change_slack_conversation_thread(
                  slack_conversation_thread
                )
+    end
+
+    test "get_by_slack_thread_ts/2 finds a slack_conversation_thread by thread_ts and channel",
+         %{
+           conversation: conversation
+         } do
+      slack_conversation_thread =
+        slack_conversation_thread_fixture(conversation, %{
+          slack_thread_ts: "ts1",
+          slack_channel: "ch1"
+        })
+
+      result = SlackConversationThreads.get_by_slack_thread_ts("ts1", "ch1")
+
+      assert result.id == slack_conversation_thread.id
+      refute SlackConversationThreads.get_by_slack_thread_ts("ts2", "ch1")
+      refute SlackConversationThreads.get_by_slack_thread_ts("ts1", "ch2")
+    end
+
+    test "get_thread_by_conversation_id/2 finds a slack_conversation_thread by conversation_id and channel",
+         %{
+           conversation: conversation
+         } do
+      slack_conversation_thread =
+        slack_conversation_thread_fixture(conversation, %{
+          slack_channel: "ch1"
+        })
+
+      result = SlackConversationThreads.get_thread_by_conversation_id(conversation.id, "ch1")
+
+      assert result.id == slack_conversation_thread.id
+      refute SlackConversationThreads.get_thread_by_conversation_id(conversation.id, "ch2")
     end
   end
 end


### PR DESCRIPTION
### Description

If a user changes the channel of their Papercups Slack integration, it messes up existing chat threads.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/61

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
