### PR TITLE
Improvements to email validation and Customer.IO integration

### DIFF
--- a/lib/chat_api/emails/customer_io.ex
+++ b/lib/chat_api/emails/customer_io.ex
@@ -57,16 +57,28 @@ defmodule ChatApi.Emails.CustomerIO do
     end
   end
 
+  @spec format_user(Users.User.t(), binary(), integer()) :: map()
+  defp format_user(user, company_name, now) do
+    %{
+      # User fields
+      id: user.id,
+      email: user.email,
+      account_id: user.account_id,
+      role: user.role,
+      # Account fields
+      company_name: company_name,
+      # Timestamps
+      created_at: now,
+      updated_at: now
+    }
+  end
+
   @spec save_new_signup(Users.User.t(), binary()) :: boolean()
   defp save_new_signup(user, company_name) do
     now = :os.system_time(:seconds)
 
     with {:ok, _} <-
-           identify(user.id, %{
-             email: user.email,
-             created_at: now,
-             company_name: company_name
-           }),
+           identify(user.id, format_user(user, company_name, now)),
          {:ok, _} <- track(user.id, "sign_up", %{signed_up_at: now}) do
       Logger.debug("Successfully added user to customer.io")
 

--- a/lib/chat_api/emails/customer_io.ex
+++ b/lib/chat_api/emails/customer_io.ex
@@ -3,29 +3,49 @@ defmodule ChatApi.Emails.CustomerIO do
   A module to handle email automation with customer.io
   """
 
+  alias ChatApi.Users
   require Logger
 
   # TODO: how should we handled disabled/archived users?
 
   @spec handle_registration_event(any(), any()) :: boolean()
   def handle_registration_event(user, company_name) do
-    now = :os.system_time(:seconds)
+    case Users.validate_email(user) do
+      {:ok, %Users.User{has_valid_email: true} = user} ->
+        save_new_signup(user, company_name)
 
-    with {:ok, _} <-
-           Customerio.identify(user.id, %{
-             email: user.email,
-             created_at: now,
-             company_name: company_name
-           }),
-         {:ok, _} <- Customerio.track(user.id, "sign_up", %{signed_up_at: now}) do
-      Logger.debug("Successfully added user to customer.io")
-
-      true
-    else
-      error ->
-        Logger.error("Something went wrong with customer.io: #{inspect(error)}")
+      _ ->
+        Logger.warn("Unable to validate user's email. Skipping save to Customer IO.")
 
         false
+    end
+  end
+
+  @spec identify(any(), any()) :: {:error, Customerio.Error.t()} | {:ok, binary()}
+  def identify(user_id, attrs \\ %{}) do
+    if enabled?() do
+      Customerio.identify(user_id, attrs)
+    else
+      msg = "Would have identified user #{inspect(user_id)} with data: #{inspect(attrs)}"
+      Logger.info("[Customer IO] #{msg}")
+
+      {:ok, msg}
+    end
+  end
+
+  @spec track(any(), binary(), any()) :: {:error, Customerio.Error.t()} | {:ok, binary()}
+  def track(user_id, event, attrs \\ %{}) do
+    if enabled?() do
+      Customerio.track(user_id, event, attrs)
+    else
+      msg =
+        "Would have tracked event #{inspect(event)} " <>
+          "for user #{inspect(user_id)} " <>
+          "with data: #{inspect(attrs)}"
+
+      Logger.info("[Customer IO] #{msg}")
+
+      {:ok, msg}
     end
   end
 
@@ -34,6 +54,28 @@ defmodule ChatApi.Emails.CustomerIO do
     case System.get_env("CUSTOMER_IO_API_KEY") do
       key when is_binary(key) -> String.length(key) > 0
       _ -> false
+    end
+  end
+
+  @spec save_new_signup(Users.User.t(), binary()) :: boolean()
+  defp save_new_signup(user, company_name) do
+    now = :os.system_time(:seconds)
+
+    with {:ok, _} <-
+           identify(user.id, %{
+             email: user.email,
+             created_at: now,
+             company_name: company_name
+           }),
+         {:ok, _} <- track(user.id, "sign_up", %{signed_up_at: now}) do
+      Logger.debug("Successfully added user to customer.io")
+
+      true
+    else
+      error ->
+        Logger.error("Something went wrong with customer.io: #{inspect(error)}")
+
+        false
     end
   end
 end

--- a/lib/chat_api/emails/debounce.ex
+++ b/lib/chat_api/emails/debounce.ex
@@ -16,6 +16,8 @@ defmodule ChatApi.Emails.Debounce do
   plug Tesla.Middleware.JSON
   plug Tesla.Middleware.Logger
 
+  # TODO: update these methods to handle errors better (rather than using default values)
+
   @spec valid?(binary()) :: boolean()
   def valid?(email) do
     case validate(email) do

--- a/lib/chat_api/user_invitations.ex
+++ b/lib/chat_api/user_invitations.ex
@@ -145,7 +145,12 @@ defmodule ChatApi.UserInvitations do
       false
   """
   def expired?(%UserInvitation{} = user_invitation) do
