### PR TITLE
Set up Companies API v1

### DIFF
--- a/lib/chat_api/companies.ex
+++ b/lib/chat_api/companies.ex
@@ -1,0 +1,96 @@
+defmodule ChatApi.Companies do
+  @moduledoc """
+  The Companies context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.Companies.Company
+
+  @spec list_companies(binary()) :: [Company.t()]
+  def list_companies(account_id) do
+    Company |> where(account_id: ^account_id) |> Repo.all()
+  end
+
+  @doc """
+  Gets a single company.
+
+  Raises `Ecto.NoResultsError` if the Company does not exist.
+
+  ## Examples
+
+      iex> get_company!(123)
+      %Company{}
+
+      iex> get_company!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_company!(id), do: Repo.get!(Company, id)
+
+  @doc """
+  Creates a company.
+
+  ## Examples
+
+      iex> create_company(%{field: value})
+      {:ok, %Company{}}
+
+      iex> create_company(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_company(attrs \\ %{}) do
+    %Company{}
+    |> Company.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a company.
+
+  ## Examples
+
+      iex> update_company(company, %{field: new_value})
+      {:ok, %Company{}}
+
+      iex> update_company(company, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_company(%Company{} = company, attrs) do
+    company
+    |> Company.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a company.
+
+  ## Examples
+
+      iex> delete_company(company)
+      {:ok, %Company{}}
+
+      iex> delete_company(company)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_company(%Company{} = company) do
+    Repo.delete(company)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking company changes.
+
+  ## Examples
+
+      iex> change_company(company)
+      %Ecto.Changeset{data: %Company{}}
+
+  """
+  def change_company(%Company{} = company, attrs \\ %{}) do
+    Company.changeset(company, attrs)
+  end
+end

--- a/lib/chat_api/companies.ex
+++ b/lib/chat_api/companies.ex
@@ -13,83 +13,29 @@ defmodule ChatApi.Companies do
     Company |> where(account_id: ^account_id) |> Repo.all()
   end
 
-  @doc """
-  Gets a single company.
-
-  Raises `Ecto.NoResultsError` if the Company does not exist.
-
-  ## Examples
-
-      iex> get_company!(123)
-      %Company{}
-
-      iex> get_company!(456)
-      ** (Ecto.NoResultsError)
-
-  """
+  @spec get_company!(binary()) :: Company.t()
   def get_company!(id), do: Repo.get!(Company, id)
 
-  @doc """
-  Creates a company.
-
-  ## Examples
-
-      iex> create_company(%{field: value})
-      {:ok, %Company{}}
-
-      iex> create_company(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
+  @spec create_company(map()) :: {:ok, Company.t()} | {:error, Ecto.Changeset.t()}
   def create_company(attrs \\ %{}) do
     %Company{}
     |> Company.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a company.
-
-  ## Examples
-
-      iex> update_company(company, %{field: new_value})
-      {:ok, %Company{}}
-
-      iex> update_company(company, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
+  @spec update_company(Company.t(), map()) :: {:ok, Company.t()} | {:error, Ecto.Changeset.t()}
   def update_company(%Company{} = company, attrs) do
     company
     |> Company.changeset(attrs)
     |> Repo.update()
   end
 
-  @doc """
-  Deletes a company.
-
-  ## Examples
-
-      iex> delete_company(company)
-      {:ok, %Company{}}
-
-      iex> delete_company(company)
-      {:error, %Ecto.Changeset{}}
-
-  """
+  @spec delete_company(Company.t()) :: {:ok, Company.t()} | {:error, Ecto.Changeset.t()}
   def delete_company(%Company{} = company) do
     Repo.delete(company)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking company changes.
-
-  ## Examples
-
-      iex> change_company(company)
-      %Ecto.Changeset{data: %Company{}}
-
-  """
+  @spec change_company(Company.t(), map()) :: Ecto.Changeset.t()
   def change_company(%Company{} = company, attrs \\ %{}) do
     Company.changeset(company, attrs)
   end

