### PR TITLE
Link to Slack conversation thread from sidebar when available

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -458,6 +458,21 @@ export const fetchRelatedConversations = async (
     .then((res) => res.body.data);
 };
 
+export const fetchSlackConversationThreads = async (
+  conversationId: string,
+  token = getAccessToken()
+): Promise<Array<Conversation>> => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/slack_conversation_threads`)
+    .query({conversation_id: conversationId})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const generateShareConversationToken = async (
   conversationId: string,
   token = getAccessToken()

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -29,6 +29,7 @@ import {
 } from './SidebarTagSection';
 import SidebarCustomerNotes from './SidebarCustomerNotes';
 import RelatedCustomerConversations from './RelatedCustomerConversations';
+import SlackConversationThreads from './SlackConversationThreads';
 import * as API from '../../api';
 import {Conversation, Customer} from '../../types';
 import logger from '../../logger';
@@ -288,7 +289,7 @@ const openShareConversationUrlNotification = (url: string) => {
 };
 
 const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
-  const {id: conversationId, status} = conversation;
+  const {id: conversationId, status, source} = conversation;
 
   const share = () => {
     API.generateShareConversationToken(conversationId)
@@ -323,15 +324,15 @@ const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
           <Text>{conversationId.toLowerCase()}</Text>
         </Tooltip>
       </Box>
-      <Box px={2} mb={3}>
+      <Box px={2} mb={1}>
         <Text type="secondary">Status:</Text>{' '}
         <Tag color={status === 'open' ? colors.primary : colors.red}>
           {status}
         </Tag>
       </Box>
-
-      {/* TODO: include other recent conversations */}
-      {/* TODO: include link to Slack thread if one exists */}
+      <Box px={2} mb={3}>
+        <Text type="secondary">Source:</Text> <Tag>{source}</Tag>
+      </Box>
 
       <DetailsSectionCard>
         <Box mb={2}>
@@ -347,6 +348,13 @@ const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
         <Box mx={-2} mb={-2}>
           <RelatedCustomerConversations conversationId={conversationId} />
         </Box>
+      </DetailsSectionCard>
+
+      <DetailsSectionCard>
+        <Box mb={2}>
+          <Text strong>Slack threads</Text>
+        </Box>
+        <SlackConversationThreads conversationId={conversationId} />
       </DetailsSectionCard>
 
       <Box px={2} mt={3} mb={3}>

--- a/assets/src/components/conversations/SlackConversationThreads.tsx
+++ b/assets/src/components/conversations/SlackConversationThreads.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {Box, Flex, Image} from 'theme-ui';
+import {Text} from '../common';
+import Spinner from '../Spinner';
+import * as API from '../../api';
+import logger from '../../logger';
+
+const SlackConversationThreads = ({
+  conversationId,
+}: {
+  conversationId: string;
+}) => {
+  const [loading, setLoading] = React.useState(false);
+  const [
+    slackConversationThreads,
+    setSlackConversationThreads,
+  ] = React.useState<Array<any>>([]);
+
+  React.useEffect(() => {
+    setLoading(true);
+
+    API.fetchSlackConversationThreads(conversationId)
+      .then(console.log)
+      .catch(console.log);
+
+    API.fetchSlackConversationThreads(conversationId)
+      .then((results) => setSlackConversationThreads(results))
+      .catch((err) =>
+        logger.error('Error retrieving Slack conversation threads:', err)
+      )
+      .then(() => setLoading(false));
+  }, [conversationId]);
+
+  if (loading) {
+    return <Spinner size={16} />;
+  } else if (!slackConversationThreads || !slackConversationThreads.length) {
+    return <Text type="secondary">None</Text>;
+  }
+
+  return (
+    <Box>
+      {slackConversationThreads
+        .filter((thread) => thread.permalink && thread.permalink.length > 0)
+        .map(({id, permalink}) => {
+          return (
+            <Flex key={id} mb={1} sx={{alignItems: 'center'}}>
+              <Image src="/slack.svg" alt="Slack" sx={{height: 16, mr: 1}} />
+              <a href={permalink} target="_blank" rel="noopener noreferrer">
+                Link to thread
+              </a>
+            </Flex>
+          );
+        })}
+    </Box>
+  );
+};
+
+export default SlackConversationThreads;

--- a/assets/src/components/conversations/SlackConversationThreads.tsx
+++ b/assets/src/components/conversations/SlackConversationThreads.tsx
@@ -20,10 +20,6 @@ const SlackConversationThreads = ({
     setLoading(true);
 
     API.fetchSlackConversationThreads(conversationId)
-      .then(console.log)
-      .catch(console.log);
-
-    API.fetchSlackConversationThreads(conversationId)
       .then((results) => setSlackConversationThreads(results))
       .catch((err) =>
         logger.error('Error retrieving Slack conversation threads:', err)

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -69,6 +69,7 @@ export type Message = {
 
 export type Conversation = {
   id: string;
+  source?: string;
   account_id: string;
   customer_id: string;
   customer: Customer;

--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -69,6 +69,25 @@ defmodule ChatApi.Slack.Client do
     end
   end
 
+  @spec get_message_permalink(binary(), binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
+  def get_message_permalink(channel, ts, access_token) do
+    if should_execute?(access_token) do
+      get("/chat.getPermalink",
+        query: [channel: channel, message_ts: ts],
+        headers: [
+          {"Authorization", "Bearer " <> access_token}
+        ]
+      )
+    else
+      # Inspect what would've been sent for debugging
+      Logger.info(
+        "Would have gotten permalink for message #{inspect(ts)} from channel #{inspect(channel)}"
+      )
+
+      {:ok, nil}
+    end
+  end
+
   @spec retrieve_user_info(binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
   def retrieve_user_info(user_id, access_token) do
     if should_execute?(access_token) do

--- a/lib/chat_api/slack_conversation_threads/slack_conversation_thread.ex
+++ b/lib/chat_api/slack_conversation_threads/slack_conversation_thread.ex
@@ -5,6 +5,19 @@ defmodule ChatApi.SlackConversationThreads.SlackConversationThread do
   alias ChatApi.Accounts.Account
   alias ChatApi.Conversations.Conversation
 
+  @type t :: %__MODULE__{
+          slack_channel: String.t() | nil,
+          slack_thread_ts: String.t() | nil,
+          # Relations
+          account_id: any(),
+          account: any(),
+          conversation_id: any(),
+          conversation: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "slack_conversation_threads" do

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -2,9 +2,8 @@ defmodule ChatApiWeb.ConversationController do
   use ChatApiWeb, :controller
   use PhoenixSwagger
 
-  alias ChatApi.Conversations
+  alias ChatApi.{Conversations, Messages}
   alias ChatApi.Conversations.{Conversation, Helpers}
-  alias ChatApi.Messages
 
   action_fallback(ChatApiWeb.FallbackController)
 

--- a/lib/chat_api_web/controllers/slack_conversation_thread_controller.ex
+++ b/lib/chat_api_web/controllers/slack_conversation_thread_controller.ex
@@ -14,9 +14,6 @@ defmodule ChatApiWeb.SlackConversationThreadController do
         "conversation_id" => conversation_id
       })
 
-    IO.inspect("!!! YO !!!")
-    IO.inspect(slack_conversation_threads)
-
     render(conn, "index.json", slack_conversation_threads: slack_conversation_threads)
   end
 end

--- a/lib/chat_api_web/controllers/slack_conversation_thread_controller.ex
+++ b/lib/chat_api_web/controllers/slack_conversation_thread_controller.ex
@@ -1,0 +1,22 @@
+defmodule ChatApiWeb.SlackConversationThreadController do
+  use ChatApiWeb, :controller
+  require Logger
+  alias ChatApi.SlackConversationThreads
+
+  action_fallback ChatApiWeb.FallbackController
+
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(%{assigns: %{current_user: %{account_id: account_id}}} = conn, %{
+        "conversation_id" => conversation_id
+      }) do
+    slack_conversation_threads =
+      SlackConversationThreads.list_slack_conversation_threads_by_account(account_id, %{
+        "conversation_id" => conversation_id
+      })
+
+    IO.inspect("!!! YO !!!")
+    IO.inspect(slack_conversation_threads)
+
+    render(conn, "index.json", slack_conversation_threads: slack_conversation_threads)
+  end
+end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -110,6 +110,7 @@ defmodule ChatApiWeb.Router do
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
 
+    get("/slack_conversation_threads", SlackConversationThreadController, :index)
     get("/conversations/:conversation_id/previous", ConversationController, :previous)
     get("/conversations/:conversation_id/related", ConversationController, :related)
     post("/conversations/:conversation_id/share", ConversationController, :share)

--- a/lib/chat_api_web/views/conversation_view.ex
+++ b/lib/chat_api_web/views/conversation_view.ex
@@ -22,6 +22,7 @@ defmodule ChatApiWeb.ConversationView do
     %{
       id: conversation.id,
       object: "conversation",
+      source: conversation.source,
       created_at: conversation.inserted_at,
       closed_at: conversation.closed_at,
       status: conversation.status,
@@ -37,6 +38,7 @@ defmodule ChatApiWeb.ConversationView do
     %{
       id: conversation.id,
       object: "conversation",
+      source: conversation.source,
       created_at: conversation.inserted_at,
       closed_at: conversation.closed_at,
       status: conversation.status,

--- a/lib/chat_api_web/views/slack_conversation_thread_view.ex
+++ b/lib/chat_api_web/views/slack_conversation_thread_view.ex
@@ -1,0 +1,42 @@
+defmodule ChatApiWeb.SlackConversationThreadView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.SlackConversationThreadView
+
+  def render("index.json", %{slack_conversation_threads: slack_conversation_threads}) do
+    %{
+      data:
+        render_many(
+          slack_conversation_threads,
+          SlackConversationThreadView,
+          "slack_conversation_thread.json"
+        )
+    }
+  end
+
+  def render("show.json", %{slack_conversation_thread: slack_conversation_thread}) do
+    %{
+      data:
+        render_one(
+          slack_conversation_thread,
+          SlackConversationThreadView,
+          "slack_conversation_thread.json"
+        )
+    }
+  end
+
+  def render("slack_conversation_thread.json", %{
+        slack_conversation_thread: slack_conversation_thread
+      }) do
+    %{
+      id: slack_conversation_thread.id,
+      object: "slack_conversation_thread",
+      account_id: slack_conversation_thread.account_id,
+      conversation_id: slack_conversation_thread.conversation_id,
+      created_at: slack_conversation_thread.inserted_at,
+      updated_at: slack_conversation_thread.updated_at,
+      permalink: slack_conversation_thread.permalink,
+      slack_channel: slack_conversation_thread.slack_channel,
+      slack_thread_ts: slack_conversation_thread.slack_thread_ts
+    }
+  end
+end


### PR DESCRIPTION
### Description

Link to Slack conversation thread from sidebar when available.

Eventually it may make sense to just add the `permalink` field to the `slack_conversation_threads` table, but for now we just get it dynamically from the Slack API (https://api.slack.com/methods/chat.getPermalink)

TODO:
- [x] Add unit tests
- [x] Create gif/screenshot

### Screenshots
![link-to-slack-v2](https://user-images.githubusercontent.com/5264279/105541481-d3673080-5cc5-11eb-892d-40582848e50a.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
