### PR TITLE
Only enable reply broadcast in Slack for messages from customers

### DIFF
--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -456,14 +456,14 @@ defmodule ChatApi.Slack.Helpers do
   def get_message_payload(text, %{
         channel: channel,
         customer: _customer,
-        account_id: account_id,
+        message: message,
         thread: %{slack_thread_ts: slack_thread_ts}
       }) do
     %{
       "channel" => channel,
       "text" => text,
       "thread_ts" => slack_thread_ts,
-      "reply_broadcast" => reply_broadcast_enabled?(account_id)
+      "reply_broadcast" => reply_broadcast_enabled?(message)
     }
   end
 
@@ -471,8 +471,12 @@ defmodule ChatApi.Slack.Helpers do
     raise "Unrecognized params for Slack payload: #{text} #{inspect(params)}"
   end
 
-  @spec reply_broadcast_enabled?(binary()) :: boolean()
-  defp reply_broadcast_enabled?(account_id) do
+  @spec reply_broadcast_enabled?(Message.t()) :: boolean()
+  # We only want to enable this for messages from customers
+  defp reply_broadcast_enabled?(%Message{
+         account_id: account_id,
+         customer: %Customer{} = _customer
+       }) do
     # TODO: figure out a better way to enable feature flags for certain accounts,
     # or just make this configurable in account settings (or something like that)
     case System.get_env("PAPERCUPS_FEATURE_FLAGGED_ACCOUNTS") do
@@ -480,4 +484,6 @@ defmodule ChatApi.Slack.Helpers do
       _ -> false
     end
   end
+
+  defp reply_broadcast_enabled?(_message), do: false
 end

--- a/lib/chat_api/slack/notifications.ex
+++ b/lib/chat_api/slack/notifications.ex
@@ -66,7 +66,7 @@ defmodule ChatApi.Slack.Notifications do
         channel: channel,
         customer: customer,
         thread: thread,
-        account_id: account_id
+        message: message
       })
       |> Slack.Client.send_message(access_token)
       |> case do

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -204,11 +204,12 @@ defmodule ChatApi.SlackTest do
                })
     end
 
-    test "Helpers.get_message_payload/2 returns payload for slack reply",
-         %{account: account, thread: thread} do
+    test "Helpers.get_message_payload/2 returns payload for slack reply", %{thread: thread} do
       text = "Hello world"
       ts = thread.slack_thread_ts
       channel = thread.slack_channel
+      customer_message = insert(:message, user: nil)
+      user_message = insert(:message, customer: nil)
 
       assert %{
                "channel" => ^channel,
@@ -219,7 +220,19 @@ defmodule ChatApi.SlackTest do
                  channel: channel,
                  thread: thread,
                  customer: nil,
-                 account_id: account.id
+                 message: customer_message
+               })
+
+      assert %{
+               "channel" => ^channel,
+               "text" => ^text,
+               "thread_ts" => ^ts
+             } =
+               Slack.Helpers.get_message_payload(text, %{
+                 channel: channel,
+                 thread: thread,
+                 customer: nil,
+                 message: user_message
                })
     end
 

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -214,7 +214,8 @@ defmodule ChatApi.SlackTest do
       assert %{
                "channel" => ^channel,
                "text" => ^text,
-               "thread_ts" => ^ts
+               "thread_ts" => ^ts,
+               "reply_broadcast" => false
              } =
                Slack.Helpers.get_message_payload(text, %{
                  channel: channel,
@@ -226,7 +227,8 @@ defmodule ChatApi.SlackTest do
       assert %{
                "channel" => ^channel,
                "text" => ^text,
-               "thread_ts" => ^ts
+               "thread_ts" => ^ts,
+               "reply_broadcast" => false
              } =
                Slack.Helpers.get_message_payload(text, %{
                  channel: channel,


### PR DESCRIPTION
### Description

Fixes case where messages from agents are broadcast when sent from the dashboard.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
