### PR TITLE
Silence warnings in tests

### DIFF
--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -91,7 +91,7 @@ defmodule ChatApi.SlackTest do
       text = "Hello world"
 
       assert %{
-               "blocks" => blocks,
+               "blocks" => _blocks,
                "channel" => ^channel
              } =
                Slack.get_message_payload(text, %{

--- a/test/chat_api_web/api_auth_plug_test.exs
+++ b/test/chat_api_web/api_auth_plug_test.exs
@@ -33,8 +33,8 @@ defmodule ChatApiWeb.APIAuthPlugTest do
 
     assert {%{
               private: %{
-                api_auth_token: renewed_access_token,
-                api_renew_token: renewed_renewal_token
+                api_auth_token: _renewed_access_token,
+                api_renew_token: _renewed_renewal_token
               }
             }, ^user} = APIAuthPlug.renew(with_auth_header(conn, renewal_token), @pow_config)
 

--- a/test/chat_api_web/channels/conversation_channel_test.exs
+++ b/test/chat_api_web/channels/conversation_channel_test.exs
@@ -20,7 +20,7 @@ defmodule ChatApiWeb.ConversationChannelTest do
   test "shout broadcasts to conversation:lobby", %{socket: socket, account: account} do
     msg = %{body: "Hello world!", account_id: account.id}
     push(socket, "shout", msg)
-    assert_broadcast "shout", msg
+    assert_broadcast "shout", _msg
   end
 
   test "broadcasts are pushed to the client", %{socket: socket} do

--- a/test/chat_api_web/channels/notification_channel_test.exs
+++ b/test/chat_api_web/channels/notification_channel_test.exs
@@ -34,7 +34,7 @@ defmodule ChatApiWeb.NotificationChannelTest do
 
     push(socket, "shout", msg)
 
-    assert_push("shout", msg)
+    assert_push("shout", _msg)
   end
 
   test "broadcasts are pushed to the client", %{socket: socket} do

--- a/test/chat_api_web/controllers/account_controller_test.exs
+++ b/test/chat_api_web/controllers/account_controller_test.exs
@@ -35,7 +35,7 @@ defmodule ChatApiWeb.AccountControllerTest do
       resp = get(authed_conn, Routes.account_path(authed_conn, :me))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "company_name" => "some company_name"
              } = json_response(resp, 200)["data"]
     end
@@ -63,7 +63,7 @@ defmodule ChatApiWeb.AccountControllerTest do
       conn = get(authed_conn, Routes.account_path(authed_conn, :me))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "company_name" => "some updated company_name"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -41,7 +41,7 @@ defmodule ChatApiWeb.ConversationControllerTest do
       conn = get(authed_conn, Routes.conversation_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "status" => "open"
              } = json_response(conn, 200)["data"]
     end
@@ -71,7 +71,7 @@ defmodule ChatApiWeb.ConversationControllerTest do
       conn = get(authed_conn, Routes.conversation_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "status" => "closed"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -79,7 +79,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
       resp = get(authed_conn, Routes.customer_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id
+               "id" => _id
              } = json_response(resp, 200)["data"]
     end
 
@@ -128,7 +128,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
       resp = get(authed_conn, Routes.customer_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id
+               "id" => _id
              } = json_response(resp, 200)["data"]
     end
 

--- a/test/chat_api_web/controllers/event_subscription_controller_test.exs
+++ b/test/chat_api_web/controllers/event_subscription_controller_test.exs
@@ -51,7 +51,7 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
       resp = get(authed_conn, Routes.event_subscription_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "scope" => "some scope",
                "webhook_url" => "some webhook_url"
              } = json_response(resp, 200)["data"]
@@ -82,7 +82,7 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
       conn = get(authed_conn, Routes.event_subscription_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "scope" => "some updated scope",
                "webhook_url" => "some updated webhook_url"
              } = json_response(conn, 200)["data"]

--- a/test/chat_api_web/controllers/message_controller_test.exs
+++ b/test/chat_api_web/controllers/message_controller_test.exs
@@ -60,7 +60,7 @@ defmodule ChatApiWeb.MessageControllerTest do
       conn = get(authed_conn, Routes.message_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "body" => "some body"
              } = json_response(conn, 200)["data"]
     end
@@ -86,7 +86,7 @@ defmodule ChatApiWeb.MessageControllerTest do
       conn = get(authed_conn, Routes.message_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "body" => "some updated body"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -36,7 +36,7 @@ defmodule ChatApiWeb.TagControllerTest do
       resp = get(authed_conn, Routes.tag_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "name" => "some name"
              } = json_response(resp, 200)["data"]
     end
@@ -57,7 +57,7 @@ defmodule ChatApiWeb.TagControllerTest do
       conn = get(authed_conn, Routes.tag_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
+               "id" => _id,
                "name" => "some updated name"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/user_invitation_controller_test.exs
+++ b/test/chat_api_web/controllers/user_invitation_controller_test.exs
@@ -31,8 +31,8 @@ defmodule ChatApiWeb.UserInvitationControllerTest do
       conn = get(authed_conn, Routes.user_invitation_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
-               "account_id" => account_id
+               "id" => _id,
+               "account_id" => _account_id
                #  "expires_at" => "2010-04-17",
                #  "token" => "some token"
              } = json_response(conn, 200)["data"]
@@ -56,8 +56,8 @@ defmodule ChatApiWeb.UserInvitationControllerTest do
       conn = get(authed_conn, Routes.user_invitation_path(authed_conn, :show, id))
 
       assert %{
-               "id" => id,
-               "account_id" => account_id
+               "id" => _id,
+               "account_id" => _account_id
                #  "expires_at" => "2011-05-18",
                #  "token" => "some updated token"
              } = json_response(conn, 200)["data"]


### PR DESCRIPTION
### Description
Most test assertions pattern matched on variables. These variables, for some assertions, may not necessarily be referenced. 
Because they are referenced, this raises warnings about the variables being ununsed. The raised warnings are in this form
```
warning: variable "renewed_access_token" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/chat_api_web/api_auth_plug_test.exs:36: ChatApiWeb.APIAuthPlugTest."test can create, fetch, renew, and delete session"/1
```



This PR silences these warnings.


### Issue

#389 

### Screenshots

N/A

## Checklist

- [X] Everything passes when running `mix test`
- [X] Ran `mix format`
- [X] No frontend compilation warnings
