### PR TITLE
Public API v1

### DIFF
--- a/lib/chat_api/api_keys.ex
+++ b/lib/chat_api/api_keys.ex
@@ -1,0 +1,79 @@
+defmodule ChatApi.ApiKeys do
+  @moduledoc """
+  The ApiKeys context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.ApiKeys.PersonalApiKey
+
+  @spec list_personal_api_keys(binary(), binary()) :: [PersonalApiKey.t()]
+  def list_personal_api_keys(user_id, account_id) do
+    PersonalApiKey
+    |> where(user_id: ^user_id)
+    |> where(account_id: ^account_id)
+    |> Repo.all()
+  end
+
+  @spec get_personal_api_key!(binary()) :: PersonalApiKey.t()
+  def get_personal_api_key!(id) do
+    # TODO: filter by user_id/account_id?
+    Repo.get!(PersonalApiKey, id)
+  end
+
+  @spec find_personal_api_key_by_value(binary()) :: PersonalApiKey.t() | nil
+  def find_personal_api_key_by_value(value) do
+    PersonalApiKey
+    |> where(value: ^value)
+    |> Repo.one()
+    |> Repo.preload(:user)
+  end
+
+  @spec create_personal_api_key(map()) :: {:ok, PersonalApiKey.t()} | {:error, Ecto.Changeset.t()}
+  def create_personal_api_key(attrs \\ %{}) do
+    %PersonalApiKey{}
+    |> PersonalApiKey.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_personal_api_key(PersonalApiKey.t(), map()) ::
+          {:ok, PersonalApiKey.t()} | {:error, Ecto.Changeset.t()}
+  def update_personal_api_key(%PersonalApiKey{} = personal_api_key, attrs) do
+    personal_api_key
+    |> PersonalApiKey.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_personal_api_key(PersonalApiKey.t()) ::
+          {:ok, PersonalApiKey.t()} | {:error, Ecto.Changeset.t()}
+  def delete_personal_api_key(%PersonalApiKey{} = personal_api_key) do
+    Repo.delete(personal_api_key)
+  end
+
+  @spec change_personal_api_key(PersonalApiKey.t(), map()) :: Ecto.Changeset.t()
+  def change_personal_api_key(%PersonalApiKey{} = personal_api_key, attrs \\ %{}) do
+    PersonalApiKey.changeset(personal_api_key, attrs)
+  end
+
+  @spec generate_random_token(map()) :: binary()
+  def generate_random_token(attrs \\ %{}) do
+    case attrs do
+      %{label: label, user_id: user_id, account_id: account_id} ->
+        generate_random_token(label, user_id: user_id, account_id: account_id)
+
+      %{"label" => label, "user_id" => user_id, "account_id" => account_id} ->
+        generate_random_token(label, user_id: user_id, account_id: account_id)
+
+      _ ->
+        # TODO: should we return an error here?
+        generate_random_token("API Key", [])
+    end
+  end
+
+  @spec generate_random_token(binary(), any()) :: binary()
+  def generate_random_token(label, data) do
+    # TODO: figure out the best way to generate a random API token
+    Phoenix.Token.sign(ChatApiWeb.Endpoint, label, data)
+  end
+end

--- a/lib/chat_api/api_keys/personal_api_key.ex
+++ b/lib/chat_api/api_keys/personal_api_key.ex
@@ -23,6 +23,7 @@ defmodule ChatApi.ApiKeys.PersonalApiKey do
     personal_api_key
     |> cast(attrs, [:label, :value, :last_used_at, :account_id, :user_id])
     |> validate_required([:label, :value, :account_id, :user_id])
+    |> unique_constraint(:value)
     |> foreign_key_constraint(:account_id)
     |> foreign_key_constraint(:user_id)
   end

--- a/lib/chat_api/api_keys/personal_api_key.ex
+++ b/lib/chat_api/api_keys/personal_api_key.ex
@@ -1,0 +1,29 @@
+defmodule ChatApi.ApiKeys.PersonalApiKey do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Users.User
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "personal_api_keys" do
+    field(:label, :string)
+    field(:value, :string)
+    field(:last_used_at, :utc_datetime)
+
+    belongs_to(:account, Account)
+    belongs_to(:user, User, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(personal_api_key, attrs) do
+    personal_api_key
+    |> cast(attrs, [:label, :value, :last_used_at, :account_id, :user_id])
+    |> validate_required([:label, :value, :account_id, :user_id])
+    |> foreign_key_constraint(:account_id)
+    |> foreign_key_constraint(:user_id)
+  end
+end

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -40,6 +40,12 @@ defmodule ChatApi.Users do
     User |> where(password_reset_token: ^token) |> Repo.one()
   end
 
+  @spec find_by_api_key(binary()) :: User.t() | nil
+  def find_by_api_key(_api_key) do
+    # TODO: implement me!
+    nil
+  end
+
   @spec send_password_reset_email(User.t()) ::
           ChatApi.Emails.deliver_result() | {:error, Ecto.Changeset.t()}
   def send_password_reset_email(user) do

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -41,9 +41,11 @@ defmodule ChatApi.Users do
   end
 
   @spec find_by_api_key(binary()) :: User.t() | nil
-  def find_by_api_key(_api_key) do
-    # TODO: implement me!
-    nil
+  def find_by_api_key(api_key) do
+    case ChatApi.ApiKeys.find_personal_api_key_by_value(api_key) do
+      %{user: %User{} = user} -> user
+      _ -> nil
+    end
   end
 
   @spec send_password_reset_email(User.t()) ::

--- a/lib/chat_api_web/api_auth_plug.ex
+++ b/lib/chat_api_web/api_auth_plug.ex
@@ -93,6 +93,7 @@ defmodule ChatApiWeb.APIAuthPlug do
   defp signing_salt(), do: Atom.to_string(__MODULE__)
 
   defp fetch_auth_token(conn, config) do
+    # TODO: if token isn't verified, check personal API keys?
     with [token | _rest] <- Conn.get_req_header(conn, "authorization"),
          {:ok, token} <- Plug.verify_token(conn, signing_salt(), token, config) do
       token

--- a/lib/chat_api_web/controllers/personal_api_key_controller.ex
+++ b/lib/chat_api_web/controllers/personal_api_key_controller.ex
@@ -1,0 +1,52 @@
+defmodule ChatApiWeb.PersonalApiKeyController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.ApiKeys
+  alias ChatApi.ApiKeys.PersonalApiKey
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(
+        %{assigns: %{current_user: %{account_id: account_id, id: user_id}}} = conn,
+        _params
+      ) do
+    personal_api_keys = ApiKeys.list_personal_api_keys(user_id, account_id)
+    render(conn, "index.json", personal_api_keys: personal_api_keys)
+  end
+
+  def create(%{assigns: %{current_user: %{account_id: account_id, id: user_id}}} = conn, %{
+        "label" => personal_api_key_label
+      }) do
+    with params <- %{
+           label: personal_api_key_label,
+           user_id: user_id,
+           account_id: account_id,
+           value:
+             ApiKeys.generate_random_token(personal_api_key_label,
+               user_id: user_id,
+               account_id: account_id
+             )
+         },
+         {:ok, %PersonalApiKey{} = personal_api_key} <-
+           ApiKeys.create_personal_api_key(params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.personal_api_key_path(conn, :show, personal_api_key))
+      |> render("show.json", personal_api_key: personal_api_key)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    # TODO: filter by user_id/account_id?
+    personal_api_key = ApiKeys.get_personal_api_key!(id)
+    render(conn, "show.json", personal_api_key: personal_api_key)
+  end
+
+  def delete(conn, %{"id" => id}) do
+    personal_api_key = ApiKeys.get_personal_api_key!(id)
+
+    with {:ok, %PersonalApiKey{}} <- ApiKeys.delete_personal_api_key(personal_api_key) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/public_api_auth_plug.ex
+++ b/lib/chat_api_web/public_api_auth_plug.ex
@@ -1,0 +1,85 @@
+defmodule ChatApiWeb.PublicAPIAuthPlug do
+  @moduledoc false
+  use Pow.Plug.Base
+
+  alias Plug.Conn
+  alias Pow.{Config, Store.CredentialsCache}
+
+  @impl true
+  @spec fetch(Conn.t(), Config.t()) :: {Conn.t(), map() | nil}
+  def fetch(conn, config) do
+    conn
+    |> fetch_auth_token(config)
+    |> fetch_user(conn, config)
+  end
+
+  defp fetch_user(nil, conn, _config), do: {conn, nil}
+
+  defp fetch_user(token, conn, config) do
+    case fetch_from_store(token, config) do
+      nil -> fetch_and_cache_user(token, conn, config)
+      user -> {conn, user}
+    end
+  end
+
+  defp fetch_and_cache_user(token, conn, config) do
+    case ChatApi.Users.find_by_api_key(token) do
+      nil ->
+        {conn, nil}
+
+      user ->
+        config
+        |> store_config()
+        |> CredentialsCache.put(token, {user, []})
+
+        {conn, user}
+    end
+  end
+
+  defp fetch_from_store(token, config) do
+    config
+    |> store_config()
+    |> CredentialsCache.get(token)
+    |> case do
+      :not_found -> nil
+      {user, _metadata} -> user
+    end
+  end
+
+  @impl true
+  @spec create(Conn.t(), map(), Config.t()) :: {Conn.t(), map()}
+  def create(conn, user, _config) do
+    {conn, user}
+  end
+
+  @impl true
+  @spec delete(Conn.t(), Config.t()) :: Conn.t()
+  def delete(conn, config) do
+    case fetch_auth_token(conn, config) do
+      nil ->
+        :ok
+
+      token ->
+        config
+        |> store_config()
+        |> CredentialsCache.delete(token)
+    end
+
+    conn
+  end
+
+  defp fetch_auth_token(conn, _config) do
+    with [token | _rest] <- Conn.get_req_header(conn, "authorization"),
+         "bearer " <> token <- String.downcase(token) do
+      token
+    else
+      _any -> nil
+    end
+  end
+
+  defp store_config(config) do
+    backend = Config.get(config, :cache_store_backend, Pow.Store.Backend.EtsCache)
+
+    [backend: backend]
+  end
+end

--- a/lib/chat_api_web/public_api_auth_plug.ex
+++ b/lib/chat_api_web/public_api_auth_plug.ex
@@ -70,7 +70,7 @@ defmodule ChatApiWeb.PublicAPIAuthPlug do
 
   defp fetch_auth_token(conn, _config) do
     with [token | _rest] <- Conn.get_req_header(conn, "authorization"),
-         "bearer " <> token <- String.downcase(token) do
+         "Bearer " <> token <- token do
       token
     else
       _any -> nil

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -20,6 +20,12 @@ defmodule ChatApiWeb.Router do
     plug(ChatApiWeb.EnsureUserEnabledPlug)
   end
 
+  pipeline :public_api do
+    plug(ChatApiWeb.IPAddressPlug)
+    plug(:accepts, ["json"])
+    plug(ChatApiWeb.PublicAPIAuthPlug, otp_app: :chat_api)
+  end
+
   # Swagger
   scope "/api/swagger" do
     forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :chat_api, swagger_file: "swagger.json"
@@ -101,6 +107,12 @@ defmodule ChatApiWeb.Router do
     post("/customers/:customer_id/tags", CustomerController, :add_tag)
     delete("/customers/:customer_id/tags/:tag_id", CustomerController, :remove_tag)
     post("/event_subscriptions/verify", EventSubscriptionController, :verify)
+  end
+
+  scope "/api/v1", ChatApiWeb do
+    pipe_through([:public_api])
+
+    get("/me", SessionController, :me)
   end
 
   # Enables LiveDashboard only for development

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -101,6 +101,7 @@ defmodule ChatApiWeb.Router do
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
     resources("/tags", TagController, except: [:new, :edit])
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
+    resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
 
     post("/conversations/:conversation_id/tags", ConversationController, :add_tag)
     delete("/conversations/:conversation_id/tags/:tag_id", ConversationController, :remove_tag)
@@ -110,9 +111,13 @@ defmodule ChatApiWeb.Router do
   end
 
   scope "/api/v1", ChatApiWeb do
-    pipe_through([:public_api])
+    pipe_through([:public_api, :api_protected])
 
     get("/me", SessionController, :me)
+
+    resources("/messages", MessageController, except: [:new, :edit])
+    resources("/conversations", ConversationController, except: [:new, :edit])
+    resources("/customers", CustomerController, except: [:new, :edit])
   end
 
   # Enables LiveDashboard only for development

--- a/lib/chat_api_web/views/personal_api_key_view.ex
+++ b/lib/chat_api_web/views/personal_api_key_view.ex
@@ -1,0 +1,23 @@
+defmodule ChatApiWeb.PersonalApiKeyView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.PersonalApiKeyView
+
+  def render("index.json", %{personal_api_keys: personal_api_keys}) do
+    %{data: render_many(personal_api_keys, PersonalApiKeyView, "personal_api_key.json")}
+  end
+
+  def render("show.json", %{personal_api_key: personal_api_key}) do
+    %{data: render_one(personal_api_key, PersonalApiKeyView, "personal_api_key.json")}
+  end
+
+  def render("personal_api_key.json", %{personal_api_key: personal_api_key}) do
+    %{
+      id: personal_api_key.id,
+      label: personal_api_key.label,
+      value: personal_api_key.value,
+      last_used_at: personal_api_key.last_used_at,
+      account_id: personal_api_key.account_id,
+      user_id: personal_api_key.user_id
+    }
+  end
+end

--- a/lib/mix/tasks/generate_api_key.ex
+++ b/lib/mix/tasks/generate_api_key.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.GenerateApiKey do
+  use Mix.Task
+
+  @shortdoc "Generates an API key for the provided user/account"
+
+  @moduledoc """
+  This task generates an API key for the provided user/account
+  """
+
+  def run(args) do
+    Application.ensure_all_started(:chat_api)
+
+    with [user_id, account_id] <- args,
+         {:ok, _personal_api_key} <- generate_api_key(user_id, account_id) do
+      Mix.shell().info(
+        "Successfully generated API key for user #{inspect(user_id)} of account #{
+          inspect(account_id)
+        }"
+      )
+    else
+      error -> Mix.shell().info("Failed to generate API key: #{inspect(error)}")
+    end
+  end
+
+  defp generate_api_key(user_id, account_id) do
+    attrs = %{
+      user_id: user_id,
+      account_id: account_id,
+      label: "Test API Key"
+    }
+
+    token = ChatApi.ApiKeys.generate_random_token(attrs)
+
+    %{value: token}
+    |> Map.merge(attrs)
+    |> ChatApi.ApiKeys.create_personal_api_key()
+  end
+end

--- a/priv/repo/migrations/20201130152701_create_personal_api_keys.exs
+++ b/priv/repo/migrations/20201130152701_create_personal_api_keys.exs
@@ -16,5 +16,6 @@ defmodule ChatApi.Repo.Migrations.CreatePersonalApiKeys do
 
     create(index(:personal_api_keys, [:account_id]))
     create(index(:personal_api_keys, [:user_id]))
+    create(unique_index(:personal_api_keys, [:value]))
   end
 end

--- a/priv/repo/migrations/20201130152701_create_personal_api_keys.exs
+++ b/priv/repo/migrations/20201130152701_create_personal_api_keys.exs
@@ -1,0 +1,20 @@
+defmodule ChatApi.Repo.Migrations.CreatePersonalApiKeys do
+  use Ecto.Migration
+
+  def change do
+    create table(:personal_api_keys, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:label, :string)
+      add(:value, :string)
+      add(:last_used_at, :utc_datetime)
+
+      add(:user_id, references(:users, type: :integer, on_delete: :delete_all), null: false)
+      add(:account_id, references(:accounts, type: :uuid, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create(index(:personal_api_keys, [:account_id]))
+    create(index(:personal_api_keys, [:user_id]))
+  end
+end

--- a/test/chat_api/api_keys_test.exs
+++ b/test/chat_api/api_keys_test.exs
@@ -1,0 +1,91 @@
+defmodule ChatApi.ApiKeysTest do
+  use ChatApi.DataCase
+
+  alias ChatApi.ApiKeys
+
+  describe "personal_api_keys" do
+    alias ChatApi.ApiKeys.PersonalApiKey
+
+    @valid_attrs %{
+      label: "some label",
+      last_used_at: ~U[2010-04-17 14:00:00Z],
+      value: "some value"
+    }
+    @update_attrs %{
+      label: "some updated label",
+      last_used_at: ~U[2010-05-18 14:00:00Z],
+      value: "some updated value"
+    }
+    @invalid_attrs %{account_id: nil, label: nil, last_used_at: nil, user_id: nil, value: nil}
+
+    setup do
+      account = account_fixture()
+      user = user_fixture(account)
+
+      {:ok, account: account, user: user}
+    end
+
+    test "list_personal_api_keys/0 returns all personal_api_keys", %{user: user, account: account} do
+      personal_api_key = personal_api_key_fixture(user)
+
+      assert ApiKeys.list_personal_api_keys(user.id, account.id) == [personal_api_key]
+    end
+
+    test "get_personal_api_key!/1 returns the personal_api_key with given id", %{user: user} do
+      personal_api_key = personal_api_key_fixture(user)
+      assert ApiKeys.get_personal_api_key!(personal_api_key.id) == personal_api_key
+    end
+
+    test "create_personal_api_key/1 with valid data creates a personal_api_key", %{
+      user: user,
+      account: account
+    } do
+      attrs = Map.merge(@valid_attrs, %{user_id: user.id, account_id: account.id})
+      assert {:ok, %PersonalApiKey{} = personal_api_key} = ApiKeys.create_personal_api_key(attrs)
+
+      assert personal_api_key.user_id == user.id
+      assert personal_api_key.account_id == account.id
+      assert personal_api_key.label == "some label"
+      assert personal_api_key.last_used_at == ~U[2010-04-17 14:00:00Z]
+      assert personal_api_key.value == "some value"
+    end
+
+    test "create_personal_api_key/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ApiKeys.create_personal_api_key(@invalid_attrs)
+    end
+
+    test "update_personal_api_key/2 with valid data updates the personal_api_key", %{user: user} do
+      personal_api_key = personal_api_key_fixture(user)
+
+      assert {:ok, %PersonalApiKey{} = personal_api_key} =
+               ApiKeys.update_personal_api_key(personal_api_key, @update_attrs)
+
+      assert personal_api_key.label == "some updated label"
+      assert personal_api_key.last_used_at == ~U[2010-05-18 14:00:00Z]
+      assert personal_api_key.value == "some updated value"
+    end
+
+    test "update_personal_api_key/2 with invalid data returns error changeset", %{user: user} do
+      personal_api_key = personal_api_key_fixture(user)
+
+      assert {:error, %Ecto.Changeset{}} =
+               ApiKeys.update_personal_api_key(personal_api_key, @invalid_attrs)
+
+      assert personal_api_key == ApiKeys.get_personal_api_key!(personal_api_key.id)
+    end
+
+    test "delete_personal_api_key/1 deletes the personal_api_key", %{user: user} do
+      personal_api_key = personal_api_key_fixture(user)
+      assert {:ok, %PersonalApiKey{}} = ApiKeys.delete_personal_api_key(personal_api_key)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        ApiKeys.get_personal_api_key!(personal_api_key.id)
+      end
+    end
+
+    test "change_personal_api_key/1 returns a personal_api_key changeset", %{user: user} do
+      personal_api_key = personal_api_key_fixture(user)
+      assert %Ecto.Changeset{} = ApiKeys.change_personal_api_key(personal_api_key)
+    end
+  end
+end

--- a/test/chat_api_web/controllers/personal_api_key_controller_test.exs
+++ b/test/chat_api_web/controllers/personal_api_key_controller_test.exs
@@ -1,0 +1,26 @@
+defmodule ChatApiWeb.PersonalApiKeyControllerTest do
+  use ChatApiWeb.ConnCase
+
+  setup %{conn: conn} do
+    account = account_fixture()
+    user = user_fixture(account)
+
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account, user: user}
+  end
+
+  describe "index" do
+    test "lists all personal_api_keys", %{authed_conn: authed_conn, user: user} do
+      conn = get(authed_conn, Routes.personal_api_key_path(authed_conn, :index))
+      assert json_response(conn, 200)["data"] == []
+
+      personal_api_key = personal_api_key_fixture(user, %{label: "Test API Key"})
+      token = personal_api_key.value
+
+      conn = get(authed_conn, Routes.personal_api_key_path(authed_conn, :index))
+      assert [%{"value" => ^token}] = json_response(conn, 200)["data"]
+    end
+  end
+end

--- a/test/support/test_fixture_helpers.ex
+++ b/test/support/test_fixture_helpers.ex
@@ -3,6 +3,7 @@ defmodule ChatApi.TestFixtureHelpers do
   alias ChatApi.{
     Repo,
     Accounts,
+    ApiKeys,
     BrowserSessions,
     BrowserReplayEvents,
     Customers,
@@ -203,6 +204,20 @@ defmodule ChatApi.TestFixtureHelpers do
       |> BrowserReplayEvents.create_browser_replay_event()
 
     browser_replay_event
+  end
+
+  def personal_api_key_fixture(%Users.User{} = user, attrs \\ %{}) do
+    {:ok, personal_api_key} =
+      attrs
+      |> Enum.into(%{
+        label: "API Key",
+        value: ApiKeys.generate_random_token(),
+        user_id: user.id,
+        account_id: user.account_id
+      })
+      |> ApiKeys.create_personal_api_key()
+
+    personal_api_key
   end
 
   defp counter do


### PR DESCRIPTION
### Description

This PR will set up API keys that developers can use to interact with certain API endpoints we expose (e.g. actions around conversations/messages/customers)

(The UI for creating/viewing API keys will be handled separately.)

### Issue

We want to make it possible to access the Papercups API with and API key, rather than an email/password auth

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
