### PR TITLE
feat: Add "Timezone" data to initial Slack conversation thread

### DIFF
--- a/lib/chat_api/slack.ex
+++ b/lib/chat_api/slack.ex
@@ -261,7 +261,8 @@ defmodule ChatApi.Slack do
           email: email,
           current_url: current_url,
           browser: browser,
-          os: os
+          os: os,
+          time_zone: time_zone
         },
         thread: nil
       }) do
@@ -297,6 +298,10 @@ defmodule ChatApi.Slack do
             %{
               "type" => "mrkdwn",
               "text" => "*OS:*\n#{os || "N/A"}"
+            },
+            %{
+              "type" => "mrkdwn",
+              "text" => "*Timezone:*\n#{time_zone || "N/A"}"
             }
           ]
         }

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -87,11 +87,40 @@ defmodule ChatApi.SlackTest do
       customer: customer,
       thread: thread
     } do
-      channel = thread.slack_channel
       text = "Hello world"
+      customer_email = "*Email:*\n#{customer.email}"
+      channel = thread.slack_channel
 
       assert %{
-               "blocks" => _blocks,
+               "blocks" => [
+                 %{
+                   "text" => %{
+                     "text" => ^text
+                   }
+                 },
+                 %{
+                   "fields" => [
+                     %{
+                       "text" => "*Name:*\nAnonymous User"
+                     },
+                     %{
+                       "text" => ^customer_email
+                     },
+                     %{
+                       "text" => "*URL:*\nN/A"
+                     },
+                     %{
+                       "text" => "*Browser:*\nN/A"
+                     },
+                     %{
+                       "text" => "*OS:*\nN/A"
+                     },
+                     %{
+                       "text" => "*Timezone:*\nN/A"
+                     }
+                   ]
+                 }
+               ],
                "channel" => ^channel
              } =
                Slack.get_message_payload(text, %{


### PR DESCRIPTION
### Problem

This is a useful proxy for knowing where the user is located. It should be easy to just add this to the initial message in our Slack conversation threads.
#388 

### Solution

Add "Timezone" to initial Slack conversation thread if it exists. If it doesn't exist, just display "N/A"
I added the `time_zone` field to function that returns payload and I improved the tests.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
