### PR TITLE
Set up API for retrieving previous conversation

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -430,6 +430,20 @@ export const fetchConversation = async (
     .then((res) => res.body.data);
 };
 
+export const fetchPreviousConversation = async (
+  id: string,
+  token = getAccessToken()
+): Promise<Conversation> => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/conversations/${id}/previous`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const generateShareConversationToken = async (
   conversationId: string,
   token = getAccessToken()

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -137,6 +137,7 @@ defmodule ChatApi.Conversations do
           messages_partition: [partition_by: :conversation_id, order_by: [desc: :inserted_at]]
         ]
 
+    # We just want to query the most recent message
     messages_query =
       from m in Message,
         join: r in subquery(ranking_query),

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -20,18 +20,32 @@ defmodule ChatApi.Conversations do
   @spec list_conversations_by_account(binary(), map()) :: [Conversation.t()]
   def list_conversations_by_account(account_id, filters \\ %{}) do
     Conversation
-    |> join(
-      :left_lateral,
-      [c],
-      f in fragment(
-        "SELECT inserted_at FROM messages WHERE conversation_id = ? ORDER BY inserted_at DESC LIMIT 1",
-        c.id
-      )
-    )
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
-    |> order_by([c, f], desc: f)
+    |> order_by_most_recent_message()
+    |> preload([:customer, messages: [user: :profile]])
+    |> Repo.all()
+  end
+
+  @spec list_other_recent_conversations(Conversation.t(), integer(), map()) :: [Conversation.t()]
+  def list_other_recent_conversations(
+        %Conversation{
+          id: conversation_id,
+          account_id: account_id,
+          customer_id: customer_id
+        } = _conversation,
+        limit \\ 5,
+        filters \\ %{}
+      ) do
+    Conversation
+    |> where(account_id: ^account_id)
+    |> where(customer_id: ^customer_id)
+    |> where([c], c.id != ^conversation_id)
+    |> where(^filter_where(filters))
+    |> where([c], is_nil(c.archived_at))
+    |> order_by_most_recent_message()
+    |> limit(^limit)
     |> preload([:customer, messages: [user: :profile]])
     |> Repo.all()
   end
@@ -47,21 +61,13 @@ defmodule ChatApi.Conversations do
         filters \\ %{}
       ) do
     Conversation
-    |> join(
-      :left_lateral,
-      [c],
-      f in fragment(
-        "SELECT inserted_at FROM messages WHERE conversation_id = ? ORDER BY inserted_at DESC LIMIT 1",
-        c.id
-      )
-    )
     |> where(account_id: ^account_id)
     |> where(customer_id: ^customer_id)
     |> where([c], c.inserted_at < ^inserted_at)
     |> where([c], c.id != ^conversation_id)
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
-    |> order_by([c, f], desc: f)
+    |> order_by_most_recent_message()
     |> preload([:customer, messages: [user: :profile]])
     |> first()
     |> Repo.one()
@@ -79,21 +85,13 @@ defmodule ChatApi.Conversations do
         filters \\ %{}
       ) do
     Conversation
-    |> join(
-      :left_lateral,
-      [c],
-      f in fragment(
-        "SELECT inserted_at FROM messages WHERE conversation_id = ? ORDER BY inserted_at DESC LIMIT 1",
-        c.id
-      )
-    )
     |> where(account_id: ^account_id)
     |> where(customer_id: ^customer_id)
     |> where([c], c.inserted_at < ^inserted_at)
     |> where([c], c.id != ^conversation_id)
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
-    |> order_by([c, f], desc: f)
+    |> order_by_most_recent_message()
     |> select([:id])
     |> first()
     |> Repo.one()
@@ -105,6 +103,7 @@ defmodule ChatApi.Conversations do
 
   @customer_conversations_limit 3
 
+  # Used externally in chat widget
   @spec find_by_customer(binary(), binary()) :: [Conversation.t()]
   def find_by_customer(customer_id, account_id) do
     # NB: this is the method used to fetch conversations for a customer in the widget,
@@ -126,11 +125,48 @@ defmodule ChatApi.Conversations do
     |> Repo.all()
   end
 
-  @doc """
-  Gets a single conversation.
+  # Used internally in dashboard
+  @spec list_recent_by_customer(binary(), binary(), integer()) :: [Conversation.t()]
+  def list_recent_by_customer(customer_id, account_id, limit \\ 5) do
+    # For more info, see https://hexdocs.pm/ecto/Ecto.Query.html#preload/3-preload-queries
+    # and https://hexdocs.pm/ecto/Ecto.Query.html#windows/3-window-expressions
+    ranking_query =
+      from m in Message,
+        select: %{id: m.id, row_number: row_number() |> over(:messages_partition)},
+        windows: [
+          messages_partition: [partition_by: :conversation_id, order_by: [desc: :inserted_at]]
+        ]
 
-  Raises `Ecto.NoResultsError` if the Conversation does not exist.
-  """
+    messages_query =
+      from m in Message,
+        join: r in subquery(ranking_query),
+        on: m.id == r.id and r.row_number <= 1,
+        preload: [:customer, user: :profile]
+
+    Conversation
+    |> where(account_id: ^account_id)
+    |> where(customer_id: ^customer_id)
+    |> where([c], is_nil(c.archived_at))
+    |> order_by_most_recent_message()
+    |> limit(^limit)
+    |> preload([:customer, messages: ^messages_query])
+    |> Repo.all()
+  end
+
+  @spec order_by_most_recent_message(Ecto.Query.t()) :: Ecto.Query.t()
+  def order_by_most_recent_message(query) do
+    query
+    |> join(
+      :left_lateral,
+      [c],
+      f in fragment(
+        "SELECT inserted_at FROM messages WHERE conversation_id = ? ORDER BY inserted_at DESC LIMIT 1",
+        c.id
+      )
+    )
+    |> order_by([c, f], desc: f)
+  end
+
   @spec get_conversation!(binary()) :: Conversation.t()
   def get_conversation!(id) do
     # TODO: make sure messages are sorted properly?

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -76,6 +76,16 @@ defmodule ChatApiWeb.ConversationController do
     render(conn, "index.json", conversations: conversations)
   end
 
+  @spec previous(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def previous(conn, %{"conversation_id" => conversation_id}) do
+    with %Conversation{} = conversation <- Conversations.get_conversation(conversation_id) do
+      # TODO: should we just return the conversation ID?
+      previous = Conversations.get_previous_conversation(conversation)
+
+      render(conn, "show.json", conversation: previous)
+    end
+  end
+
   @spec share(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def share(conn, %{"conversation_id" => conversation_id}) do
     with %{account_id: account_id} <- conn.assigns.current_user,

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -2,11 +2,11 @@ defmodule ChatApiWeb.Router do
   use ChatApiWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
   end
 
   pipeline :api do
@@ -28,7 +28,7 @@ defmodule ChatApiWeb.Router do
 
   # Swagger
   scope "/api/swagger" do
-    forward "/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :chat_api, swagger_file: "swagger.json"
+    forward("/", PhoenixSwagger.Plug.SwaggerUI, otp_app: :chat_api, swagger_file: "swagger.json")
   end
 
   # Public routes
@@ -110,6 +110,7 @@ defmodule ChatApiWeb.Router do
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
 
+    get("/conversations/:conversation_id/previous", ConversationController, :previous)
     post("/conversations/:conversation_id/share", ConversationController, :share)
     post("/conversations/:conversation_id/tags", ConversationController, :add_tag)
     delete("/conversations/:conversation_id/tags/:tag_id", ConversationController, :remove_tag)
@@ -145,14 +146,14 @@ defmodule ChatApiWeb.Router do
   end
 
   scope "/", ChatApiWeb do
-    pipe_through :browser
+    pipe_through(:browser)
 
-    get "/", PageController, :index
+    get("/", PageController, :index)
     # TODO: move somewhere else?
-    get "/gmail/auth", GmailController, :index
+    get("/gmail/auth", GmailController, :index)
 
     # Fallback to index, which renders React app
-    get "/*path", PageController, :index
+    get("/*path", PageController, :index)
   end
 
   def swagger_info do

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -384,6 +384,12 @@ defmodule ChatApi.ConversationsTest do
           inserted_at: ~N[2020-12-01 20:00:00]
         )
 
+      insert(:message,
+        account: account,
+        conversation: previous_conversation,
+        inserted_at: ~N[2020-12-02 20:00:00]
+      )
+
       assert Conversations.get_previous_conversation(conversation) |> Map.get(:id) ==
                previous_conversation.id
 
@@ -395,6 +401,12 @@ defmodule ChatApi.ConversationsTest do
           customer: customer,
           inserted_at: ~N[2020-11-01 20:00:00]
         )
+
+      insert(:message,
+        account: account,
+        conversation: earlier_conversation,
+        inserted_at: ~N[2020-11-02 20:00:00]
+      )
 
       # Assert that this hasn't changed
       assert Conversations.get_previous_conversation(conversation) |> Map.get(:id) ==


### PR DESCRIPTION
### Description

It might be useful to be able to load the previous conversation with a customer within the context of viewing an existing conversation (e.g. to remember what was discussed previously). This PR sets up the backend API(s) for handling this.

(UI updates will come in future PRs)

### Issue

Will fix https://github.com/papercups-io/papercups/issues/538

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
