### PR TITLE
Minor improvements to Slack integration logic

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -242,6 +242,23 @@ defmodule ChatApi.Conversations do
     Conversation.changeset(conversation, attrs)
   end
 
+  @spec get_first_message(binary()) :: Message.t() | nil
+  def get_first_message(conversation_id) do
+    Message
+    |> where(conversation_id: ^conversation_id)
+    |> order_by(asc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
+  @spec is_first_message?(binary(), binary()) :: boolean()
+  def is_first_message?(conversation_id, message_id) do
+    case get_first_message(conversation_id) do
+      %Message{id: ^message_id} -> true
+      _ -> false
+    end
+  end
+
   @spec count_agent_replies(binary()) :: number()
   def count_agent_replies(conversation_id) do
     Message

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -7,8 +7,12 @@ defmodule ChatApi.Messages.Helpers do
   alias ChatApi.Messages.Message
 
   @spec get_conversation_topic(Message.t()) :: binary()
-  def get_conversation_topic(%{conversation_id: conversation_id} = _message),
+  def get_conversation_topic(%Message{conversation_id: conversation_id} = _message),
     do: "conversation:" <> conversation_id
+
+  @spec get_admin_topic(Message.t()) :: binary()
+  def get_admin_topic(%Message{account_id: account_id} = _message),
+    do: "notification:" <> account_id
 
   @spec format(Message.t()) :: map()
   def format(%Message{} = message),

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -26,6 +26,15 @@ defmodule ChatApi.Messages.Notification do
     message
   end
 
+  @spec broadcast_to_admin!(Message.t()) :: Message.t()
+  def broadcast_to_admin!(%Message{} = message) do
+    message
+    |> Helpers.get_admin_topic()
+    |> ChatApiWeb.Endpoint.broadcast!("shout", Helpers.format(message))
+
+    message
+  end
+
   @spec notify(Message.t(), atom()) :: Message.t()
   def notify(
         %Message{body: _body, conversation_id: _conversation_id} = message,

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -43,7 +43,7 @@ defmodule ChatApi.Messages.Notification do
     Logger.info("Sending notification: :slack")
 
     Task.start(fn ->
-      ChatApi.Slack.Notifications.notify_primary_channel(message)
+      ChatApi.Slack.Notification.notify_primary_channel(message)
     end)
 
     message
@@ -90,7 +90,7 @@ defmodule ChatApi.Messages.Notification do
     Logger.info("Sending notification: :slack_company_channel")
 
     Task.start(fn ->
-      ChatApi.Slack.Notifications.notify_company_channel(message)
+      ChatApi.Slack.Notification.notify_company_channel(message)
     end)
 
     message
@@ -101,7 +101,7 @@ defmodule ChatApi.Messages.Notification do
     Logger.info("Sending notification: :slack_support_channel")
 
     Task.start(fn ->
-      ChatApi.Slack.Notifications.notify_support_channel(message)
+      ChatApi.Slack.Notification.notify_support_channel(message)
     end)
 
     message

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -16,9 +16,8 @@ defmodule ChatApi.Messages.Notification do
     })
   end
 
-  # TODO: rename to `broadcast_to_customer` or something more explicit?
-  @spec broadcast_to_conversation!(Message.t()) :: Message.t()
-  def broadcast_to_conversation!(%Message{} = message) do
+  @spec broadcast_to_customer!(Message.t()) :: Message.t()
+  def broadcast_to_customer!(%Message{} = message) do
     message
     |> Helpers.get_conversation_topic()
     |> ChatApiWeb.Endpoint.broadcast!("shout", Helpers.format(message))

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -113,4 +113,21 @@ defmodule ChatApi.Messages.Notification do
 
     message
   end
