### PR TITLE
fix padding height on all conversations css

### DIFF
--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -341,7 +341,12 @@ class ConversationsContainer extends React.Component<Props, State> {
             left: 220,
           }}
         >
-          <Box p={3} sx={{borderBottom: '1px solid #f0f0f0'}}>
+          <Box
+            pl={3}
+            pt={3}
+            pb={'11.5px'}
+            sx={{borderBottom: '1px solid #f0f0f0'}}
+          >
             <Title level={3} style={{marginBottom: 0, marginTop: 8}}>
               {title || 'Conversations'}
             </Title>


### PR DESCRIPTION
Before:
<img width="691" alt="Screen Shot 2021-01-23 at 9 01 41 AM" src="https://user-images.githubusercontent.com/4218509/105580339-c98f0d00-5d59-11eb-9c54-0e2ce49b00a7.png">

After:
<img width="728" alt="Screen Shot 2021-01-23 at 9 01 23 AM" src="https://user-images.githubusercontent.com/4218509/105580341-ca27a380-5d59-11eb-9f18-19fcfc6af06e.png">
