### PR TITLE
Always show current live url of user in sidebar and  live Sessions Page

### DIFF
--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -143,6 +143,15 @@ const CustomerDetails = ({
           <Box mb={1}>
             <CustomerActiveSessions customerId={customerId} />
           </Box>
+            {lastSeenUrl ? (
+              <Tooltip title={lastSeenUrl}>
+                <a href={lastSeenUrl} target="_blank" rel="noopener noreferrer">
+                  {pathname && pathname.length > 1 ? pathname : lastSeenUrl}
+                </a>
+              </Tooltip>
+            ) : (
+              ''
+            )}
         </DetailsSectionCard>
       ) : (
         <DetailsSectionCard>

--- a/assets/src/components/sessions/LiveSessionViewer.tsx
+++ b/assets/src/components/sessions/LiveSessionViewer.tsx
@@ -229,7 +229,6 @@ class LiveSessionViewer extends React.Component<Props, State> {
       message,
     } = this.state;
     const hasAdditionalDetails = !!(conversation || customer);
-
     return (
       <Flex>
         <Box
@@ -246,7 +245,13 @@ class LiveSessionViewer extends React.Component<Props, State> {
                       Back to all sessions
                     </Button>
                   </Link>
-
+                   {customer && (
+                      <a href={customer.current_url} target="_blank" rel="noopener noreferrer">
+                        <Button>
+                          {customer.pathname && customer.pathname.length > 1 ? customer.pathname : customer.current_url}
+                        </Button>
+                      </a>
+                  )}
                   {!loading && !conversation && (
                     <Button
                       type="primary"


### PR DESCRIPTION
When the user is live, you still want to be able to got to the page the user is on:


### Screenshots
Current url in sidebar
<img width="402" alt="image" src="https://user-images.githubusercontent.com/25150192/100619796-ec82df00-331d-11eb-9cbe-66a709bf0041.png">

Current url at the top of the live sessions page
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/25150192/100619864-fefd1880-331d-11eb-82a4-73d8be38717b.png">
