### PR TITLE
Exclude closed conversations from being loaded in embedded chat widget

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -69,6 +69,7 @@ defmodule ChatApi.Conversations do
     Conversation
     |> where(customer_id: ^customer_id)
     |> where(account_id: ^account_id)
+    |> where(status: "open")
     |> where([c], is_nil(c.archived_at))
     |> order_by(desc: :inserted_at)
     |> preload([:customer, messages: [user: :profile]])

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -70,7 +70,7 @@ defmodule ChatApi.ConversationsTest do
       assert result_ids == [conversation.id]
     end
 
-    test "find_by_customer/2 returns all not archived conversations for a customer", %{
+    test "find_by_customer/2 does not include archived conversations for a customer", %{
       account: account,
       conversation: conversation,
       customer: customer
@@ -81,6 +81,18 @@ defmodule ChatApi.ConversationsTest do
       result_ids = Enum.map(Conversations.find_by_customer(customer.id, account.id), & &1.id)
 
       assert result_ids == [conversation.id]
+    end
+
+    test "find_by_customer/2 does not include closed conversations for a customer", %{
+      account: account,
+      customer: customer
+    } do
+      closed = conversation_fixture(account, customer, %{status: "closed"})
+      results = Conversations.find_by_customer(customer.id, account.id)
+      ids = Enum.map(results, & &1.id)
+
+      refute Enum.member?(ids, closed.id)
+      assert Enum.all?(results, fn conv -> conv.status == "open" end)
     end
 
     test "get_conversation!/1 returns the conversation with given id", %{
@@ -115,7 +127,7 @@ defmodule ChatApi.ConversationsTest do
       assert {:error, %Ecto.Changeset{}} =
                Conversations.update_conversation(conversation, @invalid_attrs)
 
-      assert conversation = Conversations.get_conversation!(conversation.id)
+      assert _conversation = Conversations.get_conversation!(conversation.id)
     end
 
     test "delete_conversation/1 deletes the conversation", %{conversation: conversation} do

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -50,7 +50,7 @@ defmodule ChatApi.CustomersTest do
               %Customer{
                 first_seen: ~D[2020-01-01],
                 last_seen: ~D[2020-01-01]
-              } = customer} = Customers.create_customer(attrs)
+              } = _customer} = Customers.create_customer(attrs)
     end
 
     test "create_customer/1 with invalid data returns error changeset" do
@@ -117,14 +117,14 @@ defmodule ChatApi.CustomersTest do
       external_id = "cus_123"
       _customer = customer_fixture(account, %{external_id: external_id})
 
-      assert customer = Customers.find_by_external_id(external_id, account.id)
+      assert _customer = Customers.find_by_external_id(external_id, account.id)
     end
 
     test "find_by_external_id/2 works with integer external_ids", %{account: account} do
       external_id = "123"
       _customer = customer_fixture(account, %{external_id: external_id})
 
-      assert customer = Customers.find_by_external_id(123, account.id)
+      assert _customer = Customers.find_by_external_id(123, account.id)
     end
   end
 end


### PR DESCRIPTION
### Description

If one of our users closes a conversation, that typically means they don't want it to show up again for their customer. This forces the customer to open a new thread the next time they start chatting.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
