### PR TITLE
Display latest related conversations in sidebar

### DIFF
--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -50,6 +50,7 @@ body {
   color: #fff;
 }
 
+/* Mimic behavior of antd "text"-type Button */
 a.RelatedCustomerConversation--link {
   display: block;
   color: rgba(0, 0, 0, 0.45);

--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -50,13 +50,13 @@ body {
   color: #fff;
 }
 
-a.RelatedCustomerConversations {
+a.RelatedCustomerConversation--link {
   display: block;
   color: rgba(0, 0, 0, 0.45);
   transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
-a.RelatedCustomerConversations:hover {
+a.RelatedCustomerConversation--link:hover {
   background: rgba(0, 0, 0, 0.018);
 }
 

--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -50,6 +50,16 @@ body {
   color: #fff;
 }
 
+a.RelatedCustomerConversations {
+  display: block;
+  color: rgba(0, 0, 0, 0.45);
+  transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+a.RelatedCustomerConversations:hover {
+  background: rgba(0, 0, 0, 0.018);
+}
+
 /* Replayer */
 #SessionPlayer .replayer-wrapper {
   left: auto !important;

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -444,6 +444,20 @@ export const fetchPreviousConversation = async (
     .then((res) => res.body.data);
 };
 
+export const fetchRelatedConversations = async (
+  id: string,
+  token = getAccessToken()
+): Promise<Array<Conversation>> => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/conversations/${id}/related`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const generateShareConversationToken = async (
   conversationId: string,
   token = getAccessToken()

--- a/assets/src/components/conversations/ChatMessage.tsx
+++ b/assets/src/components/conversations/ChatMessage.tsx
@@ -11,7 +11,10 @@ import ChatMessageBox from './ChatMessageBox';
 
 dayjs.extend(utc);
 
-const getSenderIdentifier = (customer?: Customer | null, user?: User) => {
+export const getSenderIdentifier = (
+  customer?: Customer | null,
+  user?: User
+) => {
   if (user) {
     const {display_name, full_name, email} = user;
 
@@ -25,15 +28,17 @@ const getSenderIdentifier = (customer?: Customer | null, user?: User) => {
   }
 };
 
-const SenderAvatar = ({
+export const SenderAvatar = ({
   isAgent,
   name,
   user,
+  size = 32,
   color = colors.gold,
 }: {
   isAgent: boolean;
   name: string;
   user?: User;
+  size?: number;
   color?: string;
 }) => {
   const profilePhotoUrl = user && user.profile_photo_url;
@@ -44,8 +49,8 @@ const SenderAvatar = ({
         <Box
           mr={2}
           style={{
-            height: 32,
-            width: 32,
+            height: size,
+            width: size,
             borderRadius: '50%',
             justifyContent: 'center',
             alignItems: 'center',
@@ -65,8 +70,9 @@ const SenderAvatar = ({
         mr={2}
         sx={{
           bg: isAgent ? colors.primary : color,
-          height: 32,
-          width: 32,
+          height: size,
+          width: size,
+          fontSize: size < 24 ? 12 : 'inherit',
           borderRadius: '50%',
           justifyContent: 'center',
           alignItems: 'center',
@@ -76,7 +82,9 @@ const SenderAvatar = ({
         {isAgent ? (
           name.slice(0, 1).toUpperCase()
         ) : (
-          <UserOutlined style={{color: colors.white}} />
+          <UserOutlined
+            style={{color: colors.white, fontSize: size < 24 ? 12 : 'inherit'}}
+          />
         )}
       </Flex>
     </Tooltip>

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -28,12 +28,9 @@ import {
   SidebarConversationTags,
 } from './SidebarTagSection';
 import SidebarCustomerNotes from './SidebarCustomerNotes';
-import Spinner from '../Spinner';
-import {getSenderIdentifier, SenderAvatar} from '../conversations/ChatMessage';
-import {getColorByUuid} from '../conversations/support';
+import RelatedCustomerConversations from './RelatedCustomerConversations';
 import * as API from '../../api';
 import {Conversation, Customer} from '../../types';
-import {formatShortRelativeTime} from '../../utils';
 import logger from '../../logger';
 
 // TODO: create date utility methods so we don't have to do this everywhere
@@ -82,97 +79,6 @@ const CustomerActiveSessions = ({customerId}: {customerId: string}) => {
         View live
       </Button>
     </Link>
-  );
-};
-
-const RelatedCustomerConversations = ({
-  conversationId,
-}: {
-  conversationId: string;
-}) => {
-  const [loading, setLoading] = React.useState(false);
-  const [conversations, setRelatedConversations] = React.useState<
-    Array<Conversation>
-  >([]);
-
-  React.useEffect(() => {
-    setLoading(true);
-
-    API.fetchRelatedConversations(conversationId)
-      .then((results) => setRelatedConversations(results))
-      .catch((err) =>
-        logger.error('Error retrieving related conversations:', err)
-      )
-      .then(() => setLoading(false));
-  }, [conversationId]);
-
-  if (loading) {
-    return <Spinner size={16} />;
-  } else if (!conversations || !conversations.length) {
-    return (
-      <Box mx={2} mb={2}>
-        <Text type="secondary">None</Text>
-      </Box>
-    );
-  }
-
-  return (
-    <Box>
-      {conversations.map(({id, status, created_at, messages = []}) => {
-        const [recent] = messages;
-        const ts = recent ? recent.created_at : created_at;
-        const created = dayjs.utc(ts);
-        const date = formatShortRelativeTime(created);
-        const {user, customer} = recent;
-        const name = getSenderIdentifier(customer, user);
-        const isAgent = !!user;
-        const preview = recent.body ? recent.body : '...';
-        const customerId = customer && customer.id;
-        const color = customerId ? getColorByUuid(customerId) : colors.gray[0];
-        const isOpen = status === 'open';
-        const url = isOpen
-          ? `/conversations/all?cid=${id}`
-          : `/conversations/closed?cid=${id}`;
-
-        return (
-          <a className="RelatedCustomerConversations" href={url}>
-            <Box
-              key={id}
-              p={2}
-              sx={{
-                borderTop: '1px solid #f0f0f0',
-              }}
-            >
-              <Flex
-                mb={1}
-                sx={{alignItems: 'center', justifyContent: 'space-between'}}
-              >
-                <SenderAvatar
-                  isAgent={isAgent}
-                  color={color}
-                  size={20}
-                  name={name}
-                  user={user}
-                />
-                <Text type="secondary" style={{fontSize: 12}}>
-                  {date}
-                </Text>
-              </Flex>
-              <Box
-                sx={{
-                  maxWidth: '100%',
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                <Text type="secondary">{preview}</Text>
-              </Box>
-            </Box>
-          </a>
-        );
-      })}
-    </Box>
   );
 };
 

--- a/assets/src/components/conversations/RelatedCustomerConversations.tsx
+++ b/assets/src/components/conversations/RelatedCustomerConversations.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import {Box, Flex} from 'theme-ui';
+import {colors, Text} from '../common';
+import Spinner from '../Spinner';
+import {getSenderIdentifier, SenderAvatar} from './ChatMessage';
+import {getColorByUuid} from './support';
+import * as API from '../../api';
+import {Conversation} from '../../types';
+import {formatShortRelativeTime} from '../../utils';
+import logger from '../../logger';
+
+// TODO: create date utility methods so we don't have to do this everywhere
+dayjs.extend(utc);
+
+const RelatedConversationItem = ({
+  conversation,
+}: {
+  conversation: Conversation;
+}) => {
+  const {id, status, created_at, messages = []} = conversation;
+  const [recent] = messages;
+  const ts = recent ? recent.created_at : created_at;
+  const created = dayjs.utc(ts);
+  const date = formatShortRelativeTime(created);
+  const {user, customer} = recent;
+  const name = getSenderIdentifier(customer, user);
+  const isAgent = !!user;
+  const preview = recent.body ? recent.body : '...';
+  const customerId = customer && customer.id;
+  const color = customerId ? getColorByUuid(customerId) : colors.gray[0];
+  const isOpen = status === 'open';
+  const url = isOpen
+    ? `/conversations/all?cid=${id}`
+    : `/conversations/closed?cid=${id}`;
+
+  return (
+    <a key={id} className="RelatedCustomerConversation--link" href={url}>
+      <Box
+        p={2}
+        sx={{
+          borderTop: '1px solid #f0f0f0',
+        }}
+      >
+        <Flex
+          mb={1}
+          sx={{alignItems: 'center', justifyContent: 'space-between'}}
+        >
+          <SenderAvatar
+            isAgent={isAgent}
+            color={color}
+            size={20}
+            name={name}
+            user={user}
+          />
+          <Text type="secondary" style={{fontSize: 12}}>
+            {date}
+          </Text>
+        </Flex>
+        <Box
+          sx={{
+            maxWidth: '100%',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          <Text type="secondary">{preview}</Text>
+        </Box>
+      </Box>
+    </a>
+  );
+};
+
+const RelatedCustomerConversations = ({
+  conversationId,
+}: {
+  conversationId: string;
+}) => {
+  const [loading, setLoading] = React.useState(false);
+  const [conversations, setRelatedConversations] = React.useState<
+    Array<Conversation>
+  >([]);
+
+  React.useEffect(() => {
+    setLoading(true);
+
+    API.fetchRelatedConversations(conversationId)
+      .then((results) => setRelatedConversations(results))
+      .catch((err) =>
+        logger.error('Error retrieving related conversations:', err)
+      )
+      .then(() => setLoading(false));
+  }, [conversationId]);
+
+  if (loading) {
+    return <Spinner size={16} />;
+  } else if (!conversations || !conversations.length) {
+    return (
+      <Box mx={2} mb={2}>
+        <Text type="secondary">None</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      {conversations.map((conversation) => {
+        return (
+          <RelatedConversationItem
+            key={conversation.id}
+            conversation={conversation}
+          />
+        );
+      })}
+    </Box>
+  );
+};
+
+export default RelatedCustomerConversations;

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -61,6 +61,7 @@ export type Message = {
   sent_at?: string;
   seen_at?: string;
   customer_id?: string;
+  customer?: Customer;
   conversation_id: string;
   user_id?: number;
   user?: User;

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -30,6 +30,23 @@ export const formatRelativeTime = (date: dayjs.Dayjs) => {
   }
 };
 
+export const formatShortRelativeTime = (date: dayjs.Dayjs) => {
+  const seconds = dayjs().diff(date, 'second');
+  const mins = Math.floor(seconds / 60);
+  const hrs = Math.floor(mins / 60);
+  const days = Math.floor(hrs / 24);
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  } else if (mins <= 60) {
+    return `${mins}m`;
+  } else if (hrs <= 24) {
+    return `${hrs}h`;
+  } else {
+    return `${days}d`;
+  }
+};
+
 export const formatDiffDuration = (start: dayjs.Dayjs, finish: dayjs.Dayjs) => {
   const diff = finish.diff(start, 's');
   const seconds = diff % 60;

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -86,6 +86,17 @@ defmodule ChatApiWeb.ConversationController do
     end
   end
 
+  @spec related(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def related(conn, %{"conversation_id" => conversation_id} = params) do
+    with %Conversation{} = conversation <-
+           Conversations.get_conversation(conversation_id) do
+      limit = Map.get(params, "limit", 3)
+      results = Conversations.list_other_recent_conversations(conversation, limit)
+
+      render(conn, "index.json", conversations: results)
+    end
+  end
+
   @spec share(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def share(conn, %{"conversation_id" => conversation_id}) do
     with %{account_id: account_id} <- conn.assigns.current_user,

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -111,6 +111,7 @@ defmodule ChatApiWeb.Router do
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
 
     get("/conversations/:conversation_id/previous", ConversationController, :previous)
+    get("/conversations/:conversation_id/related", ConversationController, :related)
     post("/conversations/:conversation_id/share", ConversationController, :share)
     post("/conversations/:conversation_id/tags", ConversationController, :add_tag)
     delete("/conversations/:conversation_id/tags/:tag_id", ConversationController, :remove_tag)


### PR DESCRIPTION
### Description

Initial pass at displaying latest related conversations in the details sidebar.

### Issue

TODO

### Screenshots

**With other conversations:**
<img width="951" alt="Screen Shot 2021-01-21 at 6 18 03 PM" src="https://user-images.githubusercontent.com/5264279/105424581-98a5bf80-5c15-11eb-88e2-d7ccbdfaf49c.png">

**With none:**
<img width="953" alt="Screen Shot 2021-01-21 at 6 17 27 PM" src="https://user-images.githubusercontent.com/5264279/105424583-993e5600-5c15-11eb-894b-79c4fbeb9c19.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
