### PR TITLE
Make it possible to customize username and photo in Papercups Slack app

### DIFF
--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -45,7 +45,7 @@ const ConversationFooter = ({
               <TextArea
                 className="TextArea--transparent"
                 placeholder="Type your message here!"
-                autoSize={{maxRows: 4}}
+                autoSize={{minRows: 2, maxRows: 4}}
                 autoFocus
                 value={message}
                 onKeyDown={handleKeyDown}

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -7,8 +7,6 @@ import {SLACK_CLIENT_ID, isDev} from '../../config';
 import {IntegrationType} from './support';
 
 const getSlackAuthUrl = (type = 'reply') => {
-  // NB: when testing locally, update `origin` to an ngrok url
-  // pointing at localhost:4000 (or wherever your server is running)
   const origin = window.location.origin;
   const redirect = `${origin}/integrations/slack`;
   const scopes = [

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -18,13 +18,14 @@ const getSlackAuthUrl = (type = 'reply') => {
     'channels:manage',
     'channels:read',
     'chat:write.public',
+    'chat:write.customize',
     'users:read',
     'users:read.email',
     'groups:history',
     'groups:read',
     'reactions:read',
   ];
-  const userScopes = ['channels:history', 'groups:history'];
+  const userScopes = ['channels:history', 'groups:history', 'chat:write'];
   const q = {
     state: type,
     scope: scopes.join(' '),

--- a/lib/chat_api/slack/notifications.ex
+++ b/lib/chat_api/slack/notifications.ex
@@ -197,16 +197,16 @@ defmodule ChatApi.Slack.Notifications do
     end
   end
 
+  @papercups_app_name "Papercups"
+  @papercups_icon_url "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2021-01-05/1626939067681_3e27968eb3657d7167e5_132.png"
+
   @spec default_app_name() :: String.t()
   defp default_app_name() do
-    System.get_env("PAPERCUPS_APP_NAME", "Papercups")
+    System.get_env("PAPERCUPS_APP_NAME", @papercups_app_name)
   end
 
   @spec default_app_icon_url() :: String.t()
   defp default_app_icon_url() do
-    System.get_env(
-      "PAPERCUPS_APP_ICON_URL",
-      "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2021-01-05/1626939067681_3e27968eb3657d7167e5_132.png"
-    )
+    System.get_env("PAPERCUPS_APP_ICON_URL", @papercups_icon_url)
   end
 end

--- a/lib/chat_api/slack/notifications.ex
+++ b/lib/chat_api/slack/notifications.ex
@@ -134,7 +134,7 @@ defmodule ChatApi.Slack.Notifications do
   def notify_slack_channel(
         access_token,
         channel_id,
-        %Message{conversation_id: conversation_id} = message
+        %Message{conversation_id: conversation_id, user: user} = message
       ) do
     conversation_id
     |> SlackConversationThreads.get_threads_by_conversation_id()
@@ -143,7 +143,9 @@ defmodule ChatApi.Slack.Notifications do
       message = %{
         "text" => format_slack_message_text(message),
         "channel" => thread.slack_channel,
-        "thread_ts" => thread.slack_thread_ts
+        "thread_ts" => thread.slack_thread_ts,
+        "username" => format_user_name(user),
+        "icon_url" => slack_icon_url(user)
       }
 
       Slack.Client.send_message(message, access_token)
@@ -154,7 +156,7 @@ defmodule ChatApi.Slack.Notifications do
   defp format_slack_message_text(%Message{} = message) do
     case message do
       %{body: body, user: %User{} = user} when not is_nil(user) ->
-        "*#{format_user_name(user)}*: #{body}"
+        body
 
       %{body: body, customer: %Customer{} = customer} when not is_nil(customer) ->
         "*:wave: #{Slack.Helpers.identify_customer(customer)}*: #{body}"
@@ -164,8 +166,8 @@ defmodule ChatApi.Slack.Notifications do
     end
   end
 
-  @spec format_user_name(User.t()) :: String.t()
-  defp format_user_name(%User{} = user) do
+  @spec format_user_name(User.t() | nil) :: String.t()
+  defp format_user_name(user) do
     case user do
       %{profile: %UserProfile{display_name: display_name}}
       when not is_nil(display_name) ->
@@ -175,8 +177,36 @@ defmodule ChatApi.Slack.Notifications do
       when not is_nil(full_name) ->
         full_name
 
-      user ->
-        user.email
+      %{email: email} ->
+        email
+
+      _ ->
+        default_app_name()
     end
+  end
+
+  @spec slack_icon_url(User.t() | nil) :: String.t()
+  defp slack_icon_url(user) do
+    case user do
+      %{profile: %UserProfile{profile_photo_url: profile_photo_url}}
+      when not is_nil(profile_photo_url) ->
+        profile_photo_url
+
+      _ ->
+        default_app_icon_url()
+    end
+  end
+
+  @spec default_app_name() :: String.t()
+  defp default_app_name() do
+    System.get_env("PAPERCUPS_APP_NAME", "Papercups")
+  end
+
+  @spec default_app_icon_url() :: String.t()
+  defp default_app_icon_url() do
+    System.get_env(
+      "PAPERCUPS_APP_ICON_URL",
+      "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2021-01-05/1626939067681_3e27968eb3657d7167e5_132.png"
+    )
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -142,12 +142,20 @@ defmodule ChatApi.Factory do
     }
   end
 
-  @spec user_factory :: ChatApi.Users.User.t()
   def user_factory do
     %ChatApi.Users.User{
       email: sequence(:email, &"company_name-#{&1}@example.com"),
       account: build(:account),
       password: "supersecret123"
+    }
+  end
+
+  def user_profile_factory do
+    %ChatApi.Users.UserProfile{
+      user: build(:user),
+      display_name: "Test User",
+      full_name: "Testy McTesterson",
+      profile_photo_url: "https://via.placeholder.com/100x100"
     }
   end
 


### PR DESCRIPTION
### Description

Adds the scope to make it possible to customize username and photo in Papercups Slack app

### Issue

Users want to show up as "themselves", rather than a bot/app

### Screenshots

<img width="382" alt="Screen Shot 2021-01-13 at 12 43 54 PM" src="https://user-images.githubusercontent.com/5264279/104489420-9c926b80-559d-11eb-80d4-e4bbac71dc0b.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
