### PR TITLE
Support manually creating conversation from Slack support channel with emoji reaction

### DIFF
--- a/lib/chat_api/companies.ex
+++ b/lib/chat_api/companies.ex
@@ -40,6 +40,14 @@ defmodule ChatApi.Companies do
     Company.changeset(company, attrs)
   end
 
+  @spec find_by_slack_channel(binary()) :: Company.t() | nil
+  def find_by_slack_channel(slack_channel_id) do
+    Company
+    |> where(slack_channel_id: ^slack_channel_id)
+    |> order_by(desc: :inserted_at)
+    |> Repo.one()
+  end
+
   @spec find_by_slack_channel(binary(), binary()) :: Company.t() | nil
   def find_by_slack_channel(account_id, slack_channel_id) do
     Company

--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -52,6 +52,23 @@ defmodule ChatApi.Slack.Client do
     end
   end
 
+  @spec retrieve_message(binary(), binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
+  def retrieve_message(channel, ts, access_token) do
+    if should_execute?(access_token) do
+      get("/conversations.history",
+        query: [channel: channel, latest: ts, limit: 1, inclusive: true],
+        headers: [
+          {"Authorization", "Bearer " <> access_token}
+        ]
+      )
+    else
+      # Inspect what would've been sent for debugging
+      Logger.info("Would have retrieved message #{inspect(ts)} from channel #{inspect(channel)}")
+
+      {:ok, nil}
+    end
+  end
+
   @spec retrieve_user_info(binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
   def retrieve_user_info(user_id, access_token) do
     if should_execute?(access_token) do

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -292,6 +292,21 @@ defmodule ChatApi.Slack.Helpers do
   # Extractors
   #####################
 
+  @spec extract_slack_message(map()) :: {:ok, map()} | {:error, String.t()}
+  def extract_slack_message(%{body: %{"ok" => true, "messages" => [message | _]}}),
+    do: {:ok, message}
+
+  def extract_slack_message(%{body: %{"ok" => true, "messages" => []}}),
+    do: {:error, "No messages were found"}
+
+  def extract_slack_message(%{body: %{"ok" => false} = body}),
+    do: {:error, "conversations.history returned ok=false: #{inspect(body)}"}
+
+  def extract_slack_message(response),
+    do: {:error, "Invalid response: #{inspect(response)}"}
+
+  # TODO: refactor extractors below to return :ok/:error tuples rather than raising?
+
   @spec extract_slack_conversation_thread_info(map()) :: map()
   def extract_slack_conversation_thread_info(%{body: body}) do
     if Map.get(body, "ok") do

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -305,6 +305,16 @@ defmodule ChatApi.Slack.Helpers do
   def extract_slack_message(response),
     do: {:error, "Invalid response: #{inspect(response)}"}
 
+  @spec extract_slack_channel(map()) :: {:ok, map()} | {:error, String.t()}
+  def extract_slack_channel(%{body: %{"ok" => true, "channel" => channel}}) when is_map(channel),
+    do: {:ok, channel}
+
+  def extract_slack_channel(%{body: %{"ok" => false} = body}),
+    do: {:error, "conversations.info returned ok=false: #{inspect(body)}"}
+
+  def extract_slack_channel(response),
+    do: {:error, "Invalid response: #{inspect(response)}"}
+
   # TODO: refactor extractors below to return :ok/:error tuples rather than raising?
 
   @spec extract_slack_conversation_thread_info(map()) :: map()

--- a/lib/chat_api/slack_authorizations.ex
+++ b/lib/chat_api/slack_authorizations.ex
@@ -93,6 +93,9 @@ defmodule ChatApi.SlackAuthorizations do
       {:team_id, value}, dynamic ->
         dynamic([r], ^dynamic and r.team_id == ^value)
 
+      {:bot_user_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.bot_user_id == ^value)
+
       {:type, value}, dynamic ->
         dynamic([r], ^dynamic and r.type == ^value)
 

--- a/lib/chat_api/slack_conversation_threads.ex
+++ b/lib/chat_api/slack_conversation_threads.ex
@@ -8,9 +8,11 @@ defmodule ChatApi.SlackConversationThreads do
 
   alias ChatApi.SlackConversationThreads.SlackConversationThread
 
-  @spec list_slack_conversation_threads() :: [SlackConversationThread.t()]
-  def list_slack_conversation_threads do
-    Repo.all(SlackConversationThread)
+  @spec list_slack_conversation_threads(map()) :: [SlackConversationThread.t()]
+  def list_slack_conversation_threads(filters \\ %{}) do
+    SlackConversationThread
+    |> where(^filter_where(filters))
+    |> Repo.all()
   end
 
   @spec get_slack_conversation_thread!(binary()) :: SlackConversationThread.t()
@@ -74,6 +76,17 @@ defmodule ChatApi.SlackConversationThreads do
         attrs \\ %{}
       ) do
     SlackConversationThread.changeset(slack_conversation_thread, attrs)
+  end
+
+  @spec exists?(map()) :: boolean()
+  def exists?(filters) do
+    count =
+      SlackConversationThread
+      |> where(^filter_where(filters))
+      |> select([t], count(t.id))
+      |> Repo.one()
+
+    count > 0
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -298,8 +298,11 @@ defmodule ChatApiWeb.SlackController do
            "user" => slack_user_id,
            "channel" => slack_channel_id
            #  "inviter" => slack_inviter_id
-         } = _event
+         } = event
        ) do
+    Logger.info("Slack group_join event detected:")
+    Logger.info(inspect(event))
+
     with %{account_id: account_id, access_token: access_token} <-
            SlackAuthorizations.find_slack_authorization(%{
              bot_user_id: slack_user_id,

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -307,6 +307,8 @@ defmodule ChatApiWeb.SlackController do
              type: "support"
            }),
          :ok <- validate_channel_supported(authorization, slack_channel_id),
+         # NB: not ideal, but this may treat an internal/admin user as a "customer",
+         # because at the moment all conversations must have a customer associated with them
          {:ok, customer} <-
            Slack.Helpers.create_or_update_customer_from_slack_user_id(
              authorization,

--- a/test/chat_api/slack_conversation_threads_test.exs
+++ b/test/chat_api/slack_conversation_threads_test.exs
@@ -146,5 +146,27 @@ defmodule ChatApi.SlackConversationThreadsTest do
       assert Enum.member?(slack_channels, "ch1")
       assert Enum.member?(slack_channels, "ch2")
     end
+
+    test "exists?/1 checks if a thread exists",
+         %{conversation: conversation} do
+      channel = "ch1"
+      ts = "ts123"
+
+      refute SlackConversationThreads.exists?(%{
+               "slack_channel" => channel,
+               "slack_thread_ts" => ts
+             })
+
+      insert(:slack_conversation_thread,
+        conversation: conversation,
+        slack_channel: channel,
+        slack_thread_ts: ts
+      )
+
+      assert SlackConversationThreads.exists?(%{
+               "slack_channel" => channel,
+               "slack_thread_ts" => ts
+             })
+    end
   end
 end


### PR DESCRIPTION
### Description

This PR adds support manually creating conversation from Slack support channel with emoji reaction.

### Issue

This will make it easier to test, since at the moment admin/agent messages don't trigger conversations to be created.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
