### PR TITLE
Include sender info in messages sent to Slack from dashboard

### DIFF
--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -192,6 +192,11 @@ defmodule ChatApi.Slack.Helpers do
     end
   end
 
+  @spec is_private_slack_channel?(binary()) :: boolean()
+  def is_private_slack_channel?("G" <> _rest), do: true
+  def is_private_slack_channel?("C" <> _rest), do: false
+  def is_private_slack_channel?(_), do: false
+
   @spec get_slack_authorization(binary()) ::
           %{access_token: binary(), channel: binary(), channel_id: binary()}
           | SlackAuthorizations.SlackAuthorization.t()

--- a/lib/chat_api/slack/notifications.ex
+++ b/lib/chat_api/slack/notifications.ex
@@ -53,6 +53,7 @@ defmodule ChatApi.Slack.Notifications do
       thread = SlackConversationThreads.get_thread_by_conversation_id(conversation_id, channel_id)
 
       # TODO: use a struct here?
+      # TODO: pass through `message` instead of text/conversation_id/type individually?
       %{
         customer: customer,
         text: text,

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -4,6 +4,7 @@ defmodule ChatApiWeb.SlackController do
   require Logger
 
   alias ChatApi.{
+    Companies,
     Conversations,
     Messages,
     Slack,
@@ -372,8 +373,9 @@ defmodule ChatApiWeb.SlackController do
 
       # TODO: should we do this? might make onboarding a bit easier, but would also set up
       # companies with "weird" names (i.e. in the format of a Slack channel name)
-      Logger.info("Would have created company with fields:")
-      Logger.info(inspect(company))
+      {:ok, result} = Companies.create_company(company)
+      Logger.info("Successfully auto-created company:")
+      Logger.info(inspect(result))
     end
   end
 


### PR DESCRIPTION
### Description

- Includes sender name/email (whichever is available) in messages sent to Slack from dashboard
- Auto-creates company when Papercups app is added to channel, so channel can start being used immediately
- Sends instructional message to channel after connected explaining how to add Papercups app where necessary

### Screenshots

**Sender info:**
<img width="374" alt="Screen Shot 2021-01-11 at 5 59 10 PM" src="https://user-images.githubusercontent.com/5264279/104248073-d5640080-5436-11eb-8ded-e4835769dd7e.png">

**Instructional message:**
<img width="676" alt="Screen Shot 2021-01-11 at 7 41 48 PM" src="https://user-images.githubusercontent.com/5264279/104254550-16fba800-5445-11eb-83d8-afcce0071543.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