+
+  @spec notify(Message.t(), atom(), map()) :: Message.t()
+  def notify(%Message{} = message, :slack, metadata) do
+    # NB: we currently use the Slack authorization metadata to handle one-off cases
+    # where a user might not want to broadcast to the "reply"-type Slack integration
+    # under certain circumstances.
+    if send_to_slack_reply_channel?(metadata),
+      do: notify(message, :slack),
+      else: message
+  end
+
+  def notify(%Message{} = message, type, _metadata) do
+    notify(message, type)
+  end
+
+  defp send_to_slack_reply_channel?(%{"send_to_reply_channel" => false}), do: false
+  defp send_to_slack_reply_channel?(_), do: true
 end

--- a/lib/chat_api/slack/notification.ex
+++ b/lib/chat_api/slack/notification.ex
@@ -1,4 +1,4 @@
-defmodule ChatApi.Slack.Notifications do
+defmodule ChatApi.Slack.Notification do
   @moduledoc """
   A module to handle sending Slack notifications.
   """

--- a/lib/chat_api/slack_authorizations/slack_authorization.ex
+++ b/lib/chat_api/slack_authorizations/slack_authorization.ex
@@ -4,22 +4,46 @@ defmodule ChatApi.SlackAuthorizations.SlackAuthorization do
 
   alias ChatApi.Accounts.Account
 
+  @type t :: %__MODULE__{
+          access_token: String.t(),
+          type: String.t() | nil,
+          app_id: String.t() | nil,
+          authed_user_id: String.t() | nil,
+          bot_user_id: String.t() | nil,
+          channel: String.t() | nil,
+          channel_id: String.t() | nil,
+          configuration_url: String.t() | nil,
+          scope: String.t() | nil,
+          team_id: String.t() | nil,
+          team_name: String.t() | nil,
+          token_type: String.t() | nil,
+          webhook_url: String.t() | nil,
+          metadata: any(),
+          # Relations
+          account_id: any(),
+          account: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "slack_authorizations" do
-    field :access_token, :string
-    field :type, :string, default: "reply"
-    field :app_id, :string
-    field :authed_user_id, :string
-    field :bot_user_id, :string
-    field :channel, :string
-    field :channel_id, :string
-    field :configuration_url, :string
-    field :scope, :string
-    field :team_id, :string
-    field :team_name, :string
-    field :token_type, :string
-    field :webhook_url, :string
+    field(:access_token, :string)
+    field(:type, :string, default: "reply")
+    field(:app_id, :string)
+    field(:authed_user_id, :string)
+    field(:bot_user_id, :string)
+    field(:channel, :string)
+    field(:channel_id, :string)
+    field(:configuration_url, :string)
+    field(:scope, :string)
+    field(:team_id, :string)
+    field(:team_name, :string)
+    field(:token_type, :string)
+    field(:webhook_url, :string)
+    field(:metadata, :map)
 
     belongs_to(:account, Account)
 
@@ -43,7 +67,8 @@ defmodule ChatApi.SlackAuthorizations.SlackAuthorization do
       :scope,
       :team_id,
       :team_name,
-      :token_type
+      :token_type,
+      :metadata
     ])
     |> validate_required([:account_id, :access_token])
     |> validate_inclusion(:type, ["reply", "support"])

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -102,7 +102,7 @@ defmodule ChatApiWeb.NotificationChannel do
     broadcast(socket, "shout", Messages.Helpers.format(message))
 
     message
-    |> Messages.Notification.broadcast_to_conversation!()
+    |> Messages.Notification.broadcast_to_customer!()
     |> Messages.Notification.notify(:slack)
     |> Messages.Notification.notify(:slack_support_channel)
     |> Messages.Notification.notify(:slack_company_channel)

--- a/lib/chat_api_web/controllers/billing_controller.ex
+++ b/lib/chat_api_web/controllers/billing_controller.ex
@@ -42,7 +42,7 @@ defmodule ChatApiWeb.BillingController do
       # Putting in an async Task for now, since we don't care if this succeeds
       # or fails (and we also don't want it to block anything)
       Task.start(fn ->
-        ChatApi.Slack.Notifications.log("#{email} set subscription plan to #{plan}")
+        ChatApi.Slack.Notification.log("#{email} set subscription plan to #{plan}")
       end)
     end
 

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -244,7 +244,7 @@ defmodule ChatApiWeb.ConversationController do
            })
            |> Messages.create_message() do
       Messages.get_message!(msg.id)
