### PR TITLE
Company UI improvements

### DIFF
--- a/assets/src/components/companies/CompaniesPage.tsx
+++ b/assets/src/components/companies/CompaniesPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Button, Table, Title} from '../common';
+import {Alert, Button, Paragraph, Table, Text, Title} from '../common';
 import * as API from '../../api';
 import logger from '../../logger';
 
@@ -108,6 +108,23 @@ class CompaniesPage extends React.Component<Props, State> {
             <Button type="primary">New company</Button>
           </Link>
         </Flex>
+
+        <Box mb={4}>
+          <Paragraph>
+            View or create companies to group and manage your customers.
+          </Paragraph>
+
+          <Alert
+            message={
+              <Text>
+                This page is still a work in progress &mdash; more features
+                coming soon!
+              </Text>
+            }
+            type="info"
+            showIcon
+          />
+        </Box>
 
         <Box my={4}>
           <CompaniesTable loading={loading} companies={companies} />

--- a/assets/src/components/companies/CompanyDetailsPage.tsx
+++ b/assets/src/components/companies/CompanyDetailsPage.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {
-  Button,
-  Divider,
-  Paragraph,
-  Popconfirm,
-  Result,
-  Text,
-  Title,
-} from '../common';
+import {colors, Button, Popconfirm, Result, Text, Title} from '../common';
 import {ArrowLeftOutlined} from '../icons';
 import * as API from '../../api';
 import {sleep} from '../../utils';
@@ -19,6 +11,22 @@ import CustomersTable from '../customers/CustomersTable';
 
 const formatSlackChannel = (name: string) => {
   return name.startsWith('#') ? name : `#${name}`;
+};
+
+const DetailsSectionCard = ({children}: {children: any}) => {
+  return (
+    <Box
+      p={3}
+      mb={3}
+      sx={{
+        bg: colors.white,
+        border: '1px solid rgba(0,0,0,.06)',
+        borderRadius: 4,
+      }}
+    >
+      {children}
+    </Box>
+  );
 };
 
 type Props = RouteComponentProps<{id: string}>;
@@ -107,12 +115,16 @@ class CompanyDetailsPage extends React.Component<Props, State> {
       name,
       description,
       website_url: websiteUrl,
+      external_id: externalId,
       slack_channel_id: slackChannelId,
       slack_channel_name: slackChannelName,
     } = company;
 
     return (
-      <Box p={4}>
+      <Flex
+        p={4}
+        sx={{flexDirection: 'column', flex: 1, bg: 'rgb(245, 245, 245)'}}
+      >
         <Flex
           mb={4}
           sx={{justifyContent: 'space-between', alignItems: 'center'}}
@@ -136,58 +148,92 @@ class CompanyDetailsPage extends React.Component<Props, State> {
           )}
         </Flex>
 
-        <Title level={3}>{name}</Title>
+        <Title level={2}>{name}</Title>
 
-        {description && <Paragraph>{description}</Paragraph>}
+        <Flex>
+          <Box sx={{flex: 1, pr: 4}}>
+            <DetailsSectionCard>
+              <Box mb={3}>
+                <Box>
+                  <Text strong>Description</Text>
+                </Box>
 
-        <Box mb={2}>
-          <Box>
-            <Text strong>Website</Text>
-          </Box>
+                <Text>{description || 'N/A'}</Text>
+              </Box>
 
-          <Paragraph>
-            {websiteUrl ? (
-              <a href={websiteUrl} target="_blank" rel="noopener noreferrer">
-                {websiteUrl}
-              </a>
-            ) : (
-              'N/A'
+              <Box mb={3}>
+                <Box>
+                  <Text strong>Website</Text>
+                </Box>
+
+                <Text>
+                  {websiteUrl ? (
+                    <a
+                      href={websiteUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {websiteUrl}
+                    </a>
+                  ) : (
+                    'N/A'
+                  )}
+                </Text>
+              </Box>
+
+              <Box>
+                <Box>
+                  <Text strong>ID</Text>
+                </Box>
+
+                <Text>{externalId || 'N/A'}</Text>
+              </Box>
+            </DetailsSectionCard>
+
+            {slackChannelId && slackChannelName && (
+              <DetailsSectionCard>
+                <Box>
+                  <Text strong>Connected Slack Channel</Text>
+                </Box>
+
+                <Text>
+                  {/* TODO: include Slack team ID if necessary */}
+                  <a
+                    href={`https://slack.com/app_redirect?channel=${slackChannelId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {formatSlackChannel(slackChannelName)}
+                  </a>
+                </Text>
+              </DetailsSectionCard>
             )}
-          </Paragraph>
-        </Box>
 
-        {slackChannelId && slackChannelName && (
-          <Box mb={2}>
-            <Box>
-              <Text strong>Connected Slack Channel</Text>
-            </Box>
+            <DetailsSectionCard>
+              <Box>
+                <Text strong>Metadata</Text>
+              </Box>
 
-            <Paragraph>
-              {/* TODO: include Slack team ID if necessary */}
-              <a
-                href={`https://slack.com/app_redirect?channel=${slackChannelId}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {formatSlackChannel(slackChannelName)}
-              </a>
-            </Paragraph>
+              <Text>{'N/A'}</Text>
+            </DetailsSectionCard>
           </Box>
-        )}
 
-        <Divider />
+          <Box sx={{flex: 3}}>
+            <DetailsSectionCard>
+              <Box pb={2} sx={{borderBottom: '1px solid rgba(0,0,0,.06)'}}>
+                <Title level={4}>People</Title>
+              </Box>
 
-        <Title level={4}>People</Title>
-
-        <Box my={3}>
-          <CustomersTable
-            loading={loading || refreshing}
-            customers={customers}
-            currentlyOnline={{}}
-            onUpdate={this.handleRefreshCustomers}
-          />
-        </Box>
-      </Box>
+              <CustomersTable
+                loading={loading || refreshing}
+                customers={customers}
+                currentlyOnline={{}}
+                onUpdate={this.handleRefreshCustomers}
+              />
+            </DetailsSectionCard>
+          </Box>
+        </Flex>
+      </Flex>
     );
   }
 }

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -106,6 +106,7 @@ defmodule ChatApi.Slack.Helpers do
   @spec format_sender_id!(any(), binary(), binary()) :: map()
   def format_sender_id!(authorization, slack_user_id, slack_channel_id) do
     # TODO: what's the best way to handle these nested `case` statements?
+    # TODO: handle updating the customer's company_id if it's not set yet?
     case find_matching_user(authorization, slack_user_id) do
       %{id: user_id} ->
         %{"user_id" => user_id}

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -212,6 +212,7 @@ defmodule ChatApiWeb.SlackController do
              type: "support"
            }),
          :ok <- validate_channel_supported(authorization, slack_channel_id),
+         # TODO: handle updating the customer's company_id if it's not set yet
          {:ok, customer} <-
            Slack.Helpers.find_or_create_customer_from_slack_user_id(
              authorization,


### PR DESCRIPTION
### Description

Minor company UI improvements

### Screenshots

**Before:**
<img width="1757" alt="Screen Shot 2020-12-30 at 6 35 29 PM" src="https://user-images.githubusercontent.com/5264279/103391389-462a2500-4ae7-11eb-9a84-e5c54c458b65.png">

**After:**
<img width="1757" alt="Screen Shot 2020-12-30 at 6 36 29 PM" src="https://user-images.githubusercontent.com/5264279/103391399-5a6e2200-4ae7-11eb-8cab-2ce741a0216b.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