--- a/lib/chat_api/companies/company.ex
+++ b/lib/chat_api/companies/company.ex
@@ -7,14 +7,14 @@ defmodule ChatApi.Companies.Company do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "companies" do
-    field :description, :string
-    field :external_id, :string
-    field :industry, :string
-    field :logo_image_url, :string
-    field :metadata, :map
-    field :name, :string
-    field :slack_channel_id, :string
-    field :website_url, :string
+    field(:description, :string)
+    field(:external_id, :string)
+    field(:industry, :string)
+    field(:logo_image_url, :string)
+    field(:metadata, :map)
+    field(:name, :string)
+    field(:slack_channel_id, :string)
+    field(:website_url, :string)
 
     belongs_to(:account, Account)
     has_many(:customers, Customer)

--- a/lib/chat_api/companies/company.ex
+++ b/lib/chat_api/companies/company.ex
@@ -1,0 +1,44 @@
+defmodule ChatApi.Companies.Company do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.{Accounts.Account, Customers.Customer}
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "companies" do
+    field :description, :string
+    field :external_id, :string
+    field :industry, :string
+    field :logo_image_url, :string
+    field :metadata, :map
+    field :name, :string
+    field :slack_channel_id, :string
+    field :website_url, :string
+
+    belongs_to(:account, Account)
+    has_many(:customers, Customer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(company, attrs) do
+    company
+    |> cast(attrs, [
+      :name,
+      :account_id,
+      :external_id,
+      :website_url,
+      :description,
+      :logo_image_url,
+      :industry,
+      :slack_channel_id,
+      :metadata
+    ])
+    |> validate_required([
+      :name,
+      :account_id
+    ])
+  end
+end

--- a/lib/chat_api/companies/company.ex
+++ b/lib/chat_api/companies/company.ex
@@ -7,14 +7,14 @@ defmodule ChatApi.Companies.Company do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "companies" do
+    field(:name, :string)
     field(:description, :string)
     field(:external_id, :string)
+    field(:website_url, :string)
     field(:industry, :string)
     field(:logo_image_url, :string)
-    field(:metadata, :map)
-    field(:name, :string)
     field(:slack_channel_id, :string)
-    field(:website_url, :string)
+    field(:metadata, :map)
 
     belongs_to(:account, Account)
     has_many(:customers, Customer)
@@ -27,10 +27,10 @@ defmodule ChatApi.Companies.Company do
     company
     |> cast(attrs, [
       :name,
+      :description,
       :account_id,
       :external_id,
       :website_url,
-      :description,
       :logo_image_url,
       :industry,
       :slack_channel_id,

--- a/lib/chat_api/customers/customer.ex
+++ b/lib/chat_api/customers/customer.ex
@@ -4,6 +4,7 @@ defmodule ChatApi.Customers.Customer do
 
   alias ChatApi.{
     Accounts.Account,
+    Companies.Company,
     Conversations.Conversation,
     Messages.Message,
     Notes.Note,
@@ -42,6 +43,7 @@ defmodule ChatApi.Customers.Customer do
     has_many(:conversations, Conversation)
     has_many(:notes, Note)
     belongs_to(:account, Account)
+    belongs_to(:company, Company)
 
     has_many(:customer_tags, CustomerTag)
     has_many(:tags, through: [:customer_tags, :tag])

--- a/lib/chat_api_web/controllers/company_controller.ex
+++ b/lib/chat_api_web/controllers/company_controller.ex
@@ -6,6 +6,7 @@ defmodule ChatApiWeb.CompanyController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
       companies = Companies.list_companies(account_id)
@@ -13,8 +14,13 @@ defmodule ChatApiWeb.CompanyController do
     end
   end
 
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, %{"company" => company_params}) do
-    with {:ok, %Company{} = company} <- Companies.create_company(company_params) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         {:ok, %Company{} = company} <-
+           company_params
+           |> Map.merge(%{"account_id" => account_id})
+           |> Companies.create_company() do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.company_path(conn, :show, company))
@@ -22,11 +28,13 @@ defmodule ChatApiWeb.CompanyController do
     end
   end
 
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     company = Companies.get_company!(id)
     render(conn, "show.json", company: company)
   end
 
+  @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "company" => company_params}) do
     company = Companies.get_company!(id)
 
