### PR TITLE
Add `source` field to conversations/messages to distinguish "slack" from "chat"

### DIFF
--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -10,15 +10,40 @@ defmodule ChatApi.Conversations.Conversation do
     Users.User
   }
 
+  @type t :: %__MODULE__{
+          status: String.t(),
+          priority: String.t(),
+          source: String.t() | nil,
+          read: boolean(),
+          archived_at: any(),
+          closed_at: any(),
+          metadata: any(),
+          # Relations
+          assignee_id: any(),
+          assignee: any(),
+          account_id: any(),
+          account: any(),
+          customer_id: any(),
+          customer: any(),
+          messages: any(),
+          conversation_tags: any(),
+          tags: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
   schema "conversations" do
     field(:status, :string, default: "open")
     field(:priority, :string, default: "not_priority")
+    field(:source, :string)
     field(:read, :boolean, default: false)
     field(:archived_at, :utc_datetime)
     field(:closed_at, :utc_datetime)
+    field(:metadata, :map)
 
     has_many(:messages, Message)
     belongs_to(:assignee, User, foreign_key: :assignee_id, references: :id, type: :integer)
@@ -42,18 +67,15 @@ defmodule ChatApi.Conversations.Conversation do
       :account_id,
       :customer_id,
       :archived_at,
-      :closed_at
+      :closed_at,
+      :source,
+      :metadata
     ])
     |> validate_required([:status, :account_id, :customer_id])
+    |> validate_inclusion(:source, ["chat", "slack", "email"])
     |> put_closed_at()
     |> foreign_key_constraint(:account_id)
     |> foreign_key_constraint(:customer_id)
-  end
-
-  def test_changeset(conversation, attrs) do
-    conversation
-    |> cast(attrs, [:inserted_at, :updated_at, :status])
-    |> changeset(attrs)
   end
 
   defp put_closed_at(%Ecto.Changeset{valid?: true, changes: %{status: status}} = changeset) do

--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -39,7 +39,7 @@ defmodule ChatApi.Conversations.Conversation do
   schema "conversations" do
     field(:status, :string, default: "open")
     field(:priority, :string, default: "not_priority")
-    field(:source, :string)
+    field(:source, :string, default: "chat")
     field(:read, :boolean, default: false)
     field(:archived_at, :utc_datetime)
     field(:closed_at, :utc_datetime)

