### PR TITLE
Indicate when a Storytime session is inactive

### DIFF
--- a/assets/src/components/sessions/SessionsOverview.tsx
+++ b/assets/src/components/sessions/SessionsOverview.tsx
@@ -73,6 +73,7 @@ class SessionsOverview extends React.Component<Props, State> {
         return info;
       });
       const sessions = records.map((info) => {
+        // Default to active=true for backwards compatibility
         const {session_id: sessionId, active = true, ts} = info;
 
         return {sessionId, active, ts};

--- a/assets/src/components/sessions/SessionsTable.tsx
+++ b/assets/src/components/sessions/SessionsTable.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import {BrowserSession, Customer} from '../../types';
 import {Badge, Button, Table, Text, Tooltip} from '../common';
+import {formatRelativeTime} from '../../utils';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -36,7 +37,7 @@ const SessionsTable = ({
       title: 'Started at',
       dataIndex: 'started_at',
       key: 'started_at',
-      render: (value: string, record: any) => {
+      render: (value: string, record: BrowserSession) => {
         const {metadata = {}} = record;
         const {pathname, current_url} = metadata;
         const formatted = value ? dayjs(value).format('MMMM DD, h:mm a') : '--';
@@ -61,17 +62,32 @@ const SessionsTable = ({
     },
     {
       title: 'Status',
-      dataIndex: 'status',
-      key: 'status',
-      render: () => {
-        return <Badge status="processing" text="Online now!" />;
+      dataIndex: 'active',
+      key: 'active',
+      render: (isActive: boolean, record: BrowserSession) => {
+        const {ts} = record;
+        const date = ts ? dayjs.utc(ts) : null;
+        const since = date ? formatRelativeTime(date) : 'N/A';
+
+        return (
+          <Box>
+            {isActive ? (
+              <Badge status="processing" text="Online now!" />
+            ) : (
+              <Badge status="default" text="Inactive" />
+            )}
+            <Box sx={{fontSize: 12, lineHeight: 1.4}}>
+              <Text type="secondary">{since}</Text>
+            </Box>
+          </Box>
+        );
       },
     },
     {
       title: 'Device info',
       dataIndex: 'info',
       key: 'info',
-      render: (value: string, record: any) => {
+      render: (value: string, record: BrowserSession) => {
         const {metadata = {}} = record;
         const {browser, os} = metadata;
 
@@ -88,7 +104,7 @@ const SessionsTable = ({
       title: '',
       dataIndex: 'action',
       key: 'action',
-      render: (value: string, record: any) => {
+      render: (value: string, record: BrowserSession) => {
         const {id: sessionId} = record;
 
         return (

--- a/assets/src/components/sessions/SessionsTable.tsx
+++ b/assets/src/components/sessions/SessionsTable.tsx
@@ -67,7 +67,6 @@ const SessionsTable = ({
       render: (isActive: boolean, record: BrowserSession) => {
         const {ts} = record;
         const date = ts ? dayjs.utc(ts) : null;
-        const since = date ? formatRelativeTime(date) : 'N/A';
 
         return (
           <Box>
@@ -76,9 +75,11 @@ const SessionsTable = ({
             ) : (
               <Badge status="default" text="Inactive" />
             )}
-            <Box sx={{fontSize: 12, lineHeight: 1.4}}>
-              <Text type="secondary">{since}</Text>
-            </Box>
+            {date ? (
+              <Box sx={{fontSize: 12, lineHeight: 1.4}}>
+                <Text type="secondary">{formatRelativeTime(date)}</Text>
+              </Box>
+            ) : null}
           </Box>
         );
       },

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -70,6 +70,9 @@ export type BrowserSession = {
   started_at: string;
   finished_at?: string;
   metadata?: any;
+  // Client-side properties
+  active?: boolean;
+  ts?: string | Date;
 };
 
 export enum Alignment {

--- a/lib/chat_api_web/channels/event_channel.ex
+++ b/lib/chat_api_web/channels/event_channel.ex
@@ -83,7 +83,8 @@ defmodule ChatApiWeb.EventChannel do
         online_at: inspect(System.system_time(:second)),
         account_id: socket.assigns.account_id,
         session_id: socket.assigns.browser_session_id,
-        active: true
+        active: true,
+        ts: DateTime.utc_now()
       })
 
     ChatApiWeb.Endpoint.broadcast!(topic, "presence_state", Presence.list(topic))
@@ -111,7 +112,7 @@ defmodule ChatApiWeb.EventChannel do
 
     {:ok, _} =
       Presence.update(self(), topic, key, fn current ->
-        Map.merge(current, %{active: true})
+        Map.merge(current, %{active: true, ts: DateTime.utc_now()})
       end)
 
     ChatApiWeb.Endpoint.broadcast!(topic, "presence_state", Presence.list(topic))
@@ -125,7 +126,7 @@ defmodule ChatApiWeb.EventChannel do
 
     {:ok, _} =
       Presence.update(self(), topic, key, fn current ->
-        Map.merge(current, %{active: false})
+        Map.merge(current, %{active: false, ts: DateTime.utc_now()})
       end)
 
     ChatApiWeb.Endpoint.broadcast!(topic, "presence_state", Presence.list(topic))


### PR DESCRIPTION
### Description

Indicates when a live session is inactive (i.e. the tab is open but hidden/inactive).

### Screenshots

<img width="1030" alt="Screen Shot 2020-11-04 at 3 50 18 PM" src="https://user-images.githubusercontent.com/5264279/98166486-7d989e80-1eb5-11eb-974c-3820a656a18f.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
