### PR TITLE
Fix Slack user ID and link formatting

### DIFF
--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -352,9 +352,11 @@ defmodule ChatApi.Slack.Helpers do
         Enum.reduce(results, text, fn [match, id], acc ->
           # TODO: figure out best way to handle unrecognized user IDs
           slack_user_id = "U#{id}"
-          username = get_slack_username(slack_user_id, access_token) || "unknown"
 
-          String.replace(acc, match, "@#{username}")
+          case get_slack_username(slack_user_id, access_token) do
+            nil -> acc
+            username -> String.replace(acc, match, "@#{username}")
+          end
         end)
     end
   end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -217,7 +217,7 @@ defmodule ChatApiWeb.SlackController do
            SlackAuthorizations.get_authorization_by_account(account_id, %{type: "reply"}) do
       if Slack.Helpers.is_primary_channel?(primary_reply_authorization, slack_channel_id) do
         %{
-          "body" => text,
+          "body" => Slack.Helpers.sanitize_slack_message(text, primary_reply_authorization),
           "conversation_id" => conversation_id,
           "account_id" => account_id,
           "source" => "slack",
@@ -245,7 +245,7 @@ defmodule ChatApiWeb.SlackController do
             authorization
             |> Slack.Helpers.format_sender_id!(slack_user_id, slack_channel_id)
             |> Map.merge(%{
-              "body" => text,
+              "body" => Slack.Helpers.sanitize_slack_message(text, authorization),
               "conversation_id" => conversation_id,
               "account_id" => account_id,
               "source" => "slack"
@@ -311,7 +311,7 @@ defmodule ChatApiWeb.SlackController do
              account_id: account_id,
              conversation_id: conversation.id,
              customer_id: customer.id,
-             body: text,
+             body: Slack.Helpers.sanitize_slack_message(text, authorization),
              source: "slack"
            }),
          {:ok, _slack_conversation_thread} <-
@@ -455,7 +455,7 @@ defmodule ChatApiWeb.SlackController do
              account_id: account_id,
              conversation_id: conversation.id,
              customer_id: customer.id,
-             body: text,
+             body: Slack.Helpers.sanitize_slack_message(text, authorization),
              source: "slack"
            }),
          {:ok, _slack_conversation_thread} <-

--- a/lib/mix/tasks/fix_slack_message_formatting.ex
+++ b/lib/mix/tasks/fix_slack_message_formatting.ex
@@ -1,0 +1,70 @@
+defmodule Mix.Tasks.FixSlackMessageFormatting do
+  use Mix.Task
+
+  require Logger
+  import Ecto.Query, warn: false
+  alias ChatApi.{Messages, Repo, Slack, SlackAuthorizations}
+  alias ChatApi.Messages.Message
+  alias ChatApi.SlackAuthorizations.SlackAuthorization
+
+  @shortdoc "Fixes Slack message formatting for links and user IDs."
+
+  @moduledoc """
+  This task handles fixing Slack message formatting. For example, Slack has its own
+  markup for URLs and mailto links, which we want to convert to conventional markdown.
+  Slack also sends raw user IDs, which we want to convert to the user's display name.
+
+  Example:
+  ```
+  $ mix fix_slack_message_formatting
+  $ mix fix_slack_message_formatting [ACCOUNT_TOKEN]
+  ```
+
+  On Heroku:
+  ```
+  $ heroku run "POOL_SIZE=2 mix fix_slack_message_formatting"
+  $ heroku run "POOL_SIZE=2 mix fix_slack_message_formatting [ACCOUNT_TOKEN]"
+  ```
+
+  """
+
+  @spec run([binary()]) :: :ok
+  def run(args) do
+    Application.ensure_all_started(:chat_api)
+
+    Message
+    |> where([m], ilike(m.body, "%<@U%"))
+    |> filter_args(args)
+    |> Repo.all()
+    |> Enum.each(fn %Message{account_id: account_id, body: body} = message ->
+      case find_valid_slack_authorization(account_id) do
+        %SlackAuthorization{} = authorization ->
+          Messages.update_message(message, %{
+            body: Slack.Helpers.sanitize_slack_message(body, authorization)
+          })
+
+        _ ->
+          nil
+      end
+    end)
+  end
+
+  @spec find_valid_slack_authorization(binary()) :: SlackAuthorization.t() | nil
+  def find_valid_slack_authorization(account_id) do
+    account_id
+    |> SlackAuthorizations.list_slack_authorizations_by_account()
+    |> Enum.find(fn auth ->
+      String.contains?(auth.scope, "users:read") &&
+        String.contains?(auth.scope, "users:read.email")
+    end)
+  end
+
+  @spec filter_args(Ecto.Query.t(), [binary()] | []) :: Ecto.Query.t()
+  def filter_args(query, []), do: query
+
+  def filter_args(query, [account_id]) do
+    query |> where(account_id: ^account_id)
+  end
+
+  def filter_args(query, _), do: query
+end

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -612,7 +612,7 @@ defmodule ChatApi.SlackTest do
       end
     end
 
