### PR TITLE
Display dynamic conversation status in Slack thread initial message

### DIFF
--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -4,6 +4,7 @@ defmodule ChatApi.Messages.Helpers do
   """
 
   alias ChatApi.Conversations
+  alias ChatApi.Conversations.Conversation
   alias ChatApi.Messages.Message
 
   @spec get_conversation_topic(Message.t()) :: binary()
@@ -28,6 +29,7 @@ defmodule ChatApi.Messages.Helpers do
     message
     |> build_conversation_updates()
     |> update_conversation_and_broadcast_to_admin(message)
+    |> Conversations.Helpers.broadcast_conversation_updates_to_slack()
 
     message
   end
@@ -66,7 +68,7 @@ defmodule ChatApi.Messages.Helpers do
     end
   end
 
-  @spec update_conversation_and_broadcast_to_admin(map(), Message.t()) :: :ok | no_return()
+  @spec update_conversation_and_broadcast_to_admin(map(), Message.t()) :: Conversation.t()
   defp update_conversation_and_broadcast_to_admin(
          updates,
          %Message{
@@ -84,5 +86,7 @@ defmodule ChatApi.Messages.Helpers do
       "id" => conversation_id,
       "updates" => ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
     })
+
+    conversation
   end
 end

--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -69,6 +69,24 @@ defmodule ChatApi.Slack.Client do
     end
   end
 
+  @spec update_message(binary(), binary(), map(), binary()) :: {:ok, nil} | Tesla.Env.result()
+  def update_message(channel, ts, updates, access_token) do
+    if should_execute?(access_token) do
+      post(
+        "/chat.update",
+        Map.merge(updates, %{"channel" => channel, "ts" => ts}),
+        headers: [
+          {"Authorization", "Bearer " <> access_token}
+        ]
+      )
+    else
+      # Inspect what would've been sent for debugging
+      Logger.info("Would have retrieved message #{inspect(ts)} from channel #{inspect(channel)}")
+
+      {:ok, nil}
+    end
+  end
+
   @spec get_message_permalink(binary(), binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
   def get_message_permalink(channel, ts, access_token) do
     if should_execute?(access_token) do

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -684,16 +684,17 @@ defmodule ChatApi.Slack.Helpers do
     end
   end
 
-  @private_note_prefix_v1 ~S(\\ )
-  @private_note_prefix_v2 ~S(;; )
-  @private_note_prefix_regex_v1 ~r/^\\\\ /
-  @private_note_prefix_regex_v2 ~r/^;; /
+  @private_note_prefix_v1 ~S(\\)
+  @private_note_prefix_v2 ~S(;;)
+  @private_note_prefix_regex_v1 ~r/^\\\\/
+  @private_note_prefix_regex_v2 ~r/^;;/
 
   @spec sanitize_private_note(binary()) :: binary()
   def sanitize_private_note(text) do
     text
     |> String.replace(@private_note_prefix_regex_v1, "")
     |> String.replace(@private_note_prefix_regex_v2, "")
+    |> String.trim()
   end
 
   @spec parse_message_type_params(binary()) :: map()

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -951,17 +951,17 @@ defmodule ChatApi.Slack.Helpers do
   @spec get_slack_conversation_status(Conversation.t()) :: binary()
   def get_slack_conversation_status(conversation) do
     case conversation do
-      %{status: "open", first_replied_at: nil} ->
-        ":wave: Unhandled"
-
-      %{status: "open", first_replied_at: first_replied_at} when not is_nil(first_replied_at) ->
-        ":speech_balloon: In progress"
-
       %{status: "closed"} ->
         ":white_check_mark: Closed"
 
       %{closed_at: closed_at} when not is_nil(closed_at) ->
         ":white_check_mark: Closed"
+
+      %{status: "open", first_replied_at: nil} ->
+        ":wave: Unhandled"
+
+      %{status: "open", first_replied_at: first_replied_at} when not is_nil(first_replied_at) ->
+        ":speech_balloon: In progress"
     end
   end
 

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -826,6 +826,7 @@ defmodule ChatApi.Slack.Helpers do
   @spec get_message_payload(binary(), map()) :: map()
   def get_message_payload(text, %{
         channel: channel,
+        conversation: conversation,
         customer: %Customer{
           name: name,
           email: email,
@@ -872,6 +873,10 @@ defmodule ChatApi.Slack.Helpers do
             %{
               "type" => "mrkdwn",
               "text" => "*Timezone:*\n#{time_zone || "N/A"}"
+            },
+            %{
+              "type" => "mrkdwn",
+              "text" => "*Status:*\n#{get_slack_conversation_status(conversation)}"
             }
           ]
         }
@@ -915,6 +920,56 @@ defmodule ChatApi.Slack.Helpers do
   def get_message_payload(text, params) do
     raise "Unrecognized params for Slack payload: #{text} #{inspect(params)}"
   end
+
+  @spec update_fields_with_conversation_status([map()], Conversation.t()) :: [map()]
+  def update_fields_with_conversation_status(fields, conversation) do
+    status = get_slack_conversation_status(conversation)
+
+    if Enum.any?(fields, &is_slack_conversation_status_field?/1) do
+      Enum.map(fields, fn field ->
+        if is_slack_conversation_status_field?(field) do
+          Map.merge(field, %{
+            "type" => "mrkdwn",
+            "text" => "*Status:*\n#{status}"
+          })
+        else
+          field
+        end
+      end)
+    else
+      fields ++
+        [
+          %{
+            "type" => "mrkdwn",
+            "text" => "*Status:*\n#{status}"
+          }
+        ]
+    end
+  end
+
+  @spec get_slack_conversation_status(Conversation.t()) :: binary()
+  def get_slack_conversation_status(conversation) do
+    case conversation do
+      %{status: "open", first_replied_at: nil} ->
+        ":wave: Unhandled"
+
+      %{status: "open", first_replied_at: first_replied_at} when not is_nil(first_replied_at) ->
+        ":speech_balloon: In progress"
+
+      %{status: "closed"} ->
+        ":white_check_mark: Closed"
+
+      %{closed_at: closed_at} when not is_nil(closed_at) ->
+        ":white_check_mark: Closed"
+    end
+  end
+
+  @spec is_slack_conversation_status_field?(map()) :: boolean()
+  def is_slack_conversation_status_field?(%{"text" => text} = _field) do
+    text =~ "*Status:*" || text =~ "*Conversation status:*" || text =~ "*Conversation Status:*"
+  end
+
+  def is_slack_conversation_status_field?(_field), do: false
 
   @spec send_internal_notification(binary()) :: any()
   def send_internal_notification(message) do

--- a/lib/chat_api/slack/notification.ex
+++ b/lib/chat_api/slack/notification.ex
@@ -67,6 +67,7 @@ defmodule ChatApi.Slack.Notification do
       |> Slack.Helpers.get_message_text()
       |> Slack.Helpers.get_message_payload(%{
         channel: channel,
+        conversation: conversation,
         customer: customer,
         thread: thread,
         message: message

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -209,8 +209,9 @@ defmodule ChatApiWeb.ConversationController do
 
     with {:ok, %Conversation{} = conversation} <-
            Conversations.update_conversation(conversation, conversation_params) do
+      # Notify Slack of any conversation updates if integration exists
       Task.start(fn ->
-        Helpers.send_conversation_state_update(conversation, conversation_params)
+        Helpers.broadcast_conversation_updates_to_slack(conversation)
       end)
 
       render(conn, "update.json", conversation: conversation)

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -879,6 +879,8 @@ defmodule ChatApi.SlackTest do
       assert "note" = Slack.Helpers.sanitize_slack_message("\\\\ note", authorization)
       assert "note" = Slack.Helpers.sanitize_slack_message(~S(\\ note), authorization)
       assert "note" = Slack.Helpers.sanitize_slack_message(";; note", authorization)
+      assert "note" = Slack.Helpers.sanitize_slack_message(~S(\\note), authorization)
+      assert "note" = Slack.Helpers.sanitize_slack_message(";;note", authorization)
     end
 
     test "Helpers.parse_message_type_params/1 removes private note indicator prefixes" do
@@ -892,6 +894,12 @@ defmodule ChatApi.SlackTest do
 
       assert %{"private" => true, "type" => "note"} =
                Slack.Helpers.parse_message_type_params(";; note")
+
+      assert %{"private" => true, "type" => "note"} =
+               Slack.Helpers.parse_message_type_params(~S(\\note))
+
+      assert %{"private" => true, "type" => "note"} =
+               Slack.Helpers.parse_message_type_params(";;note")
     end
 
     test "Helpers.find_slack_user_mentions/1 extracts @mentions in a Slack message" do

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -301,7 +301,7 @@ defmodule ChatApi.SlackTest do
     end
 
     test "Helpers.get_message_payload/2 returns payload for initial slack thread",
-         %{customer: customer, thread: thread} do
+         %{customer: customer, conversation: conversation, thread: thread} do
       text = "Hello world"
       customer_email = "*Email:*\n#{customer.email}"
       channel = thread.slack_channel
@@ -332,7 +332,8 @@ defmodule ChatApi.SlackTest do
                      },
                      %{
                        "text" => "*Timezone:*\nN/A"
-                     }
+                     },
+                     %{"text" => "*Status:*\n:wave: Unhandled"}
                    ]
                  }
                ],
@@ -340,6 +341,7 @@ defmodule ChatApi.SlackTest do
              } =
                Slack.Helpers.get_message_payload(text, %{
                  channel: channel,
+                 conversation: conversation,
                  customer: customer,
                  thread: nil
                })


### PR DESCRIPTION
### Description

Display dynamic conversation status in Slack:
- When no response, status is ":wave: Unhandled"
- When an agent has responded, status is ":speech_balloon: In progress"
- Once closed, status is  ":white_check_mark: Closed"

### Screenshots

![Kapture 2021-02-05 at 15 08 45](https://user-images.githubusercontent.com/5264279/107083803-28c23800-67c4-11eb-8b04-6054fc605aa1.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
