### PR TITLE
Load customer info on a per-message basis

### DIFF
--- a/assets/src/components/conversations/ChatMessage.tsx
+++ b/assets/src/components/conversations/ChatMessage.tsx
@@ -104,7 +104,6 @@ export const SenderAvatar = ({
 
 type Props = {
   message: Message;
-  customer?: Customer | null;
   isMe?: boolean;
   isLastInGroup?: boolean;
   shouldDisplayTimestamp?: boolean;
@@ -112,7 +111,6 @@ type Props = {
 
 const ChatMessage = ({
   message,
-  customer,
   isMe,
   isLastInGroup,
   shouldDisplayTimestamp,
@@ -121,6 +119,7 @@ const ChatMessage = ({
     body,
     sent_at,
     created_at,
+    customer,
     user,
     seen_at,
     private: isPrivate,

--- a/assets/src/components/conversations/ConversationMessages.tsx
+++ b/assets/src/components/conversations/ConversationMessages.tsx
@@ -5,7 +5,7 @@ import {Button, colors, Result} from '../common';
 import {SmileOutlined} from '../icons';
 import Spinner from '../Spinner';
 import ChatMessage from './ChatMessage';
-import {Customer, Message, User} from '../../types';
+import {Message, User} from '../../types';
 
 const EmptyMessagesPlaceholder = () => {
   return (
@@ -40,7 +40,6 @@ const GettingStartedRedirect = () => {
 const ConversationMessages = ({
   messages,
   currentUser,
-  customer,
   loading,
   isClosing,
   showGetStarted,
@@ -50,7 +49,6 @@ const ConversationMessages = ({
 }: {
   messages: Array<Message>;
   currentUser?: User | null;
-  customer: Customer | null;
   loading?: boolean;
   isClosing?: boolean;
   showGetStarted?: boolean;
@@ -107,7 +105,6 @@ const ConversationMessages = ({
                 <ChatMessage
                   key={key}
                   message={msg}
-                  customer={customer}
                   isMe={isMe}
                   isLastInGroup={isLastInGroup}
                   shouldDisplayTimestamp={isLastInGroup}

--- a/assets/src/components/conversations/ConversationsContainer.tsx
+++ b/assets/src/components/conversations/ConversationsContainer.tsx
@@ -412,7 +412,6 @@ class ConversationsContainer extends React.Component<Props, State> {
             <ConversationMessages
               messages={messages}
               currentUser={currentUser}
-              customer={selectedCustomer}
               loading={loading}
               isClosing={isClosingSelected}
               showGetStarted={showGetStarted}

--- a/assets/src/components/conversations/SharedConversation.tsx
+++ b/assets/src/components/conversations/SharedConversation.tsx
@@ -5,13 +5,12 @@ import qs from 'query-string';
 import {colors} from '../common';
 import ConversationMessages from './ConversationMessages';
 import * as API from '../../api';
-import {Customer, Message} from '../../types';
+import {Message} from '../../types';
 import logger from '../../logger';
 
 type Props = RouteComponentProps<{}>;
 type State = {
   loading: boolean;
-  customer: Customer | null;
   messages: Array<Message>;
 };
 
@@ -21,7 +20,7 @@ class SharedConversationContainer extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    this.state = {loading: true, customer: null, messages: []};
+    this.state = {loading: true, messages: []};
   }
 
   async componentDidMount() {
@@ -30,13 +29,12 @@ class SharedConversationContainer extends React.Component<Props, State> {
       const q = qs.parse(search);
       const conversationId = String(q?.cid);
       const token = String(q?.token);
-      const {customer, messages = []} = await API.fetchSharedConversation(
+      const {messages = []} = await API.fetchSharedConversation(
         conversationId,
         token
       );
 
       this.setState({
-        customer,
         messages: messages.sort(
           (a: Message, b: Message) =>
             +new Date(a.created_at) - +new Date(b.created_at)
@@ -55,11 +53,7 @@ class SharedConversationContainer extends React.Component<Props, State> {
   };
 
   render() {
-    const {loading, customer, messages} = this.state;
-
-    if (!customer) {
-      return null;
-    }
+    const {loading, messages} = this.state;
 
     return (
       <Flex
@@ -83,7 +77,6 @@ class SharedConversationContainer extends React.Component<Props, State> {
             sx={{p: 3}}
             loading={loading}
             messages={messages}
-            customer={customer}
             isAgentMessage={(message: Message) => message && !!message.user_id}
             setScrollRef={(el) => (this.scrollToEl = el)}
           />

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -49,8 +49,7 @@ class ConversationSidebar extends React.Component<Props, any> {
   };
 
   render() {
-    const {conversation, currentUser, messages = []} = this.props;
-    const {customer} = conversation;
+    const {currentUser, messages = []} = this.props;
 
     return (
       <Flex
@@ -69,7 +68,6 @@ class ConversationSidebar extends React.Component<Props, any> {
           sx={{p: 3}}
           messages={messages}
           currentUser={currentUser}
-          customer={customer}
           setScrollRef={(el) => (this.scrollToEl = el)}
         />
 

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -12,11 +12,6 @@ defmodule ChatApi.Conversations do
   alias ChatApi.Messages.Message
   alias ChatApi.Tags.{Tag, ConversationTag}
 
-  @spec list_conversations() :: [Conversation.t()]
-  def list_conversations do
-    Conversation |> Repo.all() |> Repo.preload([:customer, :messages])
-  end
-
   @spec list_conversations_by_account(binary(), map()) :: [Conversation.t()]
   def list_conversations_by_account(account_id, filters \\ %{}) do
     Conversation
@@ -24,7 +19,7 @@ defmodule ChatApi.Conversations do
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
     |> order_by_most_recent_message()
-    |> preload([:customer, messages: [:attachments, user: :profile]])
+    |> preload([:customer, messages: [:attachments, :customer, user: :profile]])
     |> Repo.all()
   end
 
@@ -87,7 +82,7 @@ defmodule ChatApi.Conversations do
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
     |> order_by_most_recent_message()
-    |> preload([:customer, messages: [user: :profile]])
+    |> preload([:customer, messages: [:attachments, :customer, user: :profile]])
     |> first()
     |> Repo.one()
   end
@@ -131,7 +126,7 @@ defmodule ChatApi.Conversations do
       from m in Message,
         where: m.private == false,
         order_by: m.inserted_at,
-        preload: [user: :profile]
+        preload: [:attachments, user: :profile]
 
     Conversation
     |> where(customer_id: ^customer_id)
@@ -192,7 +187,7 @@ defmodule ChatApi.Conversations do
     # TODO: make sure messages are sorted properly?
     Conversation
     |> Repo.get!(id)
-    |> Repo.preload([:customer, :tags, messages: [:attachments, user: :profile]])
+    |> Repo.preload([:customer, :tags, messages: [:attachments, :customer, user: :profile]])
   end
 
   @spec get_conversation(binary()) :: Conversation.t() | nil
@@ -224,7 +219,7 @@ defmodule ChatApi.Conversations do
     |> where(account_id: ^account_id)
     |> where([c], is_nil(c.archived_at))
     |> Repo.one!()
-    |> Repo.preload([:customer, :tags, messages: [user: :profile]])
+    |> Repo.preload([:customer, :tags, messages: [:attachments, :customer, user: :profile]])
   end
 
   @spec create_conversation(map()) :: {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -20,15 +20,6 @@ defmodule ChatApi.ConversationsTest do
     {:ok, account: account, conversation: conversation, customer: customer}
   end
 
-  describe "list_conversations/0" do
-    test "returns all conversations",
-         %{conversation: conversation} do
-      result_ids = Conversations.list_conversations() |> Enum.map(& &1.id)
-
-      assert result_ids == [conversation.id]
-    end
-  end
-
   describe "list_conversations_by_account/1" do
     test "returns all conversations for an account",
          %{account: account, conversation: conversation} do


### PR DESCRIPTION
### Description

With our new Slack integration, we can no longer assume that the `customer` will always be the same person within a conversation.

This PR updates the queries to load the `customer` association on a per-message basis.

### Screenshots

<img width="695" alt="Screen Shot 2021-02-01 at 2 12 32 PM" src="https://user-images.githubusercontent.com/5264279/106506317-8d655600-6497-11eb-90e2-ae9fbafef364.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