-      |> Messages.Notification.broadcast_to_conversation!()
+      |> Messages.Notification.broadcast_to_customer!()
       |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:slack)
       |> Messages.Notification.notify(:webhooks)

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -245,6 +245,7 @@ defmodule ChatApiWeb.ConversationController do
            |> Messages.create_message() do
       Messages.get_message!(msg.id)
       |> Messages.Notification.broadcast_to_conversation!()
+      |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:slack)
       |> Messages.Notification.notify(:webhooks)
 

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -111,7 +111,7 @@ defmodule ChatApiWeb.GmailController do
       # Putting in an async Task for now, since we don't care if this succeeds
       # or fails (and we also don't want it to block anything)
       Task.start(fn ->
-        ChatApi.Slack.Notifications.log("#{email} successfully linked Gmail!")
+        ChatApi.Slack.Notification.log("#{email} successfully linked Gmail!")
       end)
     end
 

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -134,6 +134,7 @@ defmodule ChatApiWeb.MessageController do
   defp broadcast_new_message(message) do
     message
     |> Messages.Notification.broadcast_to_conversation!()
+    |> Messages.Notification.broadcast_to_admin!()
     |> Messages.Notification.notify(:slack)
     |> Messages.Notification.notify(:slack_support_channel)
     |> Messages.Notification.notify(:slack_company_channel)

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -133,7 +133,7 @@ defmodule ChatApiWeb.MessageController do
 
   defp broadcast_new_message(message) do
     message
-    |> Messages.Notification.broadcast_to_conversation!()
+    |> Messages.Notification.broadcast_to_customer!()
     |> Messages.Notification.broadcast_to_admin!()
     |> Messages.Notification.notify(:slack)
     |> Messages.Notification.notify(:slack_support_channel)

--- a/lib/chat_api_web/controllers/registration_controller.ex
+++ b/lib/chat_api_web/controllers/registration_controller.ex
@@ -135,7 +135,7 @@ defmodule ChatApiWeb.RegistrationController do
       # Putting in an async Task for now, since we don't care if this succeeds
       # or fails (and we also don't want it to block anything)
       Task.start(fn ->
-        ChatApi.Slack.Notifications.log("A new user has signed up: #{email}")
+        ChatApi.Slack.Notification.log("A new user has signed up: #{email}")
       end)
     end
 

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -228,6 +228,7 @@ defmodule ChatApiWeb.SlackController do
         }
         |> Messages.create_and_fetch!()
         |> Messages.Notification.broadcast_to_conversation!()
+        |> Messages.Notification.broadcast_to_admin!()
         |> Messages.Notification.notify(:webhooks)
         |> Messages.Notification.notify(:slack_support_channel)
         |> Messages.Notification.notify(:slack_company_channel)
@@ -248,6 +249,7 @@ defmodule ChatApiWeb.SlackController do
             })
             |> Messages.create_and_fetch!()
             |> Messages.Notification.broadcast_to_conversation!()
+            |> Messages.Notification.broadcast_to_admin!()
             |> Messages.Notification.notify(:webhooks)
             |> Messages.Notification.notify(:slack)
             |> Messages.Helpers.handle_post_creation_conversation_updates()
@@ -314,9 +316,11 @@ defmodule ChatApiWeb.SlackController do
 
       Messages.get_message!(message.id)
       |> Messages.Notification.broadcast_to_conversation!()
-      # notify primary channel only
-      |> Messages.Notification.notify(:slack)
+      |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:webhooks)
+      # TODO: should we make this configurable? Or only do it from private channels?
+      # (Considering temporarily disabling this until we figure out what most users want)
+      |> Messages.Notification.notify(:slack)
     end
   end
 
@@ -453,9 +457,12 @@ defmodule ChatApiWeb.SlackController do
 
       Messages.get_message!(message.id)
       |> Messages.Notification.broadcast_to_conversation!()