@@ -35,6 +43,7 @@ defmodule ChatApiWeb.CompanyController do
     end
   end
 
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     company = Companies.get_company!(id)
 

--- a/lib/chat_api_web/controllers/company_controller.ex
+++ b/lib/chat_api_web/controllers/company_controller.ex
@@ -1,0 +1,45 @@
+defmodule ChatApiWeb.CompanyController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.Companies
+  alias ChatApi.Companies.Company
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(conn, _params) do
+    with %{account_id: account_id} <- conn.assigns.current_user do
+      companies = Companies.list_companies(account_id)
+      render(conn, "index.json", companies: companies)
+    end
+  end
+
+  def create(conn, %{"company" => company_params}) do
+    with {:ok, %Company{} = company} <- Companies.create_company(company_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.company_path(conn, :show, company))
+      |> render("show.json", company: company)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    company = Companies.get_company!(id)
+    render(conn, "show.json", company: company)
+  end
+
+  def update(conn, %{"id" => id, "company" => company_params}) do
+    company = Companies.get_company!(id)
+
+    with {:ok, %Company{} = company} <- Companies.update_company(company, company_params) do
+      render(conn, "show.json", company: company)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    company = Companies.get_company!(id)
+
+    with {:ok, %Company{}} <- Companies.delete_company(company) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -100,6 +100,7 @@ defmodule ChatApiWeb.Router do
     resources("/accounts", AccountController, only: [:update, :delete])
     resources("/messages", MessageController, except: [:new, :edit])
     resources("/conversations", ConversationController, except: [:new, :edit, :create])
+    resources("/companies", CompanyController, except: [:new, :edit])
     resources("/customers", CustomerController, except: [:new, :edit, :create])
     resources("/notes", NoteController, except: [:new, :edit])
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])

--- a/lib/chat_api_web/views/company_view.ex
+++ b/lib/chat_api_web/views/company_view.ex
@@ -17,6 +17,7 @@ defmodule ChatApiWeb.CompanyView do
       name: company.name,
       created_at: company.inserted_at,
       updated_at: company.updated_at,
+      account_id: company.account_id,
       external_id: company.external_id,
       website_url: company.website_url,
       description: company.description,

--- a/lib/chat_api_web/views/company_view.ex
+++ b/lib/chat_api_web/views/company_view.ex
@@ -1,0 +1,29 @@
+defmodule ChatApiWeb.CompanyView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.CompanyView
+
+  def render("index.json", %{companies: companies}) do
+    %{data: render_many(companies, CompanyView, "company.json")}
+  end
+
+  def render("show.json", %{company: company}) do
+    %{data: render_one(company, CompanyView, "company.json")}
+  end
+
+  def render("company.json", %{company: company}) do
+    %{
+      id: company.id,
+      object: "company",
+      name: company.name,
+      created_at: company.inserted_at,
+      updated_at: company.updated_at,
+      external_id: company.external_id,
+      website_url: company.website_url,
+      description: company.description,
+      logo_image_url: company.logo_image_url,
+      industry: company.industry,
+      slack_channel_id: company.slack_channel_id,
+      metadata: company.metadata
+    }
+  end
+end