-    DateTime.utc_now() |> DateTime.truncate(:second) >= user_invitation.expires_at
+    cmp =
+      DateTime.utc_now()
+      |> DateTime.truncate(:second)
+      |> DateTime.compare(user_invitation.expires_at)
+
+    cmp == :gt
   end
 
   defp set_expires_at(invitation) do

--- a/lib/chat_api/user_invitations.ex
+++ b/lib/chat_api/user_invitations.ex
@@ -145,12 +145,13 @@ defmodule ChatApi.UserInvitations do
       false
   """
   def expired?(%UserInvitation{} = user_invitation) do
-    cmp =
-      DateTime.utc_now()
-      |> DateTime.truncate(:second)
-      |> DateTime.compare(user_invitation.expires_at)
-
-    cmp == :gt
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.compare(user_invitation.expires_at)
+    |> case do
+      :lt -> false
+      _ -> true
+    end
   end
 
   defp set_expires_at(invitation) do

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -112,6 +112,14 @@ defmodule ChatApiWeb.RegistrationController do
 
   @spec send_registration_event(Conn.t(), String.t()) :: Conn.t()
   defp send_registration_event(conn, company_name) do
+    send_registration_event(conn, company_name, ChatApi.Emails.CustomerIO.enabled?())
+  end
+
+  @spec send_registration_event(Conn.t(), String.t(), boolean()) :: Conn.t()
+  # If CustomerIO is not enabled, just pass through
+  defp send_registration_event(conn, _company_name, false), do: conn
+
+  defp send_registration_event(conn, company_name, true) do
     case conn.assigns.current_user do
       %{email: _email, id: _id} = user ->
         # TODO: should we wrap this in a Task or GenServer process?

--- a/lib/mix/tasks/update_customer_io.ex
+++ b/lib/mix/tasks/update_customer_io.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.UpdateCustomerIo do
   def update_customer_io_users(users) do
     for user <- users do
       # TODO: only execute in production
-      case Customerio.identify(user.id, user) do
+      case ChatApi.Emails.CustomerIO.identify(user.id, user) do
         {:ok, _} -> Logger.info("Successfully updated user #{inspect(user.id)}")
         error -> Logger.error("Error updating user #{inspect(user.id)}: #{inspect(error)}")
       end

--- a/lib/mix/tasks/validate_user_emails.ex
+++ b/lib/mix/tasks/validate_user_emails.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.ValidateUserEmails do
 
   It also accepts as args a list of emails that are known to be valid.
 
-  Ex: $ mix example $(cat path/to/emails.csv)
+  Ex: $ mix validate_user_emails $(cat path/to/emails.csv)
   """
 
   def run(args) do


### PR DESCRIPTION
### Description

Validates email addresses with debounce.io before sending data to Customer.IO.

### Issue

Handles https://github.com/papercups-io/papercups/issues/428

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
