### PR TITLE
Set up feature flag for testing broadcasting replies in Slack

### DIFF
--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -456,16 +456,28 @@ defmodule ChatApi.Slack.Helpers do
   def get_message_payload(text, %{
         channel: channel,
         customer: _customer,
+        account_id: account_id,
         thread: %{slack_thread_ts: slack_thread_ts}
       }) do
     %{
       "channel" => channel,
       "text" => text,
-      "thread_ts" => slack_thread_ts
+      "thread_ts" => slack_thread_ts,
+      "reply_broadcast" => reply_broadcast_enabled?(account_id)
     }
   end
 
   def get_message_payload(text, params) do
     raise "Unrecognized params for Slack payload: #{text} #{inspect(params)}"
+  end
+
+  @spec reply_broadcast_enabled?(binary()) :: boolean()
+  defp reply_broadcast_enabled?(account_id) do
+    # TODO: figure out a better way to enable feature flags for certain accounts,
+    # or just make this configurable in account settings (or something like that)
+    case System.get_env("PAPERCUPS_FEATURE_FLAGGED_ACCOUNTS") do
+      ids when is_binary(ids) -> ids |> String.split(" ") |> Enum.member?(account_id)
+      _ -> false
+    end
   end
 end

--- a/lib/chat_api/slack/notifications.ex
+++ b/lib/chat_api/slack/notifications.ex
@@ -65,7 +65,8 @@ defmodule ChatApi.Slack.Notifications do
       |> Slack.Helpers.get_message_payload(%{
         channel: channel,
         customer: customer,
-        thread: thread
+        thread: thread,
+        account_id: account_id
       })
       |> Slack.Client.send_message(access_token)
       |> case do

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -205,7 +205,7 @@ defmodule ChatApi.SlackTest do
     end
 
     test "Helpers.get_message_payload/2 returns payload for slack reply",
-         %{thread: thread} do
+         %{account: account, thread: thread} do
       text = "Hello world"
       ts = thread.slack_thread_ts
       channel = thread.slack_channel
@@ -218,7 +218,8 @@ defmodule ChatApi.SlackTest do
                Slack.Helpers.get_message_payload(text, %{
                  channel: channel,
                  thread: thread,
-                 customer: nil
+                 customer: nil,
+                 account_id: account.id
                })
     end
 


### PR DESCRIPTION
### Description

This makes it possible to allow certain accounts to test out "broadcasting replies" in Slack.

(A few people have requested trying this out to solve the problem of not seeing messages come into old threads in Slack)

### Issue

Slack doesn't do a great job of alerting the channel about new messages in threads. This is a bit of a workaround, but might be a good solution for low-medium volume accounts.

### Screenshots

<img width="1060" alt="Screen Shot 2021-01-12 at 12 14 45 PM" src="https://user-images.githubusercontent.com/5264279/104348523-ced59780-54cf-11eb-8654-1de94e839c2b.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