-      # notify primary channel only
-      |> Messages.Notification.notify(:slack)
+      |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:webhooks)
+      # TODO: should we make this configurable? Or only do it from private channels?
+      # (Leaving this enabled for the emoji reaction use case, since it's an explicit action
+      # as opposed to the auto-syncing that occurs above for all new messages)
+      |> Messages.Notification.notify(:slack)
     end
   end
 

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -536,7 +536,7 @@ defmodule ChatApiWeb.SlackController do
     Logger.info(message)
     # Putting in an async Task for now, since we don't care if this succeeds
     # or fails (and we also don't want it to block anything)
-    Task.start(fn -> Slack.Notifications.log(message) end)
+    Task.start(fn -> Slack.Notification.log(message) end)
   end
 
   @spec send_private_channel_instructions(:reply | :support, binary()) :: any()
@@ -556,7 +556,7 @@ defmodule ChatApiWeb.SlackController do
     Logger.info(message)
     # Putting in an async Task for now, since we don't care if this succeeds
     # or fails (and we also don't want it to block anything)
-    Task.start(fn -> Slack.Notifications.log(message, webhook_url) end)
+    Task.start(fn -> Slack.Notification.log(message, webhook_url) end)
   end
 
   defp send_private_channel_instructions(:support, webhook_url) do
@@ -575,7 +575,7 @@ defmodule ChatApiWeb.SlackController do
     Logger.info(message)
     # Putting in an async Task for now, since we don't care if this succeeds
     # or fails (and we also don't want it to block anything)
-    Task.start(fn -> Slack.Notifications.log(message, webhook_url) end)
+    Task.start(fn -> Slack.Notification.log(message, webhook_url) end)
   end
 
   @spec send_support_channel_instructions(binary()) :: any()
@@ -595,6 +595,6 @@ defmodule ChatApiWeb.SlackController do
     Logger.info(message)
     # Putting in an async Task for now, since we don't care if this succeeds
     # or fails (and we also don't want it to block anything)
-    Task.start(fn -> Slack.Notifications.log(message, webhook_url) end)
+    Task.start(fn -> Slack.Notification.log(message, webhook_url) end)
   end
 end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -227,7 +227,7 @@ defmodule ChatApiWeb.SlackController do
             )
         }
         |> Messages.create_and_fetch!()
-        |> Messages.Notification.broadcast_to_conversation!()
+        |> Messages.Notification.broadcast_to_customer!()
         |> Messages.Notification.broadcast_to_admin!()
         |> Messages.Notification.notify(:webhooks)
         |> Messages.Notification.notify(:slack_support_channel)
@@ -248,7 +248,7 @@ defmodule ChatApiWeb.SlackController do
               "source" => "slack"
             })
             |> Messages.create_and_fetch!()
-            |> Messages.Notification.broadcast_to_conversation!()
+            |> Messages.Notification.broadcast_to_customer!()
             |> Messages.Notification.broadcast_to_admin!()
             |> Messages.Notification.notify(:webhooks)
             |> Messages.Notification.notify(:slack)
@@ -315,12 +315,13 @@ defmodule ChatApiWeb.SlackController do
       |> Conversations.Notification.broadcast_conversation_to_customer!()
 
       Messages.get_message!(message.id)
-      |> Messages.Notification.broadcast_to_conversation!()
+      |> Messages.Notification.broadcast_to_customer!()
       |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:webhooks)
+
       # TODO: should we make this configurable? Or only do it from private channels?
       # (Considering temporarily disabling this until we figure out what most users want)
-      |> Messages.Notification.notify(:slack)
+      # |> Messages.Notification.notify(:slack)
     end
   end
 
@@ -456,7 +457,7 @@ defmodule ChatApiWeb.SlackController do
       |> Conversations.Notification.broadcast_conversation_to_customer!()
 
       Messages.get_message!(message.id)
