### PR TITLE
[Reporting] Response time metrics v2

### DIFF
--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -242,7 +242,7 @@ class ReportingDashboard extends React.Component<Props, State> {
       description: (
         <Paragraph>
           <Text
-            style={{color: percentage < 0 ? colors.red : colors.green}}
+            style={{color: percentage < 0 ? colors.green : colors.red}}
           >{`${sign}${Math.abs(percentage).toFixed(2)}%`}</Text>{' '}
           <Text type="secondary">from previous week</Text>
         </Paragraph>
@@ -278,7 +278,7 @@ class ReportingDashboard extends React.Component<Props, State> {
       description: (
         <Paragraph>
           <Text
-            style={{color: percentage < 0 ? colors.red : colors.green}}
+            style={{color: percentage < 0 ? colors.green : colors.red}}
           >{`${sign}${Math.abs(percentage).toFixed(2)}%`}</Text>{' '}
           <Text type="secondary">from previous week</Text>
         </Paragraph>

--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -233,7 +233,8 @@ class ReportingDashboard extends React.Component<Props, State> {
     }
 
     const {average: averageLastWeek} = next;
-    const percentage = (averageThisWeek - averageLastWeek) / averageLastWeek;
+    const percentage =
+      (averageThisWeek - averageLastWeek) / (averageLastWeek || 1);
     const sign = percentage < 0 ? '-' : '+';
 
     return {
@@ -249,6 +250,7 @@ class ReportingDashboard extends React.Component<Props, State> {
     };
   };
 
+  // TODO: DRY this up with function above
   formatMedianResponseTimeThisWeek = () => {
     const {firstReplyMetricsByWeek = []} = this.state;
     const [current, next] = firstReplyMetricsByWeek;
@@ -267,7 +269,8 @@ class ReportingDashboard extends React.Component<Props, State> {
     }
 
     const {median: medianLastWeek} = next;
-    const percentage = (medianThisWeek - medianLastWeek) / medianLastWeek;
+    const percentage =
+      (medianThisWeek - medianLastWeek) / (medianLastWeek || 1);
     const sign = percentage < 0 ? '-' : '+';
 
     return {

--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -125,6 +125,7 @@ defmodule ChatApi.Reporting do
   def get_weekly_chunks(filters \\ %{}) do
     from_date =
       case Map.fetch(filters, :from_date) do
+        {:ok, %NaiveDateTime{} = date} -> date
         {:ok, date} -> NaiveDateTime.from_iso8601!(date)
         # Default to one week ago
         :error -> NaiveDateTime.utc_now() |> NaiveDateTime.add(-1 * @seconds_per_week)
@@ -132,6 +133,7 @@ defmodule ChatApi.Reporting do
 
     to_date =
       case Map.fetch(filters, :to_date) do
+        {:ok, %NaiveDateTime{} = date} -> date
         {:ok, date} -> NaiveDateTime.from_iso8601!(date)
         :error -> NaiveDateTime.utc_now()
       end
@@ -139,10 +141,12 @@ defmodule ChatApi.Reporting do
     get_weekly_chunks(from_date, to_date)
   end
 
+  @spec start_of_week(Date.t()) :: Date.t()
   def start_of_week(date) do
     Date.add(date, -1 * Date.day_of_week(date))
   end
 
+  @spec end_of_week(Date.t()) :: Date.t()
   def end_of_week(date) do
     Date.add(date, 7 - Date.day_of_week(date))
   end

--- a/lib/chat_api/reporting.ex
+++ b/lib/chat_api/reporting.ex
@@ -171,6 +171,20 @@ defmodule ChatApi.Reporting do
     |> average()
   end
 
+  @spec median_seconds_to_first_reply(binary(), map()) :: float()
+  def median_seconds_to_first_reply(account_id, filters \\ %{}) do
+    account_id
+    |> list_conversations_with_agent_reply(filters)
+    |> compute_median_seconds_to_first_reply()
+  end
+
+  @spec compute_median_seconds_to_first_reply([Conversation.t()]) :: float()
+  def compute_median_seconds_to_first_reply(conversations) do
+    conversations
+    |> Enum.map(&calculate_seconds_to_first_reply/1)
+    |> median()
+  end
+
   @spec average([integer()]) :: float()
   def average([]), do: 0.0
 

--- a/lib/chat_api_web/controllers/reporting_controller.ex
+++ b/lib/chat_api_web/controllers/reporting_controller.ex
@@ -25,15 +25,17 @@ defmodule ChatApiWeb.ReportingController do
           Reporting.first_response_time_by_weekday(account_id, filters),
         sent_messages_by_date: Reporting.count_sent_messages_by_date(account_id, filters),
         received_messages_by_date: Reporting.count_received_messages_by_date(account_id, filters),
-        customer_breakdown_by_browser:
-          Reporting.get_customer_breakdown(account_id, :browser, filters),
-        customer_breakdown_by_os: Reporting.get_customer_breakdown(account_id, :os, filters),
-        average_time_to_first_respond:
+        average_time_to_first_reply:
           Reporting.average_seconds_to_first_reply(account_id, filters),
-        customer_breakdown_by_time_zone:
-          Reporting.get_customer_breakdown(account_id, :time_zone, filters),
+        median_time_to_first_reply: Reporting.median_seconds_to_first_reply(account_id, filters),
         first_reply_metrics_by_week:
           Reporting.seconds_to_first_reply_metrics_by_week(account_id, filters)
+        # NB: this are currently unused
+        # customer_breakdown_by_browser:
+        #   Reporting.get_customer_breakdown(account_id, :browser, filters),
+        # customer_breakdown_by_os: Reporting.get_customer_breakdown(account_id, :os, filters),
+        # customer_breakdown_by_time_zone:
+        #   Reporting.get_customer_breakdown(account_id, :time_zone, filters),
       }
     })
   end

--- a/lib/chat_api_web/controllers/reporting_controller.ex
+++ b/lib/chat_api_web/controllers/reporting_controller.ex
@@ -31,7 +31,9 @@ defmodule ChatApiWeb.ReportingController do
         average_time_to_first_respond:
           Reporting.average_seconds_to_first_reply(account_id, filters),
         customer_breakdown_by_time_zone:
-          Reporting.get_customer_breakdown(account_id, :time_zone, filters)
+          Reporting.get_customer_breakdown(account_id, :time_zone, filters),
+        first_reply_metrics_by_week:
+          Reporting.seconds_to_first_reply_metrics_by_week(account_id, filters)
       }
     })
   end

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -854,4 +854,30 @@ defmodule ChatApi.ReportingTest do
       assert 0.5 = Reporting.median([-1, 2, -3, 4])
     end
   end
