### PR TITLE
[Storytime] Make it clearer when customer is inactive/disconnected

### DIFF
--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -22,6 +22,7 @@ import {Storytime} from '@papercups-io/storytime';
 import ChatWidget from '@papercups-io/chat-widget';
 
 const {
+  REACT_APP_STORYTIME_ENABLED,
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
 } = process.env;
 
@@ -61,7 +62,7 @@ class Demo extends React.Component<Props, State> {
         // Not logged in, no big deal
       })
       .then(() => {
-        if (process.env.REACT_APP_STORYTIME_ENABLED) {
+        if (REACT_APP_STORYTIME_ENABLED) {
           this.storytime = Storytime.init({
             accountId: this.state.accountId,
             baseUrl: BASE_URL,


### PR DESCRIPTION
### Description

In the live session viewer, it's not always clear if the customer is inactive/disconnected. This PR adds a UI component indicating their current status more clearly.

### Screenshots

![storytime-status](https://user-images.githubusercontent.com/5264279/101836012-a5110580-3b0a-11eb-8eaf-5e95d0a4387a.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
