### PR TITLE
Fix dialyzer typespec warning

### DIFF
--- a/lib/chat_api/browser_sessions.ex
+++ b/lib/chat_api/browser_sessions.ex
@@ -134,7 +134,7 @@ defmodule ChatApi.BrowserSessions do
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries
-  @spec filter_where(map) :: Ecto.Query.DynamicExpr.t()
+  @spec filter_where(map) :: %Ecto.Query.DynamicExpr{}
   def filter_where(params) do
     Enum.reduce(params, dynamic(true), fn
       {"customer_id", value}, dynamic ->

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -435,7 +435,7 @@ defmodule ChatApi.Conversations do
   #####################
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries
-  @spec filter_where(map) :: Ecto.Query.DynamicExpr.t()
+  @spec filter_where(map) :: %Ecto.Query.DynamicExpr{}
   defp filter_where(attrs) do
     Enum.reduce(attrs, dynamic(true), fn
       {"status", value}, dynamic ->

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -7,7 +7,7 @@ defmodule ChatApi.Customers do
   alias ChatApi.Repo
 
   alias ChatApi.Customers.Customer
-  alias ChatApi.Tags.CustomerTag
+  alias ChatApi.Tags.{CustomerTag, Tag}
 
   @spec list_customers(binary(), map()) :: [Customer.t()]
   def list_customers(account_id, filters \\ %{}) do

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -251,7 +251,7 @@ defmodule ChatApi.Customers do
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries
-  @spec filter_where(map) :: Ecto.Query.DynamicExpr.t()
+  @spec filter_where(map) :: %Ecto.Query.DynamicExpr{}
   def filter_where(params) do
     Enum.reduce(params, dynamic(true), fn
       {"company_id", value}, dynamic ->

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -2,6 +2,8 @@ defmodule ChatApi.Emails.Email do
   import Swoosh.Email
   import Ecto.Changeset
 
+  @type t :: Swoosh.Email.t()
+
   @from_address System.get_env("FROM_ADDRESS") || ""
   @backend_url System.get_env("BACKEND_URL") || ""
 

--- a/lib/chat_api/event_subscriptions/event_subscription.ex
+++ b/lib/chat_api/event_subscriptions/event_subscription.ex
@@ -4,6 +4,17 @@ defmodule ChatApi.EventSubscriptions.EventSubscription do
 
   alias ChatApi.Accounts.Account
 
+  @type t :: %__MODULE__{
+          scope: String.t() | nil,
+          webhook_url: String.t(),
+          verified: boolean() | nil,
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "event_subscriptions" do

--- a/lib/chat_api/google/google_authorization.ex
+++ b/lib/chat_api/google/google_authorization.ex
@@ -5,6 +5,21 @@ defmodule ChatApi.Google.GoogleAuthorization do
   alias ChatApi.Accounts.Account
   alias ChatApi.Users.User
 
+  @type t :: %__MODULE__{
+          client: String.t(),
+          access_token: String.t() | nil,
+          refresh_token: String.t(),
+          token_type: String.t() | nil,
+          expires_at: integer(),
+          scope: String.t() | nil,
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          user_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "google_authorizations" do

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -9,22 +9,24 @@ defmodule ChatApi.Messages.Message do
 
   @type t :: %__MODULE__{
           body: String.t(),
-          sent_at: any(),
-          seen_at: any(),
-          source: String.t() | nil,
-          metadata: any(),
+          sent_at: DateTime.t() | nil,
+          seen_at: DateTime.t() | nil,
+          source: String.t(),
+          type: String.t(),
+          private: boolean() | nil,
+          metadata: map() | nil,
           # Foreign keys
-          conversation_id: any(),
+          conversation_id: Ecto.UUID.t(),
           conversation: any(),
-          account_id: any(),
+          account_id: Ecto.UUID.t(),
           account: any(),
-          customer_id: any(),
+          customer_id: Ecto.UUID.t(),
           customer: any(),
-          user_id: any(),
+          user_id: integer(),
           user: any(),
           # Timestamps
-          inserted_at: any(),
-          updated_at: any()
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
         }
 
   @primary_key {:id, :binary_id, autogenerate: true}

--- a/lib/chat_api/notes.ex
+++ b/lib/chat_api/notes.ex
@@ -54,7 +54,7 @@ defmodule ChatApi.Notes do
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries
-  @spec filter_where(map()) :: Ecto.Query.DynamicExpr.t()
+  @spec filter_where(map()) :: %Ecto.Query.DynamicExpr{}
   defp filter_where(attrs) do
     Enum.reduce(attrs, dynamic(true), fn
       {"customer_id", value}, dynamic ->

--- a/lib/chat_api/slack_conversation_threads.ex
+++ b/lib/chat_api/slack_conversation_threads.ex
@@ -142,7 +142,7 @@ defmodule ChatApi.SlackConversationThreads do
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries
-  @spec filter_where(map()) :: Ecto.Query.DynamicExpr.t()
+  @spec filter_where(map()) :: %Ecto.Query.DynamicExpr{}
   defp filter_where(attrs) do
     Enum.reduce(attrs, dynamic(true), fn
       {"slack_channel", value}, dynamic ->

--- a/lib/chat_api/tags/conversation_tag.ex
+++ b/lib/chat_api/tags/conversation_tag.ex
@@ -4,6 +4,17 @@ defmodule ChatApi.Tags.ConversationTag do
 
   alias ChatApi.{Accounts.Account, Conversations.Conversation, Tags.Tag, Users.User}
 
+  @type t :: %__MODULE__{
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          conversation_id: Ecto.UUID.t(),
+          tag_id: Ecto.UUID.t(),
+          creator_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "conversation_tags" do

--- a/lib/chat_api/tags/customer_tag.ex
+++ b/lib/chat_api/tags/customer_tag.ex
@@ -4,6 +4,17 @@ defmodule ChatApi.Tags.CustomerTag do
 
   alias ChatApi.{Accounts.Account, Customers.Customer, Tags.Tag, Users.User}
 
+  @type t :: %__MODULE__{
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          customer_id: Ecto.UUID.t(),
+          tag_id: Ecto.UUID.t(),
+          creator_id: integer() | nil,
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "customer_tags" do

--- a/lib/chat_api/user_invitations/user_invitation.ex
+++ b/lib/chat_api/user_invitations/user_invitation.ex
@@ -4,6 +4,15 @@ defmodule ChatApi.UserInvitations.UserInvitation do
 
   alias ChatApi.Accounts.Account
 
+  @type t :: %__MODULE__{
+          expires_at: DateTime.t(),
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 

--- a/lib/chat_api/users/user_profile.ex
+++ b/lib/chat_api/users/user_profile.ex
@@ -4,6 +4,18 @@ defmodule ChatApi.Users.UserProfile do
 
   alias ChatApi.Users.User
 
+  @type t :: %__MODULE__{
+          display_name: String.t() | nil,
+          full_name: String.t() | nil,
+          profile_photo_url: String.t() | nil,
+          slack_user_id: String.t() | nil,
+          # Foreign keys
+          user_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "user_profiles" do

--- a/lib/chat_api/users/user_settings.ex
+++ b/lib/chat_api/users/user_settings.ex
@@ -4,6 +4,15 @@ defmodule ChatApi.Users.UserSettings do
 
   alias ChatApi.Users.User
 
+  @type t :: %__MODULE__{
+          email_alert_on_new_message: boolean(),
+          # Foreign keys
+          user_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "user_settings" do

--- a/lib/chat_api/widget_settings/widget_setting.ex
+++ b/lib/chat_api/widget_settings/widget_setting.ex
@@ -4,6 +4,23 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
 
   alias ChatApi.Accounts.Account
 
+  @type t :: %__MODULE__{
+          title: String.t() | nil,
+          subtitle: String.t() | nil,
+          color: String.t() | nil,
+          greeting: String.t() | nil,
+          new_message_placeholder: String.t() | nil,
+          base_url: String.t() | nil,
+          host: String.t() | nil,
+          pathname: String.t() | nil,
+          last_seen_at: DateTime.t() | nil,
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "widget_settings" do


### PR DESCRIPTION
### Description

Fix dialyzer typespec warnings for missing types.

No more typespec warning
<img width="571" alt="Screenshot 2021-01-24 at 8 16 46 AM" src="https://user-images.githubusercontent.com/30904297/105618690-c27d0300-5e1c-11eb-9311-69686db240de.png">

### Issue

#534 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
