### PR TITLE
redirect to getting-started

### DIFF
--- a/assets/src/components/auth/Register.tsx
+++ b/assets/src/components/auth/Register.tsx
@@ -30,12 +30,14 @@ class Register extends React.Component<Props, State> {
     password: '',
     passwordConfirmation: '',
     inviteToken: '',
-    redirect: '/conversations',
+    redirect: '/account/getting-started',
     error: null,
   };
 
   componentDidMount() {
-    const {redirect = '/conversations'} = qs.parse(this.props.location.search);
+    const {redirect = '/account/getting-started'} = qs.parse(
+      this.props.location.search
+    );
     const {invite: inviteToken} = this.props.match.params;
 
     this.setState({inviteToken, redirect: String(redirect)});


### PR DESCRIPTION
### Description

Changed the redirect url to /account/getting-started within the Register.tsx component. Provides more intuitive flow.

### Issue

fixes #360  

### Screenshots

_For frontend updates, please include a screenshot._

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