-    test "Helpers.sanitize_slack_message/2 returns @unknown for unrecognized user IDs", %{
+    test "Helpers.sanitize_slack_message/2 doesn't do anything for unrecognized user IDs", %{
       account: account
     } do
       authorization = insert(:slack_authorization, account: account)
@@ -622,7 +622,7 @@ defmodule ChatApi.SlackTest do
           {:ok, "Something went wrong!"}
         end do
         assert capture_log(fn ->
-                 assert "What's up, @unknown?" =
+                 assert "What's up, <@U123INVALID>?" =
                           Slack.Helpers.sanitize_slack_message(
                             "What's up, <@U123INVALID>?",
                             authorization

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -612,6 +612,25 @@ defmodule ChatApi.SlackTest do
       end
     end
 
+    test "Helpers.sanitize_slack_message/2 returns @unknown for unrecognized user IDs", %{
+      account: account
+    } do
+      authorization = insert(:slack_authorization, account: account)
+
+      with_mock ChatApi.Slack.Client,
+        retrieve_user_info: fn _, _ ->
+          {:ok, "Something went wrong!"}
+        end do
+        assert capture_log(fn ->
+                 assert "What's up, @unknown?" =
+                          Slack.Helpers.sanitize_slack_message(
+                            "What's up, <@U123INVALID>?",
+                            authorization
+                          )
+               end) =~ "Unable to retrieve Slack username"
+      end
+    end
+
     test "Helpers.sanitize_slack_message/2 formats links properly", %{account: account} do
       authorization = insert(:slack_authorization, account: account)
 

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -555,6 +555,122 @@ defmodule ChatApi.SlackTest do
       end
     end
 
+    test "Helpers.sanitize_slack_message/2 formats user IDs properly", %{account: account} do
+      authorization = insert(:slack_authorization, account: account)
+      slack_user_id_with_username_only = "U123USERNAMEONLY"
+      slack_user_id_with_real_name = "U123WITHREALNAME"
+      slack_user_id_with_display_name = "U123WITHDISPLAYNAME"
+
+      slack_users_by_id = %{
+        slack_user_id_with_username_only => %{
+          "id" => slack_user_id_with_username_only,
+          "name" => "alexr",
+          "real_name" => "Alex Reichert",
+          "tz" => "America/New_York"
+        },
+        slack_user_id_with_real_name => %{
+          "id" => slack_user_id_with_real_name,
+          "name" => "alexr",
+          "real_name" => "Alex Reichert",
+          "tz" => "America/New_York",
+          "profile" => %{"email" => "new@customer.com", "real_name" => "Alex Reichert"}
+        },
+        slack_user_id_with_display_name => %{
+          "id" => slack_user_id_with_display_name,
+          "name" => "alexr",
+          "real_name" => "Alex Reichert",
+          "tz" => "America/New_York",
+          "profile" => %{
+            "email" => "new@customer.com",
+            "real_name" => "Alex Reichert",
+            "display_name" => "Alex"
+          }
+        }
+      }
+
+      with_mock ChatApi.Slack.Client,
+        retrieve_user_info: fn slack_user_id, _ ->
+          {:ok, %{body: %{"ok" => true, "user" => Map.get(slack_users_by_id, slack_user_id)}}}
+        end do
+        assert "What's up, @alexr?" =
+                 Slack.Helpers.sanitize_slack_message(
+                   "What's up, <@#{slack_user_id_with_username_only}>?",
+                   authorization
+                 )
+
+        assert "Hi there, @Alex Reichert!" =
+                 Slack.Helpers.sanitize_slack_message(
+                   "Hi there, <@#{slack_user_id_with_real_name}>!",
+                   authorization
+                 )
+
+        assert "How's it going, @Alex?" =
+                 Slack.Helpers.sanitize_slack_message(
+                   "How's it going, <@#{slack_user_id_with_display_name}>?",
+                   authorization
+                 )
+      end
+    end
+
+    test "Helpers.sanitize_slack_message/2 formats links properly", %{account: account} do
+      authorization = insert(:slack_authorization, account: account)
+
+      assert "[https://google.com](https://google.com)" =
+               Slack.Helpers.sanitize_slack_message("<https://google.com>", authorization)
+
+      assert "[google.com](http://google.com)" =
+               Slack.Helpers.sanitize_slack_message(
+                 "<http://google.com|google.com>",
+                 authorization
+               )
+
+      assert "[www.google.com](http://google.com)" =
+               Slack.Helpers.sanitize_slack_message(
+                 "<http://google.com|www.google.com>",
+                 authorization
+               )
+
+      assert "[check it out!](https://google.com)" =
+               Slack.Helpers.sanitize_slack_message(
+                 "<https://google.com|check it out!>",
+                 authorization
+               )
+    end
+
+    test "Helpers.sanitize_slack_message/2 formats mailto links properly", %{account: account} do
+      authorization = insert(:slack_authorization, account: account)
+
+      assert "[alex@test.com](mailto:alex@test.com)" =
+               Slack.Helpers.sanitize_slack_message(
+                 "<mailto:alex@test.com|alex@test.com>",
+                 authorization
+               )
+
+      assert "[alex123+papercups@test.com](mailto:alex123+papercups@test.com)" =
+               Slack.Helpers.sanitize_slack_message(
+                 "<mailto:alex123+papercups@test.com|alex123+papercups@test.com>",
+                 authorization
+               )
+    end
+
+    test "Helpers.sanitize_slack_message/2 doesn't modify messages without urls, mailto links, or user IDs",
+         %{account: account} do
+      authorization = insert(:slack_authorization, account: account)
+
+      [
+        "Hi there!",
+        "<this is not a link or user ID>",
+        "@papercups is awesome",
+        "Yo | yo | yo",
+        "<links-must-start-with-http.com>",
+        # TODO: add support for formatting this one:
+        "<#C123> is a link to a channel"
+      ]
+      |> Enum.each(fn text ->
+        assert ^text = Slack.Helpers.sanitize_slack_message(text, authorization)
+      end)
+    end
+
     test "Helpers.is_bot_message?/1 checks if the Slack message payload is from a bot" do
       bot_message = %{"bot_id" => "B123", "text" => "I am a bot"}
       nil_bot_message = %{"bot_id" => nil, "text" => "I am not a bot"}


### PR DESCRIPTION
### Description

Fix how Slack formats user IDs and links. (Slack just sends the raw user ID rather than the username, and it also has it's own style of formatting links that differs from conventional markdown.)

TODO: 
- [x] Write unit tests
- [x] Write script to retroactively update old messages with raw Slack user IDs
- [x] QA in staging

### Screenshots

**Before**:
<img width="352" alt="Screen Shot 2021-01-26 at 3 33 14 PM" src="https://user-images.githubusercontent.com/5264279/105902021-125df480-5fec-11eb-98f9-49e933ac93f3.png">

**After**:
<img width="307" alt="Screen Shot 2021-01-26 at 3 33 25 PM" src="https://user-images.githubusercontent.com/5264279/105902020-125df480-5fec-11eb-90ce-745540f894a3.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
