### PR TITLE
Make it easier to link internal users to their Slack user ID

### DIFF
--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -102,6 +102,22 @@ defmodule ChatApi.Slack.Client do
     end
   end
 
+  @spec list_users(binary()) :: {:ok, nil} | Tesla.Env.result()
+  def list_users(access_token) do
+    if should_execute?(access_token) do
+      get("/users.list",
+        query: [],
+        headers: [
+          {"Authorization", "Bearer " <> access_token}
+        ]
+      )
+    else
+      Logger.info("Invalid access token")
+
+      {:ok, nil}
+    end
+  end
+
   @spec retrieve_channel_info(binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
   def retrieve_channel_info(channel, access_token) do
     # TODO: we need channels:read scope to access this

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -329,6 +329,26 @@ defmodule ChatApi.Slack.Helpers do
   def extract_slack_channel(response),
     do: {:error, "Invalid response: #{inspect(response)}"}
 
+  @slackbot_user_id "USLACKBOT"
+
+  @spec extract_valid_slack_users(map()) :: {:ok, [map()]} | {:error, String.t()}
+  def extract_valid_slack_users(%{body: %{"ok" => true, "members" => members}}) do
+    users =
+      Enum.reject(members, fn member ->
+        Map.get(member, "is_bot") ||
+          Map.get(member, "deleted") ||
+          member["id"] == @slackbot_user_id
+      end)
+
+    {:ok, users}
+  end
+
+  def extract_valid_slack_users(%{body: %{"ok" => true, "members" => []}}),
+    do: {:error, "No users were found"}
+
+  def extract_valid_slack_users(response),
+    do: {:error, "Invalid response: #{inspect(response)}"}
+
   # TODO: refactor extractors below to return :ok/:error tuples rather than raising?
 
   @spec extract_slack_conversation_thread_info(map()) :: map()

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -20,6 +20,14 @@ defmodule ChatApi.Users do
     User |> where(account_id: ^account_id, email: ^email) |> Repo.one()
   end
 
+  @spec list_users_by_account(binary()) :: [User.t()]
+  def list_users_by_account(account_id) do
+    User
+    |> where(account_id: ^account_id)
+    |> Repo.all()
+    |> Repo.preload([:profile, :settings])
+  end
+
   @spec find_by_id!(integer() | binary()) :: User.t()
   def find_by_id!(user_id) do
     Repo.get!(User, user_id)

--- a/lib/chat_api/users/user_profile.ex
+++ b/lib/chat_api/users/user_profile.ex
@@ -10,6 +10,7 @@ defmodule ChatApi.Users.UserProfile do
     field :display_name, :string
     field :full_name, :string
     field :profile_photo_url, :string
+    field :slack_user_id, :string
     belongs_to(:user, User, type: :integer)
 
     timestamps()
@@ -18,7 +19,7 @@ defmodule ChatApi.Users.UserProfile do
   @doc false
   def changeset(user_profile, attrs) do
     user_profile
-    |> cast(attrs, [:user_id, :full_name, :display_name, :profile_photo_url])
+    |> cast(attrs, [:user_id, :full_name, :display_name, :profile_photo_url, :slack_user_id])
     |> validate_required([:user_id])
   end
 end

--- a/lib/mix/tasks/set_missing_slack_user_ids.ex
+++ b/lib/mix/tasks/set_missing_slack_user_ids.ex
@@ -1,0 +1,99 @@
+defmodule Mix.Tasks.SetMissingSlackUserIds do
+  use Mix.Task
+
+  require Logger
+
+  @shortdoc "Sets Slack user IDs for users with missing Slack ID based on email"
+
+  @moduledoc """
+  This task handles setting missing Slack user IDs for users on accounts with a
+  Slack integration. It currently does this by matching on the `email` field.
+
+  Example:
+  ```
+  $ mix set_missing_slack_user_ids
+  ```
+
+  On Heroku:
+  ```
+  $ heroku run "mix set_missing_slack_user_ids"
+  ```
+
+  """
+
+  def run(_args) do
+    Application.ensure_all_started(:chat_api)
+
+    ChatApi.SlackAuthorizations.list_slack_authorizations()
+    |> Enum.group_by(& &1.account_id)
+    |> Stream.map(fn {account_id, authorizations} ->
+      auth =
+        Enum.find(authorizations, fn auth ->
+          String.contains?(auth.scope, "users:read") &&
+            String.contains?(auth.scope, "users:read.email")
+        end)
+
+      {account_id, auth}
+    end)
+    |> Stream.reject(fn {_, auth} -> is_nil(auth) end)
+    |> Enum.map(fn {account_id, auth} ->
+      slack_users = retrieve_slack_users(auth.access_token)
+
+      account_id
+      |> list_users_with_unset_slack_id()
+      |> Enum.map(fn user ->
+        matching_slack_user = find_matching_slack_user(user, slack_users)
+
+        {user, matching_slack_user}
+      end)
+      |> Enum.each(fn {user, matching_slack_user} ->
+        case matching_slack_user do
+          %{"id" => slack_user_id} ->
+            Logger.debug(
+              "Found matching Slack user #{inspect(slack_user_id)} for user #{inspect(user.email)}"
+            )
+
+            ChatApi.Users.update_user_profile(user.id, %{slack_user_id: slack_user_id})
+
+          _ ->
+            nil
+        end
+      end)
+    end)
+  end
+
+  defp find_matching_slack_user(user, slack_users) do
+    Enum.find(slack_users, fn slack_user ->
+      case slack_user do
+        %{"profile" => %{"email" => email}} when not is_nil(email) -> email == user.email
+        _ -> false
+      end
+    end)
+  end
+
+  defp list_users_with_unset_slack_id(account_id) do
+    account_id
+    |> ChatApi.Users.list_users_by_account()
+    |> Enum.reject(fn user ->
+      case user do
+        %{profile: %{slack_user_id: slack_user_id}} when not is_nil(slack_user_id) ->
+          true
+
+        _ ->
+          false
+      end
+    end)
+  end
+
+  defp retrieve_slack_users(access_token) do
+    with {:ok, response} <- ChatApi.Slack.Client.list_users(access_token),
+         {:ok, users} <- ChatApi.Slack.Helpers.extract_valid_slack_users(response) do
+      users
+    else
+      error ->
+        Logger.error("Error retrieving Slack users: #{inspect(error)}")
+
+        []
+    end
+  end
+end

--- a/lib/mix/tasks/set_missing_slack_user_ids.ex
+++ b/lib/mix/tasks/set_missing_slack_user_ids.ex
@@ -24,6 +24,13 @@ defmodule Mix.Tasks.SetMissingSlackUserIds do
   def run(_args) do
     Application.ensure_all_started(:chat_api)
 
+    # The way this works:
+    #   1. We fetch all Slack authorizations and group them by account
+    #   2. We look for an authorization with the correct scopes for retrieving user info
+    #   3. If a valid authorization is found, we use this to fetch the Slack users for the account
+    #   4. Then, we compare the email field on the Slack user objects with the internal Papercups users' emails
+    #   5. If we find a match, we update the user's `slack_user_id` field on their profile
+    #
     ChatApi.SlackAuthorizations.list_slack_authorizations()
     |> Enum.group_by(& &1.account_id)
     |> Stream.map(fn {account_id, authorizations} ->

--- a/priv/repo/migrations/20210120183142_add_slack_user_id_to_user_profiles.exs
+++ b/priv/repo/migrations/20210120183142_add_slack_user_id_to_user_profiles.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddSlackUserIdToUserProfiles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_profiles) do
+      add(:slack_user_id, :string)
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR:
- [x] Adds the `slack_user_id` to the `user_profiles` table
- [x] Includes a script to automatically set `slack_user_id`s based on email matching for accounts with an existing Slack integration

### Issue

(This will make it easier to spec out reminders in Slack, since we'll want to know the `slack_user_id` of the conversation assignee so we know who to ping if a conversation hasn't been addressed after a certain period of time.)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
