### PR TITLE
Enable syncing replies to bot messages in Slack support integration

### DIFF
--- a/assets/src/components/companies/CreateCompanyPage.tsx
+++ b/assets/src/components/companies/CreateCompanyPage.tsx
@@ -142,7 +142,7 @@ class CreateCompanyPage extends React.Component<Props, State> {
                 value={slackChannelId || undefined}
                 onChange={(value: string, record: any) => {
                   this.setState({
-                    slackChannelId: value,
+                    slackChannelId: value || '',
                     slackChannelName: record?.label || '',
                   });
                 }}

--- a/assets/src/components/companies/CreateCompanyPage.tsx
+++ b/assets/src/components/companies/CreateCompanyPage.tsx
@@ -138,11 +138,12 @@ class CreateCompanyPage extends React.Component<Props, State> {
                 style={{width: '100%'}}
                 placeholder="Select Slack channel"
                 showSearch
+                allowClear
                 value={slackChannelId || undefined}
                 onChange={(value: string, record: any) => {
                   this.setState({
                     slackChannelId: value,
-                    slackChannelName: record.label,
+                    slackChannelName: record?.label || '',
                   });
                 }}
                 options={channels.map((channel: any) => {

--- a/assets/src/components/companies/UpdateCompanyPage.tsx
+++ b/assets/src/components/companies/UpdateCompanyPage.tsx
@@ -205,7 +205,7 @@ class UpdateCompanyPage extends React.Component<Props, State> {
                 value={slackChannelId || undefined}
                 onChange={(value: string, record: any) => {
                   this.setState({
-                    slackChannelId: value,
+                    slackChannelId: value || '',
                     slackChannelName: record?.label || '',
                   });
                 }}

--- a/assets/src/components/companies/UpdateCompanyPage.tsx
+++ b/assets/src/components/companies/UpdateCompanyPage.tsx
@@ -200,12 +200,13 @@ class UpdateCompanyPage extends React.Component<Props, State> {
                 style={{width: '100%'}}
                 placeholder="Select Slack channel"
                 showSearch
+                allowClear
                 disabled={loading}
                 value={slackChannelId || undefined}
                 onChange={(value: string, record: any) => {
                   this.setState({
                     slackChannelId: value,
-                    slackChannelName: record.label,
+                    slackChannelName: record?.label || '',
                   });
                 }}
                 options={channels.map((channel: any) => {

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -329,6 +329,9 @@ const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
         </Tag>
       </Box>
 
+      {/* TODO: include other recent conversations */}
+      {/* TODO: include link to Slack thread if one exists */}
+
       <DetailsSectionCard>
         <Box mb={2}>
           <Text strong>Conversation Tags</Text>

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -88,7 +88,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
 
     return {
       key: 'slack',
-      integration: 'Slack',
+      integration: 'Reply from Slack',
       status: auth ? 'connected' : 'not_connected',
       created_at: auth ? auth.created_at : null,
       authorization_id: auth ? auth.id : null,

--- a/lib/chat_api/google/gmail.ex
+++ b/lib/chat_api/google/gmail.ex
@@ -47,13 +47,13 @@ defmodule ChatApi.Google.Gmail do
   end
 
   def decode_message_body(text) do
-    text |> String.replace("-", "+") |> Base.decode64()
+    text |> String.replace("-", "+") |> String.replace("_", "/") |> Base.decode64()
   end
 
   # Example use case:
-  #
-  # ChatApi.Google.Gmail.list_threads(token, in: "sent", subject: "October product updates")
-  #   |> Map.get("threads")
+  #  token
+  #   |> ChatApi.Google.Gmail.list_threads(in: "sent", subject: "October product updates")
+  #   |> Map.get("threads", [])
   #   |> Enum.map(fn thread ->
   #     thread
   #     |> Map.get("id")
@@ -66,9 +66,38 @@ defmodule ChatApi.Google.Gmail do
     thread
     |> Map.get("messages")
     |> List.first()
-    |> Map.get("payload")
-    |> Map.get("headers")
+    |> get_in(["payload", "headers"])
     |> Enum.find(fn h -> h["name"] == "To" end)
     |> Map.get("value")
+  end
+
+  def get_thread_messages(thread) do
+    thread
+    |> Map.get("messages")
+    |> Enum.map(fn msg ->
+      snippet = Map.get(msg, "snippet")
+
+      msg
+      |> get_in(["payload", "parts"])
+      |> Enum.reduce(%{snippet: snippet}, fn part, acc ->
+        [key, value] =
+          case part do
+            %{"mimeType" => "text/plain", "body" => %{"data" => encoded}} ->
+              [:text, decode_message_body(encoded)]
+
+            %{"mimeType" => "text/html", "body" => %{"data" => encoded}} ->
+              [:html, decode_message_body(encoded)]
+
+            _ ->
+              [:invalid, nil]
+          end
+
+        case value do
+          {:ok, decoded} -> Map.merge(acc, %{key => decoded})
+          :error -> acc
+          _ -> acc
+        end
+      end)
+    end)
   end
 end

--- a/lib/chat_api/google/gmail.ex
+++ b/lib/chat_api/google/gmail.ex
@@ -83,19 +83,18 @@ defmodule ChatApi.Google.Gmail do
         [key, value] =
           case part do
             %{"mimeType" => "text/plain", "body" => %{"data" => encoded}} ->
-              [:text, decode_message_body(encoded)]
+              [:text, encoded]
 
             %{"mimeType" => "text/html", "body" => %{"data" => encoded}} ->
-              [:html, decode_message_body(encoded)]
+              [:html, encoded]
 
             _ ->
               [:invalid, nil]
           end
 
-        case value do
+        case decode_message_body(value) do
           {:ok, decoded} -> Map.merge(acc, %{key => decoded})
           :error -> acc
-          _ -> acc
         end
       end)
     end)

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -293,6 +293,9 @@ defmodule ChatApi.Slack.Helpers do
   def get_message_type(%Message{user_id: nil}), do: :customer
   def get_message_type(_message), do: :unknown
 
+  def is_bot_message?(%{"bot_id" => bot_id}) when not is_nil(bot_id), do: true
+  def is_bot_message?(_), do: false
+
   #####################
   # Extractors
   #####################

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -171,6 +171,7 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
+  @spec handle_payload(map()) :: any()
   defp handle_payload(
          %{
            "event" => event,
@@ -187,6 +188,7 @@ defmodule ChatApiWeb.SlackController do
 
   defp handle_payload(_), do: nil
 
+  @spec handle_event(map()) :: any()
   defp handle_event(%{"bot_id" => _bot_id} = _event) do
     # Don't do anything on bot events for now
     nil
@@ -412,6 +414,7 @@ defmodule ChatApiWeb.SlackController do
 
   # TODO: DRY this up with the message event handler above, for now the only difference between this one
   # and that one is: this handler allows admin users to create threads via Slack support channels
+  @spec handle_emoji_reaction_event(map()) :: any()
   defp handle_emoji_reaction_event(
          %{
            "type" => "message",
@@ -475,6 +478,7 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
+  @spec handle_reply_to_bot_event(map()) :: any()
   defp handle_reply_to_bot_event(
          %{
            "type" => "message",

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -364,20 +364,21 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
-  # NB: this currently listens for the Papercups app being added to a *private* Slack channel.
+  # NB: this currently listens for the Papercups app being added to a Slack channel.
   # At the moment, it doesn't do anything. But in the future, we may auto-create a
   # `company` record based on the Slack channel info (if this use case is common enough)
   defp handle_event(
          %{
            "type" => "message",
-           # Public channels use subtype "channel_join"
-           "subtype" => "group_join",
+           # Public channels use subtype "channel_join", while private channels use "group_join"
+           "subtype" => subtype,
            "user" => slack_user_id,
            "channel" => slack_channel_id
            #  "inviter" => slack_inviter_id
          } = event
-       ) do
-    Logger.info("Slack group_join event detected:")
+       )
+       when subtype in ["channel_join", "group_join"] do
+    Logger.info("Slack channel_join/group_join event detected:")
     Logger.info(inspect(event))
 
     with %{account_id: account_id, access_token: access_token} <-

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -502,6 +502,10 @@ defmodule ChatApiWeb.SlackController do
            Slack.Client.retrieve_message(slack_channel_id, thread_ts, access_token),
          {:ok, message} <- Slack.Helpers.extract_slack_message(response),
          true <- Slack.Helpers.is_bot_message?(message) do
+      # NB: we treat this reply message as if it were the initial message in the thread
+      # (i.e. we set the `ts` field to the original `thread_ts`), in order to ensure all
+      # future replies are in the same thread.
+      # TODO: should we include the original message in the thread somewhere?
       handle_event(%{
         "type" => "message",
         "text" => text,

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -256,6 +256,8 @@ defmodule ChatApiWeb.SlackController do
         end
       end
     else
+      # If an existing conversation is not found, we check to see if this is a reply to a bot message.
+      # At the moment, we want to start a new thread for replies to bot messages.
       {:error, :not_found} ->
         handle_reply_to_bot_event(event)
 

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -554,5 +554,15 @@ defmodule ChatApi.SlackTest do
         assert updated_customer.name == "Test Customer"
       end
     end
+
+    test "Helpers.is_bot_message?/1 checks if the Slack message payload is from a bot" do
+      bot_message = %{"bot_id" => "B123", "text" => "I am a bot"}
+      nil_bot_message = %{"bot_id" => nil, "text" => "I am not a bot"}
+      non_bot_message = %{"text" => "I am also not a bot"}
+
+      assert Slack.Helpers.is_bot_message?(bot_message)
+      refute Slack.Helpers.is_bot_message?(nil_bot_message)
+      refute Slack.Helpers.is_bot_message?(non_bot_message)
+    end
   end
 end


### PR DESCRIPTION
### Description

We currently ignore messages from bots in our Slack support integration, but if a user replies to a bot message we want to sync that to Papercups and start a new conversation thread.

TODO:
- [x] Write more tests
- [x] QA in staging

### Screenshots

TODO

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