--- a/lib/chat_api/conversations/helpers.ex
+++ b/lib/chat_api/conversations/helpers.ex
@@ -4,7 +4,7 @@ defmodule ChatApi.Conversations.Helpers do
   """
 
   require Logger
-  # alias ChatApi.Slack
+  alias ChatApi.Conversations.Conversation
 
   @spec send_conversation_state_update(Conversation.t(), map()) ::
           {:ok, String.t()} | {:error, String.t()}

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -11,6 +11,8 @@ defmodule ChatApi.Messages.Message do
           body: String.t(),
           sent_at: any(),
           seen_at: any(),
+          source: String.t() | nil,
+          metadata: any(),
           # Foreign keys
           conversation_id: any(),
           conversation: any(),
@@ -31,6 +33,8 @@ defmodule ChatApi.Messages.Message do
     field(:body, :string)
     field(:sent_at, :utc_datetime)
     field(:seen_at, :utc_datetime)
+    field(:source, :string)
+    field(:metadata, :map)
 
     belongs_to(:conversation, Conversation)
     belongs_to(:account, Account)
@@ -50,8 +54,11 @@ defmodule ChatApi.Messages.Message do
       :customer_id,
       :user_id,
       :sent_at,
-      :seen_at
+      :seen_at,
+      :source,
+      :metadata
     ])
     |> validate_required([:body, :account_id, :conversation_id])
+    |> validate_inclusion(:source, ["chat", "slack", "email"])
   end
 end

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -33,7 +33,7 @@ defmodule ChatApi.Messages.Message do
     field(:body, :string)
     field(:sent_at, :utc_datetime)
     field(:seen_at, :utc_datetime)
-    field(:source, :string)
+    field(:source, :string, default: "chat")
     field(:metadata, :map)
 
     belongs_to(:conversation, Conversation)

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -227,7 +227,8 @@ defmodule ChatApiWeb.SlackController do
          {:ok, conversation} <-
            Conversations.create_conversation(%{
              account_id: account_id,
-             customer_id: customer.id
+             customer_id: customer.id,
+             source: "slack"
            }),
          {:ok, message} <-
            Messages.create_message(%{

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -162,6 +162,7 @@ defmodule ChatApiWeb.SlackController do
           "body" => text,
           "conversation_id" => conversation_id,
           "account_id" => account_id,
+          "source" => "slack",
           "user_id" =>
             Slack.Helpers.get_admin_sender_id(
               primary_reply_authorization,
@@ -186,7 +187,8 @@ defmodule ChatApiWeb.SlackController do
             |> Map.merge(%{
               "body" => text,
               "conversation_id" => conversation_id,
-              "account_id" => account_id
+              "account_id" => account_id,
+              "source" => "slack"
             })
             |> Messages.create_and_fetch!()
             |> Messages.Notification.broadcast_to_conversation!()
@@ -235,7 +237,8 @@ defmodule ChatApiWeb.SlackController do
              account_id: account_id,
              conversation_id: conversation.id,
              customer_id: customer.id,
-             body: text
+             body: text,
+             source: "slack"
            }),
          {:ok, _slack_conversation_thread} <-
            SlackConversationThreads.create_slack_conversation_thread(%{

--- a/lib/workers/send_conversation_reply_email.ex
+++ b/lib/workers/send_conversation_reply_email.ex
@@ -88,6 +88,10 @@ defmodule ChatApi.Workers.SendConversationReplyEmail do
     |> Enum.map(fn id -> Oban.cancel_job(id) end)
   end
 
+  @doc """
+  Check if we should send a notification email. Note that we only want to send
+  these if the source is "chat" (we don't want to send when source is "slack")
+  """
   @spec should_send_email?(binary()) :: boolean()
   def should_send_email?(conversation_id) do
     case Conversations.get_conversation!(conversation_id) do

--- a/priv/repo/migrations/20210106033738_add_source_to_conversations_and_messages.exs
+++ b/priv/repo/migrations/20210106033738_add_source_to_conversations_and_messages.exs
@@ -1,0 +1,15 @@
+defmodule ChatApi.Repo.Migrations.AddSourceToConversationsAndMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add(:source, :string)
+      add(:metadata, :map)
+    end
+
+    alter table(:messages) do
+      add(:source, :string)
+      add(:metadata, :map)
+    end
+  end
+end

--- a/priv/repo/migrations/20210106033738_add_source_to_conversations_and_messages.exs
+++ b/priv/repo/migrations/20210106033738_add_source_to_conversations_and_messages.exs
@@ -3,12 +3,12 @@ defmodule ChatApi.Repo.Migrations.AddSourceToConversationsAndMessages do
 
   def change do
     alter table(:conversations) do
-      add(:source, :string)
+      add(:source, :string, default: "chat")
       add(:metadata, :map)
     end
 
     alter table(:messages) do
-      add(:source, :string)
+      add(:source, :string, default: "chat")
       add(:metadata, :map)
     end
   end

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -116,6 +116,13 @@ defmodule ChatApi.ConversationsTest do
       assert {:error, %Ecto.Changeset{}} = Conversations.create_conversation(@invalid_attrs)
     end
 
+    test "create_conversation/1 with invalid source returns error changeset" do
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Conversations.create_conversation(%{status: "closed", source: "unknown"})
+
+      assert {"is invalid", _} = errors[:source]
+    end
+
     test "update_conversation/2 with valid data updates the conversation",
          %{conversation: conversation} do
       assert {:ok, %Conversation{} = conversation} =

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -110,6 +110,7 @@ defmodule ChatApi.ConversationsTest do
                Conversations.create_conversation(params_with_assocs(:conversation))
 
       assert conversation.status == "open"
+      assert conversation.source == "chat"
     end
 
     test "create_conversation/1 with invalid data returns error changeset" do

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -32,6 +32,7 @@ defmodule ChatApi.MessagesTest do
 
       assert {:ok, %Message{} = message} = Messages.create_message(attrs)
       assert message.body == "valid message body"
+      assert message.source == "chat"
     end
 
     test "create_message/1 with invalid data returns error changeset" do

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -38,6 +38,13 @@ defmodule ChatApi.MessagesTest do
       assert {:error, %Ecto.Changeset{}} = Messages.create_message(@invalid_attrs)
     end
 
+    test "create_message/1 with invalid source returns error changeset" do
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Messages.create_message(%{body: "Hello world!", source: "unknown"})
+
+      assert {"is invalid", _} = errors[:source]
+    end
+
     test "update_message/2 with valid data updates the message",
          %{message: message} do
       assert {:ok, %Message{} = message} = Messages.update_message(message, @update_attrs)

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -81,7 +81,7 @@ defmodule ChatApiWeb.SlackControllerTest do
         "event" => event_params
       })
 
-      assert [%{body: body}] = Messages.list_messages(account_id)
+      assert [%{body: body, source: "slack"}] = Messages.list_messages(account_id)
       assert body == event_params["text"]
     end
 
@@ -194,7 +194,7 @@ defmodule ChatApiWeb.SlackControllerTest do
           "event" => event_params
         })
 
-        assert [%{body: body}] = Messages.list_messages(account.id)
+        assert [%{body: body, source: "slack"}] = Messages.list_messages(account.id)
         assert body == event_params["text"]
       end
     end
@@ -251,7 +251,10 @@ defmodule ChatApiWeb.SlackControllerTest do
           "event" => event_params
         })
 
-        assert [%{body: body}] = Messages.list_messages(account.id)
+        assert [%{body: body, conversation: conversation, source: "slack"}] =
+                 Messages.list_messages(account.id)
+
+        assert %{source: "slack"} = conversation
         assert body == event_params["text"]
       end
     end
@@ -293,8 +296,17 @@ defmodule ChatApiWeb.SlackControllerTest do
           "event" => event_params
         })
 
-        assert [%{body: body, customer_id: customer_id}] = Messages.list_messages(account.id)
+        assert [
+                 %{
+                   body: body,
+                   customer_id: customer_id,
+                   conversation: conversation,
+                   source: "slack"
+                 }
+               ] = Messages.list_messages(account.id)
+
         assert %{company_id: company_id} = Customers.get_customer!(customer_id)
+        assert %{source: "slack"} = conversation
         assert body == event_params["text"]
         assert company_id == company.id
       end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -44,7 +44,8 @@ defmodule ChatApi.Factory do
     %ChatApi.Conversations.Conversation{
       account: build(:account),
       customer: build(:customer),
-      status: "open"
+      status: "open",
+      source: "chat"
     }
   end
 
@@ -83,7 +84,8 @@ defmodule ChatApi.Factory do
       conversation: build(:conversation),
       customer: build(:customer),
       user: build(:user),
-      body: "some message body"
+      body: "some message body",
+      source: "chat"
     }
   end
 

--- a/test/workers/send_conversation_reply_email_test.exs
+++ b/test/workers/send_conversation_reply_email_test.exs
@@ -1,0 +1,209 @@
+defmodule ChatApi.SendConversationReplyEmailTest do
+  use ChatApi.DataCase, async: true
+
+  import ExUnit.CaptureLog
+  import ChatApi.Factory
+
+  setup do
+    account = insert(:account)
+    user = insert(:user, account: account)
+    customer = insert(:customer, account: account)
+
+    {:ok, account: account, customer: customer, user: user}
+  end
+
+  describe "send_email/1" do
+    test "skips sending if the latest message was from a customer", %{
+      account: account,
+      customer: customer
+    } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          customer: customer,
+          user: nil,
+          seen_at: nil
+        )
+
+      assert :skipped =
+               ChatApi.Workers.SendConversationReplyEmail.send_email(%{
+                 "seen_at" => message.seen_at,
+                 "user_id" => message.user_id,
+                 "user" => message.user,
+                 "account_id" => message.account_id,
+                 "customer_id" => message.customer_id,
+                 "conversation_id" => message.conversation_id
+               })
+    end
+
+    test "skips sending if the conversation originated in Slack", %{
+      account: account,
+      customer: customer,
+      user: user
+    } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "slack")
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          user: user,
+          customer: nil,
+          seen_at: nil
+        )
+
+      assert :skipped =
+               ChatApi.Workers.SendConversationReplyEmail.send_email(%{
+                 "seen_at" => message.seen_at,
+                 "user_id" => message.user_id,
+                 "user" => message.user,
+                 "account_id" => message.account_id,
+                 "customer_id" => message.customer_id,
+                 "conversation_id" => message.conversation_id
+               })
+    end
+
+    test "skips sending if the conversation has no unread messages", %{
+      account: account,
+      customer: customer,
+      user: user
+    } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          user: user,
+          customer: nil,
+          seen_at: ~U[2020-12-08 10:00:00Z]
+        )
+
+      assert :skipped =
+               ChatApi.Workers.SendConversationReplyEmail.send_email(%{
+                 "seen_at" => nil,
+                 "user_id" => message.user_id,
+                 "user" => message.user,
+                 "account_id" => message.account_id,
+                 "customer_id" => message.customer_id,
+                 "conversation_id" => message.conversation_id
+               })
+    end
+
+    test "sends if the conversation has unread messages", %{
+      account: account,
+      customer: customer,
+      user: user
+    } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          user: user,
+          customer: nil,
+          seen_at: nil
+        )
+
+      assert capture_log(fn ->
+               result =
+                 ChatApi.Workers.SendConversationReplyEmail.send_email(%{
+                   "seen_at" => message.seen_at,
+                   "user_id" => message.user_id,
+                   "user" => message.user,
+                   "account_id" => message.account_id,
+                   "customer_id" => message.customer_id,
+                   "conversation_id" => message.conversation_id
+                 })
+
+               assert result == :ok
+             end) =~ "Skipped sending"
+    end
+
+    test "handles invalid input" do
+      assert :error =
+               ChatApi.Workers.SendConversationReplyEmail.send_email(%{
+                 "foo" => "bar"
+               })
+    end
+  end
+
+  describe "should_send_email?/1" do
+    test "should_send_email?/1 returns false if the conversation is not from a chat", %{
+      account: account,
+      customer: customer
+    } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "slack")
+
+      refute ChatApi.Workers.SendConversationReplyEmail.should_send_email?(conversation.id)
+    end
+
+    test "should_send_email?/1 returns false if the conversation has no unread messages and is from a 'chat'",
+         %{
+           account: account,
+           customer: customer,
+           user: user
+         } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: ~U[2020-12-06 10:00:00Z]
+      )
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: ~U[2020-12-07 10:00:00Z]
+      )
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: ~U[2020-12-08 10:00:00Z]
+      )
+
+      refute ChatApi.Workers.SendConversationReplyEmail.should_send_email?(conversation.id)
+    end
+
+    test "should_send_email?/1 returns true if the conversation has unread messages and is from a 'chat'",
+         %{
+           account: account,
+           customer: customer,
+           user: user
+         } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: ~U[2020-12-06 10:00:00Z]
+      )
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: nil
+      )
+
+      insert(:message,
+        account: account,
+        conversation: conversation,
+        user: user,
+        seen_at: ~U[2020-12-08 10:00:00Z]
+      )
+
+      assert ChatApi.Workers.SendConversationReplyEmail.should_send_email?(conversation.id)
+    end
+  end
+end


### PR DESCRIPTION
### Description

- [x] Add `source` field to conversations/messages to distinguish "slack" from "chat"
- [x] Prevent notification emails from being sent when conversation source is "slack"
- [x] Add tests for email notification worker

### Issue

It's helpful to know where conversations/messages originate from.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