--- a/priv/repo/migrations/20201222023551_create_companies.exs
+++ b/priv/repo/migrations/20201222023551_create_companies.exs
@@ -1,0 +1,29 @@
+defmodule ChatApi.Repo.Migrations.CreateCompanies do
+  use Ecto.Migration
+
+  def change do
+    create table(:companies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :external_id, :string
+      add :website_url, :string
+      add :description, :string
+      add :logo_image_url, :string
+      add :industry, :string
+      add :slack_channel_id, :string
+      add :metadata, :map
+
+      add :account_id, references(:accounts, on_delete: :delete_all, type: :binary_id),
+        null: false
+
+      timestamps()
+    end
+
+    alter table(:customers) do
+      add :company_id, references(:companies, on_delete: :nothing, type: :binary_id)
+    end
+
+    create index(:companies, [:account_id])
+    create index(:customers, [:company_id])
+  end
+end

--- a/test/chat_api/companies_test.exs
+++ b/test/chat_api/companies_test.exs
@@ -1,0 +1,91 @@
+defmodule ChatApi.CompaniesTest do
+  use ChatApi.DataCase, async: true
+
+  import ChatApi.Factory
+  alias ChatApi.Companies
+
+  describe "companies" do
+    alias ChatApi.Companies.Company
+
+    @update_attrs %{
+      description: "some updated description",
+      external_id: "some updated external_id",
+      industry: "some updated industry",
+      logo_image_url: "some updated logo_image_url",
+      metadata: %{},
+      name: "some updated name",
+      slack_channel_id: "some updated slack_channel_id",
+      website_url: "some updated website_url"
+    }
+    @invalid_attrs %{
+      description: nil,
+      external_id: nil,
+      industry: nil,
+      logo_image_url: nil,
+      metadata: nil,
+      name: nil,
+      slack_channel_id: nil,
+      website_url: nil
+    }
+
+    setup do
+      account = insert(:account)
+      company = insert(:company, account: account)
+
+      {:ok, account: account, company: company}
+    end
+
+    test "list_companies/1 returns all companies", %{account: account, company: company} do
+      company_ids =
+        Companies.list_companies(account.id)
+        |> Enum.map(& &1.id)
+
+      assert company_ids == [company.id]
+    end
+
+    test "get_company!/1 returns the company with given id", %{company: company} do
+      found_company =
+        Companies.get_company!(company.id)
+        |> Repo.preload([:account])
+
+      assert found_company == company
+    end
+
+    test "create_company/1 with valid data creates a company", %{account: account} do
+      attrs = params_with_assocs(:company, account: account, name: "Test Co")
+
+      assert {:ok, %Company{name: "Test Co"}} = Companies.create_company(attrs)
+    end
+
+    test "create_company/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Companies.create_company(@invalid_attrs)
+    end
+
+    test "update_company/2 with valid data updates the company", %{company: company} do
+      assert {:ok, %Company{} = company} = Companies.update_company(company, @update_attrs)
+
+      assert company.description == "some updated description"
+      assert company.external_id == "some updated external_id"
+      assert company.industry == "some updated industry"
+      assert company.logo_image_url == "some updated logo_image_url"
+      assert company.name == "some updated name"
+      assert company.slack_channel_id == "some updated slack_channel_id"
+      assert company.website_url == "some updated website_url"
+      assert company.metadata == %{}
+    end
+
+    test "update_company/2 with invalid data returns error changeset", %{company: company} do
+      assert {:error, %Ecto.Changeset{}} = Companies.update_company(company, @invalid_attrs)
+      assert company == Companies.get_company!(company.id) |> Repo.preload([:account])
+    end
+
+    test "delete_company/1 deletes the company", %{company: company} do
+      assert {:ok, %Company{}} = Companies.delete_company(company)
+      assert_raise Ecto.NoResultsError, fn -> Companies.get_company!(company.id) end
+    end
+
+    test "change_company/1 returns a company changeset", %{company: company} do
+      assert %Ecto.Changeset{} = Companies.change_company(company)
+    end
+  end
+end

--- a/test/chat_api_web/controllers/company_controller_test.exs
+++ b/test/chat_api_web/controllers/company_controller_test.exs
@@ -1,0 +1,121 @@
+defmodule ChatApiWeb.CompanyControllerTest do
+  use ChatApiWeb.ConnCase, async: true
+  import ChatApi.Factory
+  alias ChatApi.Companies.Company
+
+  @update_attrs %{
+    description: "some updated description",
+    external_id: "some updated external_id",
+    industry: "some updated industry",
+    logo_image_url: "some updated logo_image_url",
+    metadata: %{},
+    name: "some updated name",
+    slack_channel_id: "some updated slack_channel_id",
+    website_url: "some updated website_url"
+  }
+  @invalid_attrs %{
+    description: nil,
+    external_id: nil,
+    industry: nil,
+    logo_image_url: nil,
+    metadata: nil,
+    name: nil,
+    slack_channel_id: nil,
+    website_url: nil
+  }
+
+  setup %{conn: conn} do
+    account = insert(:account)
+    user = insert(:user, account: account)
+    company = insert(:company, account: account)
+
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account, company: company}
+  end
+
+  describe "index" do
+    test "lists all companies", %{authed_conn: authed_conn, company: company} do
+      resp = get(authed_conn, Routes.company_path(authed_conn, :index))
+      ids = json_response(resp, 200)["data"] |> Enum.map(& &1["id"])
+
+      assert ids == [company.id]
+    end
+  end
+
+  describe "create company" do
+    test "renders company when data is valid", %{
+      authed_conn: authed_conn,
+      account: account
+    } do
+      resp =
+        post(authed_conn, Routes.company_path(authed_conn, :create),
+          company: params_for(:company, account: account, name: "Test Co")
+        )
+
+      assert %{"id" => id} = json_response(resp, 201)["data"]
+
+      resp = get(authed_conn, Routes.company_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => _id,
+               "object" => "company",
+               "name" => "Test Co"
+             } = json_response(resp, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      conn = post(authed_conn, Routes.company_path(authed_conn, :create), company: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update company" do
+    test "renders company when data is valid", %{
+      authed_conn: authed_conn,
+      company: %Company{id: id} = company
+    } do
+      conn =
+        put(authed_conn, Routes.company_path(authed_conn, :update, company),
+          company: @update_attrs
+        )
+
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.company_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "description" => "some updated description",
+               "external_id" => "some updated external_id",
+               "industry" => "some updated industry",
+               "logo_image_url" => "some updated logo_image_url",
+               "metadata" => %{},
+               "name" => "some updated name",
+               "slack_channel_id" => "some updated slack_channel_id",
+               "website_url" => "some updated website_url"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn, company: company} do
+      conn =
+        put(authed_conn, Routes.company_path(authed_conn, :update, company),
+          company: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete company" do
+    test "deletes chosen company", %{authed_conn: authed_conn, company: company} do
+      conn = delete(authed_conn, Routes.company_path(authed_conn, :delete, company))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(authed_conn, Routes.company_path(authed_conn, :show, company))
+      end
+    end
+  end
+end

--- a/test/chat_api_web/controllers/company_controller_test.exs
+++ b/test/chat_api_web/controllers/company_controller_test.exs
@@ -57,9 +57,11 @@ defmodule ChatApiWeb.CompanyControllerTest do
       assert %{"id" => id} = json_response(resp, 201)["data"]
 
       resp = get(authed_conn, Routes.company_path(authed_conn, :show, id))
+      account_id = account.id
 
       assert %{
-               "id" => _id,
+               "id" => ^id,
+               "account_id" => ^account_id,
                "object" => "company",
                "name" => "Test Co"
              } = json_response(resp, 200)["data"]

--- a/test/chat_api_web/controllers/company_controller_test.exs
+++ b/test/chat_api_web/controllers/company_controller_test.exs
@@ -86,17 +86,19 @@ defmodule ChatApiWeb.CompanyControllerTest do
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
       conn = get(authed_conn, Routes.company_path(authed_conn, :show, id))
+      account_id = company.account_id
 
       assert %{
-               "id" => id,
+               "id" => ^id,
+               "account_id" => ^account_id,
+               "name" => "some updated name",
                "description" => "some updated description",
                "external_id" => "some updated external_id",
                "industry" => "some updated industry",
                "logo_image_url" => "some updated logo_image_url",
-               "metadata" => %{},
-               "name" => "some updated name",
+               "website_url" => "some updated website_url",
                "slack_channel_id" => "some updated slack_channel_id",
-               "website_url" => "some updated website_url"
+               "metadata" => %{}
              } = json_response(conn, 200)["data"]
     end
 

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -29,16 +29,14 @@ defmodule ChatApiWeb.CustomerControllerTest do
   end
 
   describe "index" do
-    test "lists all customers",
-         %{authed_conn: authed_conn, customer: customer} do
+    test "lists all customers", %{authed_conn: authed_conn, customer: customer} do
       resp = get(authed_conn, Routes.customer_path(authed_conn, :index))
       ids = json_response(resp, 200)["data"] |> Enum.map(& &1["id"])
 
       assert ids == [customer.id]
     end
 
-    test "lists all customers in csv format",
-         %{authed_conn: authed_conn, customer: customer} do
+    test "lists all customers in csv format", %{authed_conn: authed_conn, customer: customer} do
       resp = get(authed_conn, Routes.customer_path(authed_conn, :index) <> "?format=csv")
       csv = response(resp, 200)
 
@@ -62,8 +60,11 @@ defmodule ChatApiWeb.CustomerControllerTest do
   end
 
   describe "create customer" do
-    test "renders customer when data is valid",
-         %{conn: conn, authed_conn: authed_conn, account: account} do
+    test "renders customer when data is valid", %{
+      conn: conn,
+      authed_conn: authed_conn,
+      account: account
+    } do
       resp =
         post(conn, Routes.customer_path(conn, :create),
           customer: params_for(:customer, account: account)
@@ -79,16 +80,14 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
 
-    test "ensures external_id is a string",
-         %{conn: conn, account: account} do
+    test "ensures external_id is a string", %{conn: conn, account: account} do
       customer = params_for(:customer, account: account, external_id: 123)
       resp = post(conn, Routes.customer_path(conn, :create), customer: customer)
 
       assert %{"external_id" => "123"} = json_response(resp, 201)["data"]
     end
 
-    test "truncates current_url if it is too long",
-         %{conn: conn, account: account} do
+    test "truncates current_url if it is too long", %{conn: conn, account: account} do
       current_url =
         "http://example.com/login?next=/insights%3Finsight%3DTRENDS%26interval%3Dday%26events%3D%255B%257B%2522id%2522%253A%2522%2524pageview%2522%252C%2522name%2522%253A%2522%2524pageview%2522%252C%2522type%2522%253A%2522events%2522%252C%2522order%2522%253A0%252C%2522math%2522%253A%2522total%2522%257D%255D%26display%3DActionsTable%26actions%3D%255B%255D%26new_entity%3D%255B%255D%26breakdown%3D%2524browser%26breakdown_type%3Devent%26properties%3D%255B%255D"
 
@@ -133,8 +132,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
   end
 
   describe "delete customer" do
-    test "deletes chosen customer",
-         %{authed_conn: authed_conn, customer: customer} do
+    test "deletes chosen customer", %{authed_conn: authed_conn, customer: customer} do
       resp =
         delete(
           authed_conn,
@@ -229,8 +227,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
   end
 
   describe "identifies a customer by external_id" do
-    test "finds the correct customer",
-         %{conn: conn, account: account} do
+    test "finds the correct customer", %{conn: conn, account: account} do
       external_id = "cus_123"
       customer = insert(:customer, account: account, external_id: external_id)
       %{id: customer_id, account_id: account_id} = customer
@@ -246,8 +243,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
 
-    test "returns nil if no match is found",
-         %{conn: conn, account: account} do
+    test "returns nil if no match is found", %{conn: conn, account: account} do
       customer = insert(:customer, account: account, external_id: "cus_123")
       %{id: _customer_id, account_id: account_id} = customer
 
@@ -262,8 +258,7 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
 
-    test "returns the most recent match if multiple exist",
-         %{conn: conn} do
+    test "returns the most recent match if multiple exist", %{conn: conn} do
       external_id = "cus_123"
       acc_1 = insert(:account)
       insert(:customer, account: acc_1, external_id: external_id)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -33,6 +33,13 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def company_factory do
+    %ChatApi.Companies.Company{
+      account: build(:account),
+      name: "Test Inc"
+    }
+  end
+
   def conversation_factory do
     %ChatApi.Conversations.Conversation{
       account: build(:account),


### PR DESCRIPTION
### Description

Sets up boilerplate for `/api/companies` for use in the dashboard.

The goal of the `Company` model is to allow us to group `Customer`s by account/company, which is important context for our B2B users.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/485

### Screenshots

N/A

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