-      |> Messages.Notification.broadcast_to_conversation!()
+      |> Messages.Notification.broadcast_to_customer!()
       |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:webhooks)
       # TODO: should we make this configurable? Or only do it from private channels?

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -318,10 +318,9 @@ defmodule ChatApiWeb.SlackController do
       |> Messages.Notification.broadcast_to_customer!()
       |> Messages.Notification.broadcast_to_admin!()
       |> Messages.Notification.notify(:webhooks)
-
       # TODO: should we make this configurable? Or only do it from private channels?
       # (Considering temporarily disabling this until we figure out what most users want)
-      # |> Messages.Notification.notify(:slack)
+      |> Messages.Notification.notify(:slack, authorization.metadata)
     end
   end
 

--- a/priv/repo/migrations/20210118193526_add_metadata_to_slack_authorizations.exs
+++ b/priv/repo/migrations/20210118193526_add_metadata_to_slack_authorizations.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddMetadataToSlackAuthorizations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:slack_authorizations) do
+      add(:metadata, :map)
+    end
+  end
+end

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -9,6 +9,7 @@ defmodule ChatApi.ConversationsTest do
   describe "conversations" do
     alias ChatApi.Conversations.Conversation
     alias ChatApi.SlackConversationThreads.SlackConversationThread
+    alias ChatApi.Messages.Message
 
     @update_attrs %{status: "closed"}
     @invalid_attrs %{status: nil}
@@ -334,6 +335,42 @@ defmodule ChatApi.ConversationsTest do
                Conversations.update_conversation(conversation, %{status: "open"})
 
       assert open_conversation.closed_at == nil
+    end
+
+    test "get_first_message/1 returns the first message of the conversation",
+         %{account: account, conversation: conversation} do
+      refute Conversations.get_first_message(conversation.id)
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          inserted_at: ~N[2020-11-02 20:00:00]
+        )
+
+      message_id = message.id
+
+      assert %Message{id: ^message_id} = Conversations.get_first_message(conversation.id)
+    end
+
+    test "is_first_message?/2 checks if the message is the first message of the conversation",
+         %{account: account, conversation: conversation} do
+      first_message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          inserted_at: ~N[2020-11-02 20:00:00]
+        )
+
+      second_message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          inserted_at: ~N[2020-11-02 20:00:00]
+        )
+
+      assert Conversations.is_first_message?(conversation.id, first_message.id)
+      refute Conversations.is_first_message?(conversation.id, second_message.id)
     end
 
     defp days_ago(days) do

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -366,7 +366,7 @@ defmodule ChatApi.ConversationsTest do
         insert(:message,
           account: account,
           conversation: conversation,
-          inserted_at: ~N[2020-11-02 20:00:00]
+          inserted_at: ~N[2020-11-02 20:15:00]
         )
 
       assert Conversations.is_first_message?(conversation.id, first_message.id)

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -108,7 +108,8 @@ defmodule ChatApi.MessagesTest do
         insert(:message, conversation: conversation, customer: customer, user: nil)
 
       # No conversation updates are necessary on the first customer message
-      assert %{} = Messages.Helpers.build_conversation_updates(initial_customer_message)
+      assert %{read: false} =
+               Messages.Helpers.build_conversation_updates(initial_customer_message)
 
       first_agent_reply = insert(:message, conversation: conversation, user: agent, customer: nil)
       agent_id = agent.id
@@ -120,7 +121,7 @@ defmodule ChatApi.MessagesTest do
       first_customer_reply =
         insert(:message, conversation: conversation, customer: customer, user: nil)
 
-      assert %{} = Messages.Helpers.build_conversation_updates(first_customer_reply)
+      assert %{read: false} = Messages.Helpers.build_conversation_updates(first_customer_reply)
 
       second_agent_reply =
         insert(:message, conversation: conversation, user: agent, customer: nil)

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -23,7 +23,7 @@ defmodule ChatApi.SlackTest do
   @slack_user_id "U123TEST"
   @slack_channel_id "C123TEST"
 
