### PR TITLE
Add account `settings` to handle configuring account-level automated notifications

### DIFF
--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -7,7 +7,7 @@ defmodule ChatApi.Accounts do
   require Logger
   alias ChatApi.Repo
 
-  alias ChatApi.Accounts.{Account, WorkingHours}
+  alias ChatApi.Accounts.{Account, Settings, WorkingHours}
   alias ChatApi.Users.User
 
   @spec list_accounts() :: [Account.t()]
@@ -137,6 +137,15 @@ defmodule ChatApi.Accounts do
     |> select([:subscription_plan])
     |> Repo.one!()
     |> Map.get(:subscription_plan)
+  end
+
+  @spec get_account_settings!(binary()) :: Settings.t()
+  def get_account_settings!(account_id) do
+    Account
+    |> where(id: ^account_id)
+    |> select([:settings])
+    |> Repo.one!()
+    |> Map.get(:settings, %{})
   end
 
   @starter_plan_max_users 2

--- a/lib/chat_api/accounts/settings.ex
+++ b/lib/chat_api/accounts/settings.ex
@@ -1,0 +1,14 @@
+defmodule ChatApi.Accounts.Settings do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  embedded_schema do
+    field(:disable_automated_reply_emails, :boolean)
+  end
+
+  @spec changeset(any(), map()) :: Ecto.Changeset.t()
+  def changeset(schema, params) do
+    schema
+    |> cast(params, [:disable_automated_reply_emails])
+  end
+end

--- a/lib/chat_api/emails.ex
+++ b/lib/chat_api/emails.ex
@@ -34,8 +34,9 @@ defmodule ChatApi.Emails do
   @spec format_sender_name(User.t(), Account.t()) :: binary
   def format_sender_name(user, account) do
     case user.profile do
-      nil -> account.company_name
-      profile -> profile.display_name || profile.full_name
+      %{display_name: display_name} when not is_nil(display_name) -> display_name
+      %{full_name: full_name} when not is_nil(full_name) -> full_name
+      _ -> account.company_name
     end
   end
 

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -70,8 +70,8 @@ defmodule ChatApi.Messages.Notification do
 
   def notify(%Message{} = message, :conversation_reply_email) do
     Logger.info("Sending notification: :conversation_reply_email")
-    # 2 minutes (TODO: make this configurable?)
-    schedule_in = 2 * 60
+    # 20 minutes (TODO: make this configurable?)
+    schedule_in = 20 * 60
     formatted = Helpers.format(message)
 
     # TODO: not sure the best way to handle this, but basically we want to only

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -234,6 +234,7 @@ defmodule ChatApiWeb.SlackController do
         |> Messages.Notification.notify(:webhooks)
         |> Messages.Notification.notify(:slack_support_channel)
         |> Messages.Notification.notify(:slack_company_channel)
+        |> Messages.Notification.notify(:conversation_reply_email)
         |> Messages.Helpers.handle_post_creation_conversation_updates()
       else
         case SlackAuthorizations.get_authorization_by_account(account_id, %{type: "support"}) do

--- a/priv/repo/migrations/20210125193914_add_settings_to_account.exs
+++ b/priv/repo/migrations/20210125193914_add_settings_to_account.exs
@@ -1,0 +1,11 @@
+defmodule ChatApi.Repo.Migrations.AddSettingsToAccount do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      # NB: eventually it may make sense to have a separate `account_settings` table,
+      # but for now I'm not sure it necessarily needs to be relational?
+      add(:settings, :map)
+    end
+  end
+end

--- a/test/chat_api/accounts_test.exs
+++ b/test/chat_api/accounts_test.exs
@@ -52,6 +52,16 @@ defmodule ChatApi.AccountsTest do
       assert account.subscription_plan != "team"
     end
 
+    test "update_account/2 updates the account's embedded settings",
+         %{account: account} do
+      assert {:ok, %Account{} = account} =
+               Accounts.update_account(account, %{
+                 settings: %{disable_automated_reply_emails: true}
+               })
+
+      assert %Accounts.Settings{disable_automated_reply_emails: true} = account.settings
+    end
+
     test "update_account/2 with invalid data returns error changeset",
          %{account: account} do
       assert {:error, %Ecto.Changeset{}} = Accounts.update_account(account, @invalid_attrs)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,8 @@ defmodule ChatApi.Factory do
   # Factories
   def account_factory do
     %ChatApi.Accounts.Account{
-      company_name: sequence("some company_name")
+      company_name: sequence("some company_name"),
+      settings: %{}
     }
   end
 


### PR DESCRIPTION
### Description

This PR handles a couple enhancements to our automatic reply emails:
- [x] When an agent replies through Slack, trigger an automatic email to get sent if the customer is no longer available (the same way it works in the dashboard)
- [x] Add the `settings` field to the `accounts` table, with a configuration option for `disable_automated_reply_emails`

### Issue

Backend for https://github.com/papercups-io/papercups/issues/441

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
