### PR TITLE
Include Slack channel name in link to thread in sidebar

### DIFF
--- a/assets/src/components/conversations/SlackConversationThreads.tsx
+++ b/assets/src/components/conversations/SlackConversationThreads.tsx
@@ -27,26 +27,30 @@ const SlackConversationThreads = ({
       .then(() => setLoading(false));
   }, [conversationId]);
 
+  const threads = slackConversationThreads.filter(
+    (thread) => thread.permalink && thread.permalink.length > 0
+  );
+
   if (loading) {
     return <Spinner size={16} />;
-  } else if (!slackConversationThreads || !slackConversationThreads.length) {
+  } else if (!threads || !threads.length) {
     return <Text type="secondary">None</Text>;
   }
 
   return (
     <Box>
-      {slackConversationThreads
-        .filter((thread) => thread.permalink && thread.permalink.length > 0)
-        .map(({id, permalink}) => {
-          return (
-            <Flex key={id} mb={1} sx={{alignItems: 'center'}}>
-              <Image src="/slack.svg" alt="Slack" sx={{height: 16, mr: 1}} />
-              <a href={permalink} target="_blank" rel="noopener noreferrer">
-                Link to thread
-              </a>
-            </Flex>
-          );
-        })}
+      {threads.map(({id, permalink, slack_channel_name: slackChannelName}) => {
+        return (
+          <Flex key={id} mb={1} sx={{alignItems: 'center'}}>
+            <Image src="/slack.svg" alt="Slack" sx={{height: 16, mr: 1}} />
+            <a href={permalink} target="_blank" rel="noopener noreferrer">
+              {slackChannelName
+                ? `View in #${slackChannelName}`
+                : 'Link to thread'}
+            </a>
+          </Flex>
+        );
+      })}
     </Box>
   );
 };

--- a/lib/chat_api/slack_conversation_threads/slack_conversation_thread.ex
+++ b/lib/chat_api/slack_conversation_threads/slack_conversation_thread.ex
@@ -21,6 +21,8 @@ defmodule ChatApi.SlackConversationThreads.SlackConversationThread do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "slack_conversation_threads" do
+    # NB: this represents the slack_channel_id, not the name... might be worth
+    # renaming this at some point, and also including a field for the slack_channel_name)
     field :slack_channel, :string
     field :slack_thread_ts, :string
 

--- a/lib/chat_api_web/views/slack_conversation_thread_view.ex
+++ b/lib/chat_api_web/views/slack_conversation_thread_view.ex
@@ -34,9 +34,11 @@ defmodule ChatApiWeb.SlackConversationThreadView do
       conversation_id: slack_conversation_thread.conversation_id,
       created_at: slack_conversation_thread.inserted_at,
       updated_at: slack_conversation_thread.updated_at,
-      permalink: slack_conversation_thread.permalink,
       slack_channel: slack_conversation_thread.slack_channel,
-      slack_thread_ts: slack_conversation_thread.slack_thread_ts
+      slack_thread_ts: slack_conversation_thread.slack_thread_ts,
+      # Computed params
+      permalink: slack_conversation_thread.permalink,
+      slack_channel_name: slack_conversation_thread.slack_channel_name
     }
   end
 end


### PR DESCRIPTION
### Description

Include Slack channel name in link to thread in sidebar

### Screenshots
<img width="257" alt="Screen Shot 2021-01-26 at 1 38 51 PM" src="https://user-images.githubusercontent.com/5264279/105889246-f5b9c080-5fdb-11eb-9705-896407461d5c.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
