### PR TITLE
Limit number of users to account based on subscription plan

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
 } from './icons';
 import {BASE_URL, isDev, isHostedProd} from '../config';
 import analytics from '../analytics';
+import {hasValidStripeKey} from '../utils';
 import {useAuth} from './auth/AuthProvider';
 import AccountOverview from './account/AccountOverview';
 import UserProfile from './account/UserProfile';
@@ -47,18 +48,11 @@ import LiveSessionViewer from './sessions/LiveSessionViewer';
 import ReportingDashboard from './reporting/ReportingDashboard';
 
 const {
-  REACT_APP_STRIPE_PUBLIC_KEY,
   REACT_APP_STORYTIME_ENABLED,
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
 } = process.env;
 
 const TITLE_FLASH_INTERVAL = 2000;
-
-const hasValidStripeKey = () => {
-  const key = REACT_APP_STRIPE_PUBLIC_KEY;
-
-  return key && key.startsWith('pk_');
-};
 
 const shouldDisplayChat = (pathname: string) => {
   return isHostedProd && pathname !== '/account/getting-started';

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -330,7 +330,7 @@ class AccountOverview extends React.Component<Props, State> {
                   <Input
                     ref={(el) => (this.input = el)}
                     type="text"
-                    placeholder="Click the button to generate an invite URL!"
+                    placeholder="Click the button to generate an invite URL"
                     value={inviteUrl}
                   ></Input>
                 </Box>

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -17,7 +17,7 @@ import {WorkingHours} from './support';
 import * as API from '../../api';
 import {User} from '../../types';
 import {BASE_URL} from '../../config';
-import {sleep} from '../../utils';
+import {sleep, hasValidStripeKey} from '../../utils';
 import logger from '../../logger';
 
 type Props = {};
@@ -78,7 +78,23 @@ class AccountOverview extends React.Component<Props, State> {
         () => this.focusAndHighlightInput()
       );
     } catch (err) {
-      logger.error('Failed to generate user invitation URL:', err);
+      const hasServerErrorMessage = !!err?.response?.body?.error?.message;
+      const shouldDisplayBillingLink =
+        hasServerErrorMessage && hasValidStripeKey();
+      const description =
+        err?.response?.body?.error?.message || err?.message || String(err);
+
+      notification.error({
+        message: 'Failed to generate user invitation!',
+        description,
+        btn: shouldDisplayBillingLink ? (
+          <a href="/billing">
+            <Button type="primary" size="small">
+              Upgrade subscription
+            </Button>
+          </a>
+        ) : null,
+      });
     }
   };
 

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -16,7 +16,7 @@ import WorkingHoursSelector from './WorkingHoursSelector';
 import {WorkingHours} from './support';
 import * as API from '../../api';
 import {User} from '../../types';
-import {BASE_URL} from '../../config';
+import {FRONTEND_BASE_URL} from '../../config';
 import {sleep, hasValidStripeKey} from '../../utils';
 import logger from '../../logger';
 
