### PR TITLE
Quick fix for securing `/api/customers/identify` better

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -41,18 +41,21 @@ defmodule ChatApi.Customers do
     Customer |> Repo.get!(id) |> Repo.preload(:tags)
   end
 
-  @spec find_by_external_id(binary(), binary()) :: Customer.t() | nil
-  def find_by_external_id(external_id, account_id) when is_binary(external_id) do
+  @spec find_by_external_id(binary(), binary(), map()) :: Customer.t() | nil
+  def find_by_external_id(external_id, account_id, filters \\ %{})
+
+  def find_by_external_id(external_id, account_id, filters) when is_binary(external_id) do
     Customer
     |> where(account_id: ^account_id, external_id: ^external_id)
+    |> where(^filter_where(filters))
     |> order_by(desc: :updated_at)
     |> first()
     |> Repo.one()
   end
 
-  @spec find_by_external_id(integer(), binary()) :: Customer.t() | nil
-  def find_by_external_id(external_id, account_id) when is_integer(external_id) do
-    external_id |> to_string() |> find_by_external_id(account_id)
+  @spec find_by_external_id(integer(), binary(), map()) :: Customer.t() | nil
+  def find_by_external_id(external_id, account_id, filters) when is_integer(external_id) do
+    external_id |> to_string() |> find_by_external_id(account_id, filters)
   end
 
   @spec find_by_email(binary() | nil, binary()) :: Customer.t() | nil
@@ -259,6 +262,9 @@ defmodule ChatApi.Customers do
 
       {"email", value}, dynamic ->
         dynamic([r], ^dynamic and ilike(r.email, ^value))
+
+      {"host", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.host, ^value))
 
       {_, _}, dynamic ->
         # Not a where parameter

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -68,6 +68,7 @@ defmodule ChatApiWeb.ConversationController do
     end
   end
 
+  # TODO: figure out a better way to handle this
   @spec find_by_customer(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def find_by_customer(conn, %{"customer_id" => customer_id, "account_id" => account_id}) do
     conversations = Conversations.find_by_customer(customer_id, account_id)

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -46,15 +46,15 @@ defmodule ChatApiWeb.CustomerController do
         %{
           "external_id" => external_id,
           "account_id" => account_id
-        } = _params
+        } = params
       ) do
-    Logger.info("Connection host for /api/customers/identify: #{inspect(conn.host)}")
-
     # TODO: support whitelisting urls for an account so we only enable this and
     # other chat widget-related APIs for incoming requests from supported urls?
     if Accounts.exists?(account_id) do
       # TODO: use `conn.host` to filter by customers with matching host