-  describe "Slack.Notifications" do
+  describe "Slack.Notification" do
     setup do
       account = insert(:account)
       auth = insert(:slack_authorization, account: account, type: "support")
@@ -73,7 +73,7 @@ defmodule ChatApi.SlackTest do
           {:ok, %{body: Map.merge(%{"ok" => true}, msg)}}
         end do
         message = Messages.get_message!(message.id)
-        assert :ok = Slack.Notifications.notify_slack_channel(@slack_channel_id, message)
+        assert :ok = Slack.Notification.notify_slack_channel(@slack_channel_id, message)
 
         assert_called(Slack.Client.send_message(:_, :_))
 
@@ -114,7 +114,7 @@ defmodule ChatApi.SlackTest do
           {:ok, %{body: Map.merge(%{"ok" => true}, msg)}}
         end do
         message = Messages.get_message!(message.id)
-        assert :ok = Slack.Notifications.notify_slack_channel(@slack_channel_id, message)
+        assert :ok = Slack.Notification.notify_slack_channel(@slack_channel_id, message)
 
         assert_called(Slack.Client.send_message(:_, :_))
 
@@ -144,7 +144,7 @@ defmodule ChatApi.SlackTest do
         send_message: fn msg, _ ->
           {:ok, %{body: Map.merge(%{"ok" => true}, msg)}}
         end do
-        assert :ok = Slack.Notifications.notify_slack_channel("C123UNKNOWN", message)
+        assert :ok = Slack.Notification.notify_slack_channel("C123UNKNOWN", message)
 
         assert_not_called(Slack.Client.send_message(:_, :_))
       end

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -45,7 +45,7 @@ defmodule ChatApi.SlackTest do
        thread: thread}
     end
 
-    test "Notifications.notify_slack_channel/2 sends a thread reply notification", %{
+    test "Notification.notify_slack_channel/2 sends a thread reply notification", %{
       account: account,
       auth: auth,
       conversation: conversation,
@@ -92,7 +92,7 @@ defmodule ChatApi.SlackTest do
       end
     end
 
-    test "Notifications.notify_slack_channel/2 sends a thread reply notification for users without profile info",
+    test "Notification.notify_slack_channel/2 sends a thread reply notification for users without profile info",
          %{
            account: account,
            auth: auth,
@@ -132,7 +132,7 @@ defmodule ChatApi.SlackTest do
       end
     end
 
-    test "Notifications.notify_slack_channel/2 does not send a thread reply if channel is not found",
+    test "Notification.notify_slack_channel/2 does not send a thread reply if channel is not found",
          %{
            account: account,
            customer: customer,
@@ -148,6 +148,26 @@ defmodule ChatApi.SlackTest do
 
         assert_not_called(Slack.Client.send_message(:_, :_))
       end
+    end
+
+    test "Notification.validate_send_to_primary_channel/2 returns :ok if the message is the initial message",
+         %{thread: thread} do
+      assert :ok =
+               Slack.Notification.validate_send_to_primary_channel(thread, is_first_message: true)
+
+      assert :ok =
+               Slack.Notification.validate_send_to_primary_channel(nil, is_first_message: true)
+    end
+
+    test "Notification.validate_send_to_primary_channel/2 returns :ok if a thread already exists",
+         %{thread: thread} do
+      assert :ok =
+               Slack.Notification.validate_send_to_primary_channel(thread, is_first_message: false)
+    end
+
+    test "Notification.validate_send_to_primary_channel/2 returns :error if the message when the message is not an initial message and a thread does not exist" do
+      assert :error =
+               Slack.Notification.validate_send_to_primary_channel(nil, is_first_message: false)
     end
   end
 


### PR DESCRIPTION
### Description

Minor improvements to Slack integration logic.

TODO:
- [x] Add validation logic for when to create new thread in Slack "reply" integration
- [x] Make the separation between customer/admin channels more explicit
- [x] Add `metadata` field to `slack_authorizations` so we can start customizing logic per account more easily
- [x] Testing!

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
