### PR TITLE
Clean up conversation/notification channels

### DIFF
--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -4,7 +4,7 @@ import {throttle} from 'lodash';
 import * as API from '../../api';
 import {notification} from '../common';
 import {Account, Conversation, Message, User} from '../../types';
-import {sleep, isWindowHidden, updateQueryParams} from '../../utils';
+import {isWindowHidden, updateQueryParams} from '../../utils';
 import {SOCKET_URL} from '../../socket';
 import logger from '../../logger';
 

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -411,28 +411,15 @@ export class ConversationsProvider extends React.Component<Props, State> {
   };
 
   handleNewConversation = async (conversationId?: string) => {
-    if (!this.channel || !conversationId) {
-      return;
-    }
+    logger.debug('Listening to new conversation:', conversationId);
 
-    this.channel.push('watch:one', {
-      conversation_id: conversationId,
-    });
-
-    // FIXME: this is a hack to fix the race condition with the `shout` event
-    await sleep(1000);
     await this.fetchAllConversations();
     await this.throttledNotificationSound();
   };
 
+  // TODO: double check that there's no logic we need to add here
   handleJoinMultipleConversations = (conversationIds: Array<string>) => {
-    if (!this.channel) {
-      return;
-    }
-
-    this.channel.push('watch:many', {
-      conversation_ids: conversationIds,
-    });
+    logger.debug('Listening to multiple new conversations:', conversationIds);
   };
 
   handleConversationUpdated = (id: string, updates: any) => {

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -16,6 +16,7 @@ defmodule ChatApi.Messages.Notification do
     })
   end
 
+  # TODO: rename to `broadcast_to_customer` or something more explicit?
   @spec broadcast_to_conversation!(Message.t()) :: Message.t()
   def broadcast_to_conversation!(%Message{} = message) do
     message
@@ -31,7 +32,7 @@ defmodule ChatApi.Messages.Notification do
         :slack
       ) do
     Logger.info("Sending notification: :slack")
-    # TODO: should we just pass in the message struct here?
+
     Task.start(fn ->
       ChatApi.Slack.Notifications.notify_primary_channel(message)
     end)

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -4,6 +4,7 @@ defmodule ChatApiWeb.NotificationChannel do
   alias ChatApiWeb.Presence
   alias Phoenix.Socket.Broadcast
   alias ChatApi.{Messages, Conversations}
+  alias ChatApi.Messages.Message
 
   require Logger
 
@@ -87,6 +88,7 @@ defmodule ChatApiWeb.NotificationChannel do
     {:noreply, socket}
   end
 
+  @spec broadcast_new_message(Message.t(), any()) :: Message.t()
   defp broadcast_new_message(message, socket) do
     broadcast(socket, "shout", Messages.Helpers.format(message))
 
@@ -99,6 +101,7 @@ defmodule ChatApiWeb.NotificationChannel do
     |> Messages.Notification.notify(:conversation_reply_email)
   end
 
+  @spec authorized?(any(), binary()) :: boolean()
   defp authorized?(socket, account_id) do
     with %{current_user: current_user} <- socket.assigns,
          %{account_id: acct} <- current_user do

--- a/test/chat_api_web/channels/notification_channel_test.exs
+++ b/test/chat_api_web/channels/notification_channel_test.exs
@@ -3,6 +3,7 @@ defmodule ChatApiWeb.NotificationChannelTest do
   import ChatApi.Factory
 
   alias ChatApi.Conversations
+  alias ChatApi.Conversations.Conversation
 
   setup do
     account = insert(:account)
@@ -43,6 +44,64 @@ defmodule ChatApiWeb.NotificationChannelTest do
   test "broadcasts are pushed to the client", %{socket: socket} do
     broadcast_from!(socket, "broadcast", %{"some" => "data"})
     assert_push "broadcast", %{"some" => "data"}
+  end
+
+  describe "Auto-assigning first responder" do
+    test "conversation assignee is updated when first agent replies", %{
+      socket: socket,
+      account: account,
+      user: user,
+      conversation: conversation
+    } do
+      msg = %{
+        body: "Hello world!",
+        account_id: account.id,
+        conversation_id: conversation.id
+      }
+
+      ref = push(socket, "shout", msg)
+      assert_reply(ref, :ok)
+      user_id = user.id
+
+      assert %Conversation{assignee_id: ^user_id} =
+               Conversations.get_conversation(conversation.id)
+    end
+
+    test "conversation assignee is not updated on subsequent replies", %{
+      socket: socket,
+      account: account,
+      user: user,
+      conversation: conversation
+    } do
+      msg = %{
+        body: "Hello world!",
+        account_id: account.id,
+        conversation_id: conversation.id
+      }
+
+      # First reply message
+      ref = push(socket, "shout", msg)
+      assert_reply(ref, :ok)
+
+      other_agent = insert(:user, account: account)
+
+      {:ok, _, other_socket} =
+        ChatApiWeb.UserSocket
+        |> socket("user_id", %{current_user: other_agent})
+        |> subscribe_and_join(ChatApiWeb.NotificationChannel, "notification:" <> account.id, %{
+          "ids" => [conversation.id]
+        })
+
+      # Second reply message
+      other_ref = push(other_socket, "shout", msg)
+      assert_reply(other_ref, :ok)
+
+      assert %Conversation{assignee_id: assignee_id} =
+               Conversations.get_conversation(conversation.id)
+
+      assert assignee_id != other_agent.id
+      assert assignee_id == user.id
+    end
   end
 
   describe "Updating first replied at" do
@@ -102,24 +161,5 @@ defmodule ChatApiWeb.NotificationChannelTest do
 
       assert conv.first_replied_at == DateTime.truncate(inserted_at, :second)
     end
-  end
-
-  test "conversation assignee is updated when first agent replies", %{
-    socket: socket,
-    account: account,
-    user: user,
-    conversation: conversation
-  } do
-    msg = %{
-      body: "Hello world!",
-      account_id: account.id,
-      conversation_id: conversation.id
-    }
-
-    ref = push(socket, "shout", msg)
-    assert_reply(ref, :ok)
-    conv = Conversations.get_conversation(conversation.id)
-
-    assert conv.assignee_id == user.id
   end
 end


### PR DESCRIPTION
### Description

Minor refactoring to the `conversation_channel` and `notification_channel` to make it easier to support private messages.

### Issue

Prereq for https://github.com/papercups-io/papercups/issues/452

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