+
+  describe "get_weekly_chunks/2" do
+    test "gets the week tuples for the given date range" do
+      from_date = ~N[2020-10-01 12:00:00]
+      to_date = ~N[2020-10-04 13:00:00]
+
+      assert [{~D[2020-09-27] = start, ~D[2020-10-03] = finish}] =
+               Reporting.get_weekly_chunks(from_date, to_date)
+
+      from_date = ~N[2020-10-01 12:00:00]
+      to_date = ~N[2020-11-01 12:00:00]
+      chunks = Reporting.get_weekly_chunks(from_date, to_date)
+
+      assert [
+               {~D[2020-10-25], ~D[2020-10-31]},
+               {~D[2020-10-18], ~D[2020-10-24]},
+               {~D[2020-10-11], ~D[2020-10-17]},
+               {~D[2020-10-04], ~D[2020-10-10]},
+               {~D[2020-09-27], ~D[2020-10-03]}
+             ] = chunks
+
+      # Verify that the start is on a Sunday (7) and the end is on a Saturday (6)
+      assert Enum.all?(chunks, fn {start, _} -> Date.day_of_week(start) == 7 end)
+      assert Enum.all?(chunks, fn {_, finish} -> Date.day_of_week(finish) == 6 end)
+    end
+  end
 end


### PR DESCRIPTION
### Description

Adds response time metrics on a week-by-week level

### Issue

TODO

### Screenshots

<img width="1107" alt="Screen Shot 2021-01-15 at 5 54 23 PM" src="https://user-images.githubusercontent.com/5264279/104786355-b9c06900-575a-11eb-9565-22dca06cbe2f.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
