### PR TITLE
specify the object type in json returns

### DIFF
--- a/lib/chat_api_web/views/browser_replay_event_view.ex
+++ b/lib/chat_api_web/views/browser_replay_event_view.ex
@@ -16,6 +16,7 @@ defmodule ChatApiWeb.BrowserReplayEventView do
   def render("browser_replay_event.json", %{browser_replay_event: browser_replay_event}) do
     %{
       id: browser_replay_event.id,
+      object: "browser_replay_event",
       account_id: browser_replay_event.account_id,
       event: browser_replay_event.event,
       timestamp: browser_replay_event.timestamp

--- a/lib/chat_api_web/views/browser_session_view.ex
+++ b/lib/chat_api_web/views/browser_session_view.ex
@@ -17,6 +17,7 @@ defmodule ChatApiWeb.BrowserSessionView do
   def render("basic.json", %{browser_session: browser_session}) do
     %{
       id: browser_session.id,
+      object: "browser_session",
       account_id: browser_session.account_id,
       customer_id: browser_session.customer_id,
       metadata: browser_session.metadata,
@@ -28,6 +29,7 @@ defmodule ChatApiWeb.BrowserSessionView do
   def render("preview.json", %{browser_session: browser_session}) do
     %{
       id: browser_session.id,
+      object: "browser_session",
       account_id: browser_session.account_id,
       customer_id: browser_session.customer_id,
       metadata: browser_session.metadata,
@@ -40,6 +42,7 @@ defmodule ChatApiWeb.BrowserSessionView do
   def render("expanded.json", %{browser_session: browser_session}) do
     %{
       id: browser_session.id,
+      object: "browser_session",
       account_id: browser_session.account_id,
       customer_id: browser_session.customer_id,
       metadata: browser_session.metadata,

--- a/lib/chat_api_web/views/conversation_view.ex
+++ b/lib/chat_api_web/views/conversation_view.ex
@@ -21,6 +21,7 @@ defmodule ChatApiWeb.ConversationView do
   def render("basic.json", %{conversation: conversation}) do
     %{
       id: conversation.id,
+      object: "conversation",
       created_at: conversation.inserted_at,
       status: conversation.status,
       read: conversation.read,
@@ -34,6 +35,7 @@ defmodule ChatApiWeb.ConversationView do
   def render("expanded.json", %{conversation: conversation}) do
     %{
       id: conversation.id,
+      object: "conversation",
       created_at: conversation.inserted_at,
       status: conversation.status,
       read: conversation.read,

--- a/lib/chat_api_web/views/customer_view.ex
+++ b/lib/chat_api_web/views/customer_view.ex
@@ -24,6 +24,7 @@ defmodule ChatApiWeb.CustomerView do
   def render("basic.json", %{customer: customer}) do
     %{
       id: customer.id,
+      object: "customer",
       name: customer.name,
       email: customer.email,
       created_at: customer.inserted_at,
@@ -42,6 +43,7 @@ defmodule ChatApiWeb.CustomerView do
   def render("customer.json", %{customer: customer}) do
     %{
       id: customer.id,
+      object: "customer",
       name: customer.name,
       email: customer.email,
       created_at: customer.inserted_at,

--- a/lib/chat_api_web/views/event_subscription_view.ex
+++ b/lib/chat_api_web/views/event_subscription_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.EventSubscriptionView do
   def render("event_subscription.json", %{event_subscription: event_subscription}) do
     %{
       id: event_subscription.id,
+      object: "event_subscription",
       created_at: event_subscription.inserted_at,
       updated_at: event_subscription.updated_at,
       webhook_url: event_subscription.webhook_url,

--- a/lib/chat_api_web/views/message_view.ex
+++ b/lib/chat_api_web/views/message_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.MessageView do
   def render("message.json", %{message: message}) do
     %{
       id: message.id,
+      object: "message",
       body: message.body,
       created_at: message.inserted_at,
       sent_at: message.sent_at,
@@ -27,6 +28,7 @@ defmodule ChatApiWeb.MessageView do
   def render("expanded.json", %{message: %{customer: %ChatApi.Customers.Customer{}} = message}) do
     %{
       id: message.id,
+      object: "message",
       body: message.body,
       created_at: message.inserted_at,
       sent_at: message.sent_at,
@@ -43,6 +45,7 @@ defmodule ChatApiWeb.MessageView do
   def render("expanded.json", %{message: message}) do
     %{
       id: message.id,
+      object: "message",
       body: message.body,
       created_at: message.inserted_at,
       sent_at: message.sent_at,

--- a/lib/chat_api_web/views/payment_method_view.ex
+++ b/lib/chat_api_web/views/payment_method_view.ex
@@ -9,6 +9,7 @@ defmodule ChatApiWeb.PaymentMethodView do
   def render("payment_method.json", %{payment_method: payment_method}) do
     %{
       id: payment_method.id,
+      object: "payment_method",
       customer: payment_method.customer,
       brand: payment_method.card.brand,
       country: payment_method.card.country,

--- a/lib/chat_api_web/views/personal_api_key_view.ex
+++ b/lib/chat_api_web/views/personal_api_key_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.PersonalApiKeyView do
   def render("personal_api_key.json", %{personal_api_key: personal_api_key}) do
     %{
       id: personal_api_key.id,
+      object: "personal_api_key",
       label: personal_api_key.label,
       value: personal_api_key.value,
       last_used_at: personal_api_key.last_used_at,

--- a/lib/chat_api_web/views/tag_view.ex
+++ b/lib/chat_api_web/views/tag_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.TagView do
   def render("tag.json", %{tag: tag}) do
     %{
       id: tag.id,
+      object: "tag",
       name: tag.name,
       description: tag.description,
       color: tag.color

--- a/lib/chat_api_web/views/user_settings_view.ex
+++ b/lib/chat_api_web/views/user_settings_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.UserSettingsView do
   def render("user_settings.json", %{user_settings: user_settings}) do
     %{
       id: user_settings.id,
+      object: "user_settings",
       user_id: user_settings.user_id,
       email_alert_on_new_message: user_settings.email_alert_on_new_message
     }

--- a/lib/chat_api_web/views/user_view.ex
+++ b/lib/chat_api_web/views/user_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.UserView do
       %{profile: %UserProfile{} = profile} ->
         %{
           id: user.id,
+          object: "user",
           email: user.email,
           created_at: user.inserted_at,
           disabled_at: user.disabled_at,
@@ -25,6 +26,7 @@ defmodule ChatApiWeb.UserView do
       _ ->
         %{
           id: user.id,
+          object: "user",
           email: user.email,
           created_at: user.inserted_at,
           disabled_at: user.disabled_at,

--- a/lib/chat_api_web/views/widget_settings_view.ex
+++ b/lib/chat_api_web/views/widget_settings_view.ex
@@ -13,6 +13,7 @@ defmodule ChatApiWeb.WidgetSettingsView do
   def render("basic.json", %{widget_settings: widget_settings}) do
     %{
       id: widget_settings.id,
+      object: "widget_settings",
       title: widget_settings.title,
       subtitle: widget_settings.subtitle,
       color: widget_settings.color,
@@ -24,6 +25,7 @@ defmodule ChatApiWeb.WidgetSettingsView do
 
   def render("expanded.json", %{widget_settings: widget_settings}) do
     %{
+      object: "widget_settings",
       title: widget_settings.title,
       subtitle: widget_settings.subtitle,
       color: widget_settings.color,

--- a/test/chat_api_web/controllers/browser_session_controller_test.exs
+++ b/test/chat_api_web/controllers/browser_session_controller_test.exs
@@ -52,6 +52,7 @@ defmodule ChatApiWeb.BrowserSessionControllerTest do
 
       assert %{
                "id" => ^id,
+               "object" => "browser_session",
                "finished_at" => "2010-04-17T14:00:00Z",
                "metadata" => %{},
                "started_at" => "2010-04-17T14:00:00Z"
@@ -84,6 +85,7 @@ defmodule ChatApiWeb.BrowserSessionControllerTest do
 
       assert %{
                "id" => ^id,
+               "object" => "browser_session",
                "finished_at" => "2011-05-18T15:01:01Z",
                "metadata" => %{},
                "started_at" => "2011-05-18T15:01:01Z"

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -54,6 +54,7 @@ defmodule ChatApiWeb.ConversationControllerTest do
 
       assert %{
                "id" => _id,
+               "object" => "conversation",
                "status" => "open"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -79,7 +79,8 @@ defmodule ChatApiWeb.CustomerControllerTest do
       resp = get(authed_conn, Routes.customer_path(authed_conn, :show, id))
 
       assert %{
-               "id" => _id
+               "id" => _id,
+               "object" => "customer"
              } = json_response(resp, 200)["data"]
     end
 

--- a/test/chat_api_web/controllers/event_subscription_controller_test.exs
+++ b/test/chat_api_web/controllers/event_subscription_controller_test.exs
@@ -52,6 +52,7 @@ defmodule ChatApiWeb.EventSubscriptionControllerTest do
 
       assert %{
                "id" => _id,
+               "object" => "event_subscription",
                "scope" => "some scope",
                "webhook_url" => "some webhook_url"
              } = json_response(resp, 200)["data"]

--- a/test/chat_api_web/controllers/message_controller_test.exs
+++ b/test/chat_api_web/controllers/message_controller_test.exs
@@ -61,6 +61,7 @@ defmodule ChatApiWeb.MessageControllerTest do
 
       assert %{
                "id" => _id,
+               "object" => "message",
                "body" => "some body"
              } = json_response(conn, 200)["data"]
     end

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -37,6 +37,7 @@ defmodule ChatApiWeb.TagControllerTest do
 
       assert %{
                "id" => _id,
+               "object" => "tag",
                "name" => "some name"
              } = json_response(resp, 200)["data"]
     end

--- a/test/chat_api_web/controllers/user_profile_controller_test.exs
+++ b/test/chat_api_web/controllers/user_profile_controller_test.exs
@@ -60,7 +60,7 @@ defmodule ChatApiWeb.UserProfileControllerTest do
       user_profile = Users.get_user_profile(user.id)
       resp = get(authed_conn, Routes.user_profile_path(authed_conn, :show, %{}))
 
-      assert %{"display_name" => display_name, "full_name" => full_name} =
+      assert %{"display_name" => display_name, "full_name" => full_name, "object" => "user"} =
                json_response(resp, 200)["data"]
 
       assert display_name == user_profile.display_name

--- a/test/chat_api_web/controllers/widget_settings_controller_test.exs
+++ b/test/chat_api_web/controllers/widget_settings_controller_test.exs
@@ -46,6 +46,7 @@ defmodule ChatApiWeb.WidgetSettingsControllerTest do
         })
 
       assert %{
+               "object" => "widget_settings",
                "title" => "Test title",
                "subtitle" => "Test subtitle",
                "color" => "Test color"
@@ -57,6 +58,7 @@ defmodule ChatApiWeb.WidgetSettingsControllerTest do
         })
 
       assert %{
+               "object" => "widget_settings",
                "title" => "Test title",
                "subtitle" => "Test subtitle",
                "color" => "Updated color"


### PR DESCRIPTION
### Description

this commit adds the object key to
- conversations
- tags
- widgets
- event_subscription
- message
- payment_method
- customer
- user
- user_settings
- browser_replay

### Issue
 
Fixes https://github.com/papercups-io/papercups/issues/453

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
