### PR TITLE
Handle auto-assigning first responder in Slack

### DIFF
--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -56,6 +56,16 @@ export const colors = {
   note: '#feedaf',
 };
 
+export const shadows = {
+  primary:
+    '0 0 #0000, 0 0 #0000, 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+  small: '0 0 #0000, 0 0 #0000, 0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+  medium:
+    '0 0 #0000, 0 0 #0000, 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+  large:
+    '0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+};
+
 export const TextArea = Input.TextArea;
 
 /* Whitelist node types that we allow when we render markdown.

--- a/assets/src/components/companies/CompanyDetailsPage.tsx
+++ b/assets/src/components/companies/CompanyDetailsPage.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {colors, Button, Popconfirm, Result, Text, Title} from '../common';
+import {
+  colors,
+  shadows,
+  Button,
+  Popconfirm,
+  Result,
+  Text,
+  Title,
+} from '../common';
 import {ArrowLeftOutlined} from '../icons';
 import * as API from '../../api';
 import {sleep} from '../../utils';
@@ -22,6 +30,7 @@ const DetailsSectionCard = ({children}: {children: any}) => {
         bg: colors.white,
         border: '1px solid rgba(0,0,0,.06)',
         borderRadius: 4,
+        boxShadow: shadows.medium,
       }}
     >
       {children}
@@ -123,7 +132,11 @@ class CompanyDetailsPage extends React.Component<Props, State> {
     return (
       <Flex
         p={4}
-        sx={{flexDirection: 'column', flex: 1, bg: 'rgb(245, 245, 245)'}}
+        sx={{
+          flexDirection: 'column',
+          flex: 1,
+          bg: 'rgb(245, 245, 245)',
+        }}
       >
         <Flex
           mb={4}

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -23,7 +23,7 @@ defmodule ChatApi.Messages.Helpers do
   def handle_post_creation_conversation_updates(%Message{} = message) do
     message
     |> build_conversation_updates()
-    |> update_and_broadcast_to_admin(message)
+    |> update_conversation_and_broadcast_to_admin(message)
 
     message
   end
@@ -59,8 +59,8 @@ defmodule ChatApi.Messages.Helpers do
     end
   end
 
-  @spec update_and_broadcast_to_admin(map(), Message.t()) :: any()
-  defp update_and_broadcast_to_admin(
+  @spec update_conversation_and_broadcast_to_admin(map(), Message.t()) :: any()
+  defp update_conversation_and_broadcast_to_admin(
          updates,
          %Message{
            account_id: account_id,

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -3,6 +3,7 @@ defmodule ChatApi.Messages.Helpers do
   Helpers for Messages context
   """
 
+  alias ChatApi.Conversations
   alias ChatApi.Messages.Message
 
   @spec get_conversation_topic(Message.t()) :: binary()
@@ -17,4 +18,64 @@ defmodule ChatApi.Messages.Helpers do
   def get_message_type(%Message{customer_id: nil}), do: :agent
   def get_message_type(%Message{user_id: nil}), do: :customer
   def get_message_type(_message), do: :unknown
+
+  @spec handle_post_creation_conversation_updates(Message.t()) :: Message.t()
+  def handle_post_creation_conversation_updates(%Message{} = message) do
+    message
+    |> build_conversation_updates()
+    |> update_and_broadcast_to_admin(message)
+
+    message
+  end
+
+  @spec build_conversation_updates(Message.t()) :: map()
+  def build_conversation_updates(%Message{} = message) do
+    %{}
+    |> build_first_reply_updates(message)
+    |> build_message_type_updates(message)
+  end
+
+  @spec build_first_reply_updates(map(), Message.t()) :: map()
+  defp build_first_reply_updates(
+         updates,
+         %Message{
+           conversation_id: conversation_id,
+           user_id: assignee_id
+         }
+       ) do
+    if Conversations.count_agent_replies(conversation_id) == 1 do
+      Map.merge(updates, %{assignee_id: assignee_id})
+    else
+      updates
+    end
+  end
+
+  @spec build_message_type_updates(map(), Message.t()) :: map()
+  defp build_message_type_updates(updates, %Message{} = message) do
+    case get_message_type(message) do
+      # If agent responded, conversation should be marked as "read"
+      :agent -> Map.merge(updates, %{read: true})
+      _ -> updates
+    end
+  end
+
+  @spec update_and_broadcast_to_admin(map(), Message.t()) :: any()
+  defp update_and_broadcast_to_admin(
+         updates,
+         %Message{
+           account_id: account_id,
+           conversation_id: conversation_id
+         } = _message
+       ) do
+    # TODO: DRY up this logic with other places we do conversation updates w/ broadcasting?
+    {:ok, conversation} =
+      conversation_id
+      |> Conversations.get_conversation!()
+      |> Conversations.update_conversation(updates)
+
+    ChatApiWeb.Endpoint.broadcast!("notification:" <> account_id, "conversation:updated", %{
+      "id" => conversation_id,
+      "updates" => ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
+    })
+  end
 end

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -43,7 +43,7 @@ defmodule ChatApi.Messages.Helpers do
            user_id: assignee_id
          }
        ) do
-    if Conversations.count_agent_replies(conversation_id) == 1 do
+    if !is_nil(assignee_id) && Conversations.count_agent_replies(conversation_id) == 1 do
       Map.merge(updates, %{assignee_id: assignee_id})
     else
       updates
@@ -59,7 +59,7 @@ defmodule ChatApi.Messages.Helpers do
     end
   end
 
-  @spec update_conversation_and_broadcast_to_admin(map(), Message.t()) :: any()
+  @spec update_conversation_and_broadcast_to_admin(map(), Message.t()) :: :ok | no_return()
   defp update_conversation_and_broadcast_to_admin(
          updates,
          %Message{

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -35,15 +35,14 @@ defmodule ChatApi.Messages.Helpers do
     |> build_message_type_updates(message)
   end
 
+  @spec is_first_agent_reply?(Message.t()) :: boolean()
+  def is_first_agent_reply?(%Message{conversation_id: conversation_id, user_id: assignee_id}) do
+    !is_nil(assignee_id) && Conversations.count_agent_replies(conversation_id) == 1
+  end
+
   @spec build_first_reply_updates(map(), Message.t()) :: map()
-  defp build_first_reply_updates(
-         updates,
-         %Message{
-           conversation_id: conversation_id,
-           user_id: assignee_id
-         }
-       ) do
-    if !is_nil(assignee_id) && Conversations.count_agent_replies(conversation_id) == 1 do
+  defp build_first_reply_updates(updates, %Message{user_id: assignee_id} = message) do
+    if is_first_agent_reply?(message) do
       Map.merge(updates, %{assignee_id: assignee_id})
     else
       updates

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -107,6 +107,7 @@ defmodule ChatApi.Slack.Helpers do
   def format_sender_id!(authorization, slack_user_id, slack_channel_id) do
     # TODO: what's the best way to handle these nested `case` statements?
     # TODO: handle updating the customer's company_id if it's not set yet?
+    # TODO: should we check if the slack_user_id is a workspace admin, or something like that?
     case find_matching_user(authorization, slack_user_id) do
       %{id: user_id} ->
         %{"user_id" => user_id}

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -174,6 +174,7 @@ defmodule ChatApiWeb.SlackController do
         |> Messages.Notification.notify(:webhooks)
         |> Messages.Notification.notify(:slack_support_channel)
         |> Messages.Notification.notify(:slack_company_channel)
+        |> Messages.Helpers.handle_post_creation_conversation_updates()
       else
         case SlackAuthorizations.get_authorization_by_account(account_id, %{type: "support"}) do
           nil ->
@@ -191,6 +192,7 @@ defmodule ChatApiWeb.SlackController do
             |> Messages.Notification.broadcast_to_conversation!()
             |> Messages.Notification.notify(:webhooks)
             |> Messages.Notification.notify(:slack)
+            |> Messages.Helpers.handle_post_creation_conversation_updates()
         end
       end
     end

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -3,10 +3,9 @@ defmodule ChatApi.MessagesTest do
 
   import ChatApi.Factory
   alias ChatApi.Messages
+  alias ChatApi.Messages.Message
 
   describe "messages" do
-    alias ChatApi.Messages.Message
-
     @update_attrs %{body: "some updated body"}
     @invalid_attrs %{body: nil}
 
@@ -59,6 +58,12 @@ defmodule ChatApi.MessagesTest do
          %{message: message} do
       assert %Ecto.Changeset{} = Messages.change_message(message)
     end
+  end
+
+  describe "helpers" do
+    setup do
+      {:ok, message: insert(:message)}
+    end
 
     test "get_message_type/1 returns the message sender type" do
       customer_message = insert(:message, user: nil)
@@ -83,6 +88,42 @@ defmodule ChatApi.MessagesTest do
       assert %{body: body, customer: c} = Messages.Helpers.format(message)
       assert body == message.body
       assert customer.email == c.email
+    end
+
+    test "build_conversation_updates/1 builds the conversation updates for a created message" do
+      account = insert(:account)
+      agent = insert(:user, account: account)
+      customer = insert(:customer, account: account)
+      conversation = insert(:conversation, account: account, customer: customer)
+
+      initial_customer_message =
+        insert(:message, conversation: conversation, customer: customer, user: nil)
+
+      # No conversation updates are necessary on the first customer message
+      assert %{} = Messages.Helpers.build_conversation_updates(initial_customer_message)
+
+      first_agent_reply = insert(:message, conversation: conversation, user: agent, customer: nil)
+      agent_id = agent.id
+
+      # After the first reply, auto-assign the responder and mark the conversation as "read"
+      assert %{assignee_id: ^agent_id, read: true} =
+               Messages.Helpers.build_conversation_updates(first_agent_reply)
+
+      first_customer_reply =
+        insert(:message, conversation: conversation, customer: customer, user: nil)
+
+      assert %{} = Messages.Helpers.build_conversation_updates(first_customer_reply)
+
+      second_agent_reply =
+        insert(:message, conversation: conversation, user: agent, customer: nil)
+
+      # On subsequent replies, just mark the conversation as "read"
+      assert %{read: true} = Messages.Helpers.build_conversation_updates(second_agent_reply)
+
+      second_customer_reply =
+        insert(:message, conversation: conversation, customer: customer, user: nil)
+
+      assert %{} = Messages.Helpers.build_conversation_updates(second_customer_reply)
     end
   end
 end

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -151,7 +151,9 @@ defmodule ChatApiWeb.SlackControllerTest do
           {:ok, %{body: %{"ok" => true, "user" => slack_user}}}
         end,
         send_message: fn _, _ ->
-          {:ok, %{body: %{"ok" => true}}}
+          # TODO: this prevents a new thread from being created, but we should include an
+          # actual response payload so that we can test that a thread is successfully created
+          {:ok, nil}
         end do
         post(conn, Routes.slack_path(conn, :webhook), %{
           "event" => event_params

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -33,7 +33,8 @@ defmodule ChatApiWeb.SlackControllerTest do
      auth: auth,
      account: account,
      conversation: conversation,
-     customer: customer}
+     customer: customer,
+     user: user}
   end
 
   describe "authorization" do
@@ -63,8 +64,8 @@ defmodule ChatApiWeb.SlackControllerTest do
   describe "webhook" do
     test "sends a new thread message event to the webhook from the primary channel", %{
       conn: conn,
-      thread: thread,
-      auth: auth
+      auth: auth,
+      thread: thread
     } do
       account_id = thread.account_id
 
@@ -82,6 +83,40 @@ defmodule ChatApiWeb.SlackControllerTest do
 
       assert [%{body: body}] = Messages.list_messages(account_id)
       assert body == event_params["text"]
+    end
+
+    test "updates the conversation with the assignee after the first agent reply", %{
+      conn: conn,
+      auth: auth,
+      thread: thread,
+      user: user
+    } do
+      account_id = thread.account_id
+
+      event_params = %{
+        "type" => "message",
+        "text" => "hello world #{System.unique_integer([:positive])}",
+        "thread_ts" => thread.slack_thread_ts,
+        "channel" => @slack_channel,
+        "user" => auth.authed_user_id
+      }
+
+      slack_user = %{
+        "profile" => %{"email" => user.email}
+      }
+
+      with_mock ChatApi.Slack.Client,
+        retrieve_user_info: fn _, _ ->
+          {:ok, %{body: %{"ok" => true, "user" => slack_user}}}
+        end do
+        post(conn, Routes.slack_path(conn, :webhook), %{
+          "event" => event_params
+        })
+
+        assert [%{conversation: conversation}] = Messages.list_messages(account_id)
+        assert conversation.assignee_id == user.id
+        assert conversation.read
+      end
     end
 
     test "sends a new thread message event to the webhook from a support channel without authorization",


### PR DESCRIPTION
### Description

At the moment, we auto-assign the first responder in the Papercups dashboard.

This PR updates things so that this works through the Slack integration as well.

TODOs:
- [x] Set up utility methods to handle conversation updates after a message is created
- [x] Use new method(s) in Slack controller where appropriate
- [x] Add test coverage for the utility methods
- [x] Add test coverage for Slack controller making sure things work as expected
- [x] Do some manual QA

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
