### PR TITLE
Add better support for private notes in Slack

### DIFF
--- a/lib/chat_api/slack/event.ex
+++ b/lib/chat_api/slack/event.ex
@@ -58,7 +58,9 @@ defmodule ChatApi.Slack.Event do
          primary_reply_authorization <-
            SlackAuthorizations.get_authorization_by_account(account_id, %{type: "reply"}) do
       if Slack.Helpers.is_primary_channel?(primary_reply_authorization, slack_channel_id) do
-        %{
+        text
+        |> Slack.Helpers.parse_message_type_params()
+        |> Map.merge(%{
           "body" => Slack.Helpers.sanitize_slack_message(text, primary_reply_authorization),
           "conversation_id" => conversation_id,
           "account_id" => account_id,
@@ -70,7 +72,7 @@ defmodule ChatApi.Slack.Event do
               slack_user_id,
               conversation.assignee_id
             )
-        }
+        })
         |> Messages.create_and_fetch!()
         |> Messages.Notification.broadcast_to_customer!()
         |> Messages.Notification.broadcast_to_admin!()

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -95,12 +95,14 @@ defmodule ChatApiWeb.NotificationChannel do
 
   @spec broadcast_new_message(Message.t(), any()) :: Message.t()
   defp broadcast_new_message(%Message{private: true} = message, socket) do
-    # For private messages, we only need to broadcast back to the admin channel
-    # (We avoid broadcasting to the customer channel or Slack or email)
-    # TODO: broadcast to webhooks and internal Slack channel?
+    # For private messages, we only need to broadcast back to the admin channel,
+    # the internal Slack channel, and webhooks. (We avoid broadcasting to the
+    # customer channel or any public Slack channel or email.)
     broadcast(socket, "shout", Messages.Helpers.format(message))
 
     message
+    |> Messages.Notification.notify(:slack)
+    |> Messages.Notification.notify(:webhooks)
   end
 
   defp broadcast_new_message(message, socket) do


### PR DESCRIPTION
### Description

Add better support for private notes in Slack:
- [x] Display private notes in internal Slack integration when created from dashboard
- [x] Allow prefixing messages in Slack with `\\` or `;;` to create private note from within Slack
- [x] Remove these special prefix characters from messages internally
- [x] Write more tests
- [x] QA in staging

### Issue

https://github.com/papercups-io/papercups/issues/560

### Screenshots

| In Slack (internal) | In dashboard (internal) | In chat widget (external) |  
|---|---|---|
| <img width="367" alt="Screen Shot 2021-02-04 at 4 29 16 PM" src="https://user-images.githubusercontent.com/5264279/106957658-4b8e1700-6706-11eb-9ee8-ae1b7a6e7c29.png"> | <img width="564" alt="Screen Shot 2021-02-04 at 4 29 37 PM" src="https://user-images.githubusercontent.com/5264279/106957657-4b8e1700-6706-11eb-86c4-3096d3b1a355.png"> | <img width="373" alt="Screen Shot 2021-02-04 at 4 29 55 PM" src="https://user-images.githubusercontent.com/5264279/106957656-4af58080-6706-11eb-83cf-9927b086a519.png"> |

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