@@ -73,7 +73,7 @@ class AccountOverview extends React.Component<Props, State> {
 
       this.setState(
         {
-          inviteUrl: `${BASE_URL}/register/${token}`,
+          inviteUrl: `${FRONTEND_BASE_URL}/register/${token}`,
         },
         () => this.focusAndHighlightInput()
       );

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -85,7 +85,9 @@ class AccountOverview extends React.Component<Props, State> {
         err?.response?.body?.error?.message || err?.message || String(err);
 
       notification.error({
-        message: 'Failed to generate user invitation!',
+        message: hasServerErrorMessage
+          ? 'Please upgrade to add more users!'
+          : 'Failed to generate user invitation!',
         description,
         duration: 10, // 10 seconds
         btn: (

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -87,13 +87,20 @@ class AccountOverview extends React.Component<Props, State> {
       notification.error({
         message: 'Failed to generate user invitation!',
         description,
-        btn: shouldDisplayBillingLink ? (
-          <a href="/billing">
+        duration: 10, // 10 seconds
+        btn: (
+          <a
+            href={
+              shouldDisplayBillingLink
+                ? '/billing'
+                : 'https://papercups.io/pricing'
+            }
+          >
             <Button type="primary" size="small">
               Upgrade subscription
             </Button>
           </a>
-        ) : null,
+        ),
       });
     }
   };

--- a/assets/src/components/account/GettingStartedOverview.tsx
+++ b/assets/src/components/account/GettingStartedOverview.tsx
@@ -8,7 +8,7 @@ import ChatWidget from '@papercups-io/chat-widget';
 import * as API from '../../api';
 import {User} from '../../types';
 import {Paragraph, Input, colors, Text, Title} from '../common';
-import {BASE_URL} from '../../config';
+import {BASE_URL, FRONTEND_BASE_URL} from '../../config';
 import logger from '../../logger';
 
 type Props = {};
@@ -147,7 +147,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
   type="text/javascript"
   async
   defer
-  src="${BASE_URL}/widget.js"
+  src="${FRONTEND_BASE_URL}/widget.js"
 ></script>
   `.trim();
   };

--- a/assets/src/config.ts
+++ b/assets/src/config.ts
@@ -12,10 +12,12 @@ export const isHostedProd = window.location.hostname === 'app.papercups.io';
 
 export const REACT_URL = process.env.REACT_APP_URL || 'app.papercups.io';
 
-// FIXME: sometimes we should be using localhost:3000
 export const BASE_URL = isDev
   ? 'http://localhost:4000'
   : `https://${REACT_URL}`;
+
+// In the dev environment, we use port 3000 and proxy API requests to 4000
+export const FRONTEND_BASE_URL = isDev ? 'http://localhost:3000' : BASE_URL;
 
 // Defaults to Papercups client ID (it's ok for this value to be public)
 export const SLACK_CLIENT_ID =

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -1,6 +1,14 @@
 import dayjs from 'dayjs';
 
+const {REACT_APP_STRIPE_PUBLIC_KEY} = process.env;
+
 export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export const hasValidStripeKey = () => {
+  const key = REACT_APP_STRIPE_PUBLIC_KEY;
+
+  return key && key.startsWith('pk_');
+};
 
 export const formatRelativeTime = (date: dayjs.Dayjs) => {
   const seconds = dayjs().diff(date, 'second');

--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -9,6 +9,8 @@ defmodule ChatApi.Accounts do
   alias ChatApi.Accounts.Account
   alias ChatApi.Users.User
 
+  @starter_plan_max_users 5
+
   @spec list_accounts() :: [Account.t()]
   @doc """
   Returns the list of accounts.
@@ -141,7 +143,7 @@ defmodule ChatApi.Accounts do
   @spec has_reached_user_capacity?(binary()) :: boolean()
   def has_reached_user_capacity?(account_id) do
     case get_subscription_plan!(account_id) do
-      "starter" -> count_active_users(account_id) >= 5
+      "starter" -> count_active_users(account_id) >= @starter_plan_max_users
       "team" -> false
       _ -> false
     end

--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -79,6 +79,14 @@ defmodule ChatApi.Accounts do
     |> Repo.update()
   end
 
+  @spec update_billing_info(Account.t(), map()) ::
+          {:ok, Account.t()} | {:error, Ecto.Changeset.t()}
+  def update_billing_info(%Account{} = account, attrs) do
+    account
+    |> Account.billing_details_changeset(attrs)
+    |> Repo.update()
+  end
+
   @spec delete_account(Account.t()) :: {:ok, Account.t()} | {:error, Ecto.Changeset.t()}
   @doc """
   Deletes a account.

--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -9,8 +9,6 @@ defmodule ChatApi.Accounts do
   alias ChatApi.Accounts.Account
   alias ChatApi.Users.User
 
-  @starter_plan_max_users 5
-
   @spec list_accounts() :: [Account.t()]
   @doc """
   Returns the list of accounts.
@@ -139,6 +137,8 @@ defmodule ChatApi.Accounts do
     |> Repo.one!()
     |> Map.get(:subscription_plan)
   end
+
+  @starter_plan_max_users 2
 
   @spec has_reached_user_capacity?(binary()) :: boolean()
   def has_reached_user_capacity?(account_id) do

--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -142,6 +142,17 @@ defmodule ChatApi.Accounts do
 
   @spec has_reached_user_capacity?(binary()) :: boolean()
   def has_reached_user_capacity?(account_id) do
+    # NB: if you're self-hosting, you can run the following to upgrade your account:
+    # ```
+    # $ mix set_subscription_plan [YOUR_ACCOUNT_TOKEN] team
+    # ```
+
+    # Or, on Heroku:
+    # ```
+    # $ heroku run "mix set_subscription_plan [YOUR_ACCOUNT_TOKEN] team"
+    # ```
+    #
+    # (These commands would update your account from the "starter" plan to the "team" plan.)
     case get_subscription_plan!(account_id) do
       "starter" -> count_active_users(account_id) >= @starter_plan_max_users
       "team" -> false

--- a/lib/chat_api/accounts/account.ex
+++ b/lib/chat_api/accounts/account.ex
@@ -37,15 +37,22 @@ defmodule ChatApi.Accounts.Account do
     account
     |> cast(attrs, [
       :company_name,
-      :time_zone,
+      :time_zone
+    ])
+    |> cast_embed(:working_hours, with: &working_hours_changeset/2)
+    |> validate_required([:company_name])
+  end
+
+  def billing_details_changeset(account, attrs) do
+    account
+    |> cast(attrs, [
       :subscription_plan,
       :stripe_customer_id,
       :stripe_subscription_id,
       :stripe_product_id,
       :stripe_default_payment_method_id
     ])
-    |> cast_embed(:working_hours, with: &working_hours_changeset/2)
-    |> validate_required([:company_name])
+    |> validate_required([:subscription_plan])
   end
 
   defp working_hours_changeset(schema, params) do

--- a/lib/chat_api/billing.ex
+++ b/lib/chat_api/billing.ex
@@ -117,7 +117,7 @@ defmodule ChatApi.Billing do
              items: items,
              trial_period_days: @trial_period_days
            }) do
-      Accounts.update_account(account, %{
+      Accounts.update_billing_info(account, %{
         stripe_subscription_id: subscription.id,
         stripe_product_id: product.id,
         subscription_plan: plan
@@ -143,7 +143,7 @@ defmodule ChatApi.Billing do
            Stripe.Subscription.update(account.stripe_subscription_id, %{
              items: new_items ++ items_to_delete
            }) do
-      Accounts.update_account(account, %{
+      Accounts.update_billing_info(account, %{
         stripe_subscription_id: subscription.id,
         stripe_product_id: product.id,
         subscription_plan: plan

--- a/lib/chat_api/stripe.ex
+++ b/lib/chat_api/stripe.ex
@@ -7,6 +7,14 @@ defmodule ChatApi.StripeClient do
   alias ChatApi.{Accounts, Repo}
   alias ChatApi.Accounts.Account
 
+  @spec enabled? :: boolean()
+  def enabled?() do
+    case System.get_env("PAPERCUPS_STRIPE_SECRET") do
+      "sk_" <> _rest -> true
+      _ -> false
+    end
+  end
+
   @spec add_payment_method(
           binary(),
           binary(),

--- a/lib/chat_api/stripe.ex
+++ b/lib/chat_api/stripe.ex
@@ -26,7 +26,7 @@ defmodule ChatApi.StripeClient do
 
     Account
     |> Repo.get!(account_id)
-    |> Accounts.update_account(%{stripe_default_payment_method_id: payment_method_id})
+    |> Accounts.update_billing_info(%{stripe_default_payment_method_id: payment_method_id})
 
     payment_method
   end
@@ -40,7 +40,7 @@ defmodule ChatApi.StripeClient do
       %{company_name: name, stripe_customer_id: nil} = account ->
         {:ok, customer} = Stripe.Customer.create(%{name: name, email: user.email})
         stripe_customer_id = customer.id
-        Accounts.update_account(account, %{stripe_customer_id: stripe_customer_id})
+        Accounts.update_billing_info(account, %{stripe_customer_id: stripe_customer_id})
 
         stripe_customer_id
 

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -23,7 +23,8 @@ defmodule ChatApiWeb.RegistrationController do
           send_server_error(
             conn,
             403,
-            "Your account has reached the capacity for its current subscription plan. Please contact your admin to upgrade the account."
+            "Your account has reached the capacity for its current subscription plan. " <>
+              "Please contact your admin to upgrade the account."
           )
 
         true ->

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -15,6 +15,37 @@ defmodule ChatApiWeb.RegistrationController do
       invite = ChatApi.UserInvitations.get_user_invitation!(user_params["invite_token"])
       params = Enum.into(user_params, %{"account_id" => invite.account.id})
 
+      cond do
+        ChatApi.UserInvitations.expired?(invite) ->
+          send_server_error(conn, 403, "Invitation token has expired")
+
+        ChatApi.Accounts.has_reached_user_capacity?(invite.account.id) ->
+          send_server_error(
+            conn,
+            403,
+            "Your account has reached the capacity for its current subscription plan. Please contact your admin to upgrade the account."
+          )
+
+        true ->
+          conn
+          |> Pow.Plug.create_user(params)
+          |> case do
+            {:ok, _user, conn} ->
+              # # TODO: figure out what we want to do here -- it's not currently
+              # # obvious that a user invitation expires after one use.
+              # ChatApi.UserInvitations.expire_user_invitation(invite)
+              conn
+              |> send_registration_event(invite.account.company_name)
+              |> enqueue_welcome_email()
+              |> notify_slack()
+              |> send_api_token()
+
+            {:error, changeset, conn} ->
+              errors = Changeset.traverse_errors(changeset, &ErrorHelpers.translate_error/1)
+              send_user_create_errors(conn, errors)
+          end
+      end
+
       if ChatApi.UserInvitations.expired?(invite) do
         send_server_error(conn, 403, "Invitation token has expired")
       else

--- a/lib/chat_api_web/controllers/user_invitation_controller.ex
+++ b/lib/chat_api_web/controllers/user_invitation_controller.ex
@@ -26,7 +26,9 @@ defmodule ChatApiWeb.UserInvitationController do
       |> json(%{
         error: %{
           status: 403,
-          message: "Please upgrade your subscription plan if you want to invite more users."
+          message:
+            "You've hit the user limit for our free tier. " <>
+              "Try the premium plan free for 30 days to invite more users to your account!"
         }
       })
     else

--- a/lib/mix/tasks/set_subscription_plan.ex
+++ b/lib/mix/tasks/set_subscription_plan.ex
@@ -1,0 +1,26 @@
+defmodule Mix.Tasks.SetSubscriptionPlan do
+  use Mix.Task
+
+  @shortdoc "Manually updates the subscription plan for the provided account"
+
+  @moduledoc """
+  This task handles setting the subscription plan for an account. For example,
+  we may automatically upgrade some of our beta users so they can continue to
+  use some of our premium features for free.
+  """
+
+  def run(args) do
+    Application.ensure_all_started(:chat_api)
+
+    case args do
+      [account_id, plan] when plan in ["starter", "team"] ->
+        account_id
+        |> ChatApi.Accounts.get_account!()
+        |> ChatApi.Accounts.update_billing_info(%{subscription_plan: plan})
+
+      _ ->
+        Mix.shell().info("Invalid args #{inspect(args)}")
+        Mix.shell().info("Please specify a valid account ID and subscription plan (starter/team)")
+    end
+  end
+end

--- a/lib/mix/tasks/set_subscription_plan.ex
+++ b/lib/mix/tasks/set_subscription_plan.ex
@@ -7,6 +7,18 @@ defmodule Mix.Tasks.SetSubscriptionPlan do
   This task handles setting the subscription plan for an account. For example,
   we may automatically upgrade some of our beta users so they can continue to
   use some of our premium features for free.
+
+  Example:
+  ```
+  $ mix set_subscription_plan [YOUR_ACCOUNT_TOKEN] team
+  ```
+
+  On Heroku:
+  ```
+  $ heroku run "mix set_subscription_plan [YOUR_ACCOUNT_TOKEN] team"
+  ```
+
+  (These commands would update your account from the "starter" plan to the "team" plan.)
   """
 
   def run(args) do

--- a/test/chat_api/accounts_test.exs
+++ b/test/chat_api/accounts_test.exs
@@ -41,9 +41,23 @@ defmodule ChatApi.AccountsTest do
       assert account.company_name == "some updated company_name"
     end
 
+    test "update_account/2 does not update billing information fields", %{account: account} do
+      assert {:ok, %Account{} = account} =
+               Accounts.update_account(account, %{subscription_plan: "team"})
+
+      assert account.subscription_plan != "team"
+    end
+
     test "update_account/2 with invalid data returns error changeset", %{account: account} do
       assert {:error, %Ecto.Changeset{}} = Accounts.update_account(account, @invalid_attrs)
       assert account == Accounts.get_account!(account.id)
+    end
+
+    test "update_billing_info/2 updates billing information fields", %{account: account} do
+      assert {:ok, %Account{} = account} =
+               Accounts.update_billing_info(account, %{subscription_plan: "team"})
+
+      assert account.subscription_plan == "team"
     end
 
     test "delete_account/1 deletes the account", %{account: account} do

--- a/test/chat_api/accounts_test.exs
+++ b/test/chat_api/accounts_test.exs
@@ -95,28 +95,28 @@ defmodule ChatApi.AccountsTest do
       assert 1 = Accounts.count_active_users(account.id)
     end
 
-    test "has_reached_user_capacity?/1 returns true for accounts on the 'starter' plan with >= 5 users",
+    test "has_reached_user_capacity?/1 returns true for accounts on the 'starter' plan with >= 2 users",
          %{
            account: account
          } do
       assert "starter" = Accounts.get_subscription_plan!(account.id)
       refute Accounts.has_reached_user_capacity?(account.id)
 
-      for _n <- 1..5 do
+      for _n <- 1..3 do
         user_fixture(account)
       end
 
       assert Accounts.has_reached_user_capacity?(account.id)
     end
 
-    test "has_reached_user_capacity?/1 returns false for accounts on the 'team' plan with >= 5 users",
+    test "has_reached_user_capacity?/1 returns false for accounts on the 'team' plan with >= 2 users",
          %{
            account: account
          } do
       Accounts.update_billing_info(account, %{subscription_plan: "team"})
       refute Accounts.has_reached_user_capacity?(account.id)
 
-      for _n <- 1..5 do
+      for _n <- 1..3 do
         user_fixture(account)
       end
 


### PR DESCRIPTION
### Description

This PR prevents accounts from exceeding the user limit of their subscription plan.

(We may need to grandfather in a few accounts that have already exceeded this limit)

### Issue

https://github.com/papercups-io/papercups/issues/444

Fixes: https://github.com/papercups-io/papercups/issues/443

### Screenshots

When new user tries to register, but the account has already reached its limit:
<img width="655" alt="Screen Shot 2020-12-04 at 2 47 08 PM" src="https://user-images.githubusercontent.com/5264279/101208485-421dfb00-3640-11eb-913e-b27f3cc5cf32.png">

When an admin users attempts to generate a new invite link after the account has reached its limit:
<img width="1093" alt="Screen Shot 2020-12-04 at 2 47 28 PM" src="https://user-images.githubusercontent.com/5264279/101208489-434f2800-3640-11eb-99c8-139c3d9b6a80.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
