### PR TITLE
Fix support for external shared Slack channels

### DIFF
--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -54,6 +54,7 @@ defmodule ChatApi.Messages.Helpers do
     case get_message_type(message) do
       # If agent responded, conversation should be marked as "read"
       :agent -> Map.merge(updates, %{read: true})
+      :customer -> Map.merge(updates, %{read: false})
       _ -> updates
     end
   end

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -105,7 +105,7 @@ defmodule ChatApiWeb.GmailController do
     json(conn, %{data: %{url: url}})
   end
 
-  @spec notify_slack(Conn.t()) :: Conn.t()
+  @spec notify_slack(Plug.Conn.t()) :: Plug.Conn.t()
   defp notify_slack(conn) do
     with %{email: email} <- conn.assigns.current_user do
       # Putting in an async Task for now, since we don't care if this succeeds

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -74,7 +74,7 @@ defmodule ChatApiWeb.RegistrationController do
     end
   end
 
-  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec create(Conn.t(), map()) :: Conn.t()
   def create(conn, %{"user" => user_params}) do
     if registration_disabled?() do
       send_server_error(conn, 403, "An invitation token is required to register")

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -105,6 +105,10 @@ defmodule ChatApiWeb.SlackController do
     Logger.debug("Payload from Slack webhook: #{inspect(payload)}")
 
     case payload do
+      %{"event" => _event, "is_ext_shared_channel" => true} ->
+        handle_payload(payload)
+        send_resp(conn, 200, "")
+
       %{"event" => event} ->
         handle_event(event)
         send_resp(conn, 200, "")
@@ -131,6 +135,22 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
+  defp handle_payload(
+         %{
+           "event" => event,
+           "team_id" => team,
+           "is_ext_shared_channel" => true
+         } = _payload
+       ) do
+    # NB: this is a bit of a hack -- we override the "team" id in the "event" payload
+    # to match the "team" where the Papercups app is installed
+    event
+    |> Map.merge(%{"team" => team})
+    |> handle_event()
+  end
+
+  defp handle_payload(_), do: nil
+
   defp handle_event(%{"bot_id" => _bot_id} = _event) do
     # Don't do anything on bot events for now
     nil
@@ -151,7 +171,7 @@ defmodule ChatApiWeb.SlackController do
            "user" => slack_user_id
          } = event
        ) do
-    Logger.debug("Handling Slack event: #{inspect(event)}")
+    Logger.debug("Handling Slack message reply event: #{inspect(event)}")
 
     with {:ok, conversation} <- get_thread_conversation(thread_ts, slack_channel_id),
          %{account_id: account_id, id: conversation_id} <- conversation,
@@ -208,8 +228,10 @@ defmodule ChatApiWeb.SlackController do
            "channel" => slack_channel_id,
            "user" => slack_user_id,
            "ts" => ts
-         } = _event
+         } = event
        ) do
+    Logger.debug("Handling Slack new message event: #{inspect(event)}")
+
     with %{account_id: account_id} = authorization <-
            SlackAuthorizations.find_slack_authorization(%{
              team_id: team,
@@ -271,6 +293,8 @@ defmodule ChatApiWeb.SlackController do
            }
          } = event
        ) do
+    Logger.debug("Handling Slack reaction event: #{inspect(event)}")
+
     with :ok <- validate_no_existing_thread(channel, ts),
          # TODO: allow in support channel as well?
          %{account_id: account_id} <- ChatApi.Companies.find_by_slack_channel(channel),
@@ -441,7 +465,7 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
-  @spec notify_slack(Conn.t()) :: Conn.t()
+  @spec notify_slack(Plug.Conn.t()) :: Plug.Conn.t()
   defp notify_slack(conn) do
     with %{email: email} <- conn.assigns.current_user do
       # Putting in an async Task for now, since we don't care if this succeeds

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -194,8 +194,11 @@ defmodule ChatApiWeb.SlackControllerTest do
           "event" => event_params
         })
 
-        assert [%{body: body, source: "slack"}] = Messages.list_messages(account.id)
+        assert [%{body: body, conversation: conversation, source: "slack"}] =
+                 Messages.list_messages(account.id)
+
         assert body == event_params["text"]
+        refute conversation.read
       end
     end
 

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -315,6 +315,64 @@ defmodule ChatApiWeb.SlackControllerTest do
       end
     end
 
+    test "uses the correct Slack team_id from a shared external private company channel", %{
+      conn: conn,
+      account: account
+    } do
+      team_id = "T123TEST"
+
+      authorization =
+        insert(:slack_authorization, account: account, type: "support", team_id: team_id)
+
+      company =
+        insert(:company,
+          account: account,
+          name: "Slack Test Co",
+          slack_channel_id: @slack_channel
+        )
+
+      event_params = %{
+        "type" => "message",
+        "text" => "hello world #{System.unique_integer([:positive])}",
+        "channel" => @slack_channel,
+        "team" => "T123EXTERNAL",
+        "user" => authorization.authed_user_id,
+        "ts" => "1234.56789"
+      }
+
+      slack_user = %{
+        "real_name" => "Test User",
+        "tz" => "America/New_York",
+        "profile" => %{"email" => @email}
+      }
+
+      with_mock ChatApi.Slack.Client,
+        retrieve_user_info: fn _, _ ->
+          {:ok, %{body: %{"ok" => true, "user" => slack_user}}}
+        end,
+        send_message: fn _, _ -> {:ok, nil} end do
+        post(conn, Routes.slack_path(conn, :webhook), %{
+          "event" => event_params,
+          "is_ext_shared_channel" => true,
+          "team_id" => team_id
+        })
+
+        assert [
+                 %{
+                   body: body,
+                   customer_id: customer_id,
+                   conversation: conversation,
+                   source: "slack"
+                 }
+               ] = Messages.list_messages(account.id)
+
+        assert %{company_id: company_id} = Customers.get_customer!(customer_id)
+        assert %{source: "slack"} = conversation
+        assert body == event_params["text"]
+        assert company_id == company.id
+      end
+    end
+
     test "sending a new message event to the webhook from an unknown channel", %{
       conn: conn,
       account: account


### PR DESCRIPTION
### Description

- [x] Fixes support for external shared Slack channel webhook event payload
- [x] Fixes issue with marking conversation "read" from Slack message
- [x] Makes it possible to spawn conversation thread from primary Slack support channel by tagging it with an 👀 emoji 

### Issue

Fixes some edge cases related to external shared Slack channels

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