-      case Customers.find_by_external_id(external_id, account_id) do
+      filters = Map.take(params, ["email", "host"])
+
+      case Customers.find_by_external_id(external_id, account_id, filters) do
         %{id: customer_id} ->
           json(conn, %{
             data: %{

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -150,6 +150,7 @@ defmodule ChatApiWeb.CustomerController do
   # Helpers
   ###
 
+  @spec blank?(binary() | nil) :: boolean()
   defp blank?(nil), do: true
   defp blank?(""), do: true
   defp blank?(_), do: false

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -51,7 +51,6 @@ defmodule ChatApiWeb.CustomerController do
     # TODO: support whitelisting urls for an account so we only enable this and
     # other chat widget-related APIs for incoming requests from supported urls?
     if Accounts.exists?(account_id) do
-      # TODO: use `conn.host` to filter by customers with matching host
       filters = Map.take(params, ["email", "host"])
 
       case Customers.find_by_external_id(external_id, account_id, filters) do

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -51,8 +51,12 @@ defmodule ChatApiWeb.CustomerController do
     # TODO: support whitelisting urls for an account so we only enable this and
     # other chat widget-related APIs for incoming requests from supported urls?
     if Accounts.exists?(account_id) do
-      # TODO: make these required params?
-      filters = Map.take(params, ["email", "host"])
+      # TODO: make "host" a required param? (but would have to ignore on mobile...)
+      filters =
+        params
+        |> Map.take(["email", "host"])
+        |> Enum.reject(fn {_k, v} -> blank?(v) end)
+        |> Map.new()
 
       case Customers.find_by_external_id(external_id, account_id, filters) do
         %{id: customer_id} ->
@@ -145,6 +149,10 @@ defmodule ChatApiWeb.CustomerController do
   ###
   # Helpers
   ###
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(_), do: false
 
   @spec resp_format(map()) :: String.t()
   defp resp_format(%{"format" => "csv"}), do: "csv"

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -41,13 +41,19 @@ defmodule ChatApiWeb.CustomerController do
   end
 
   @spec identify(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def identify(conn, %{
-        "external_id" => external_id,
-        "account_id" => account_id
-      }) do
+  def identify(
+        conn,
+        %{
+          "external_id" => external_id,
+          "account_id" => account_id
+        } = _params
+      ) do
     Logger.info("Connection host for /api/customers/identify: #{inspect(conn.host)}")
 
+    # TODO: support whitelisting urls for an account so we only enable this and
+    # other chat widget-related APIs for incoming requests from supported urls?
     if Accounts.exists?(account_id) do
+      # TODO: use `conn.host` to filter by customers with matching host
       case Customers.find_by_external_id(external_id, account_id) do
         %{id: customer_id} ->
           json(conn, %{

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -51,6 +51,7 @@ defmodule ChatApiWeb.CustomerController do
     # TODO: support whitelisting urls for an account so we only enable this and
     # other chat widget-related APIs for incoming requests from supported urls?
     if Accounts.exists?(account_id) do
+      # TODO: make these required params?
       filters = Map.take(params, ["email", "host"])
 
       case Customers.find_by_external_id(external_id, account_id, filters) do

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -169,18 +169,49 @@ defmodule ChatApi.CustomersTest do
       assert %Ecto.Changeset{} = Customers.change_customer(customer)
     end
 
-    test "find_by_external_id/2 returns a customer by external_id", %{account: account} do
+    test "find_by_external_id/3 returns a customer by external_id", %{account: account} do
       external_id = "cus_123"
       %{id: customer_id} = insert(:customer, %{external_id: external_id, account: account})
 
       assert %Customer{id: ^customer_id} = Customers.find_by_external_id(external_id, account.id)
     end
 
-    test "find_by_external_id/2 works with integer external_ids", %{account: account} do
+    test "find_by_external_id/3 works with integer external_ids", %{account: account} do
       external_id = "123"
       %{id: customer_id} = insert(:customer, %{external_id: external_id, account: account})
 
       assert %Customer{id: ^customer_id} = Customers.find_by_external_id(123, account.id)
+    end
+
+    test "find_by_external_id/3 can filter by email and host", %{account: account} do
+      external_id = "123"
+      email = "test@test.com"
+      host = "app.chat.com"
+
+      %{id: customer_id} =
+        insert(:customer, %{
+          external_id: external_id,
+          account: account,
+          email: email,
+          host: host
+        })
+
+      # These all work
+      assert %Customer{id: ^customer_id} = Customers.find_by_external_id(123, account.id)
+
+      assert %Customer{id: ^customer_id} =
+               Customers.find_by_external_id(123, account.id, %{"email" => email})
+
+      assert %Customer{id: ^customer_id} =
+               Customers.find_by_external_id(123, account.id, %{"email" => email, "host" => host})
+
+      # These all should not work
+      refute Customers.find_by_external_id(123, account.id, %{"email" => "other@test.com"})
+
+      refute Customers.find_by_external_id(123, account.id, %{
+               "email" => email,
+               "host" => "other.host.com"
+             })
     end
 
     test "find_or_create_by_email/3 finds the matching customer", %{account: account} do

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -262,6 +262,29 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
 
+    test "ignoring nil/null filters", %{conn: conn, account: account} do
+      external_id = "cus_123"
+      email = "customer@test.com"
+      host = "app.test.com"
+
+      customer =
+        insert(:customer, account: account, external_id: external_id, email: email, host: host)
+
+      customer_id = customer.id
+
+      resp =
+        get(conn, Routes.customer_path(conn, :identify),
+          account_id: account.id,
+          external_id: external_id,
+          email: email,
+          host: nil
+        )
+
+      assert %{
+               "customer_id" => ^customer_id
+             } = json_response(resp, 200)["data"]
+    end
+
     test "returns nil if no match is found", %{conn: conn, account: account} do
       external_id = "cus_123"
       email = "test@test.com"

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -241,13 +241,20 @@ defmodule ChatApiWeb.CustomerControllerTest do
   describe "identifies a customer by external_id" do
     test "finds the correct customer", %{conn: conn, account: account} do
       external_id = "cus_123"
-      customer = insert(:customer, account: account, external_id: external_id)
-      %{id: customer_id, account_id: account_id} = customer
+      email = "customer@test.com"
+      host = "app.test.com"
+
+      customer =
+        insert(:customer, account: account, external_id: external_id, email: email, host: host)
+
+      customer_id = customer.id
 
       resp =
         get(conn, Routes.customer_path(conn, :identify),
-          account_id: account_id,
-          external_id: external_id
+          account_id: account.id,
+          external_id: external_id,
+          email: email,
+          host: host
         )
 
       assert %{
@@ -256,13 +263,25 @@ defmodule ChatApiWeb.CustomerControllerTest do
     end
 
     test "returns nil if no match is found", %{conn: conn, account: account} do
-      customer = insert(:customer, account: account, external_id: "cus_123")
-      %{id: _customer_id, account_id: account_id} = customer
+      external_id = "cus_123"
+      email = "test@test.com"
+      _customer = insert(:customer, account: account, external_id: external_id, email: email)
 
       resp =
         get(conn, Routes.customer_path(conn, :identify),
-          account_id: account_id,
+          account_id: account.id,
           external_id: "invalid"
+        )
+
+      assert %{
+               "customer_id" => nil
+             } = json_response(resp, 200)["data"]
+
+      resp =
+        get(conn, Routes.customer_path(conn, :identify),
+          account_id: account.id,
+          external_id: external_id,
+          email: "unknown@test.com"
         )
 
       assert %{


### PR DESCRIPTION
### Description

Quick fix for securing `/api/customers/identify` better by including filters for `email` and `host` in the query, to prevent malicious users from trying to guess `external_id` + account token combos.

(Note that we'll want to come up with a better long term solution here, but this should prevent the collisions we're seeing at the moment.)

### Issue

https://github.com/papercups-io/papercups/issues/515

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
