### PR TITLE
Make it possible to close/reopen conversations from Slack

### DIFF
--- a/lib/chat_api/conversations/helpers.ex
+++ b/lib/chat_api/conversations/helpers.ex
@@ -31,6 +31,12 @@ defmodule ChatApi.Conversations.Helpers do
                   Slack.Helpers.update_fields_with_conversation_status(fields, conversation)
               })
 
+            %{"type" => "actions"} ->
+              Map.merge(block, %{
+                "elements" =>
+                  Slack.Helpers.update_action_elements_with_conversation_status(conversation)
+              })
+
             _ ->
               block
           end

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -780,7 +780,9 @@ defmodule ChatApi.Slack.Helpers do
 
     primary_message_text <>
       "\n\n" <>
-      "Reply to this thread to start chatting, or view in the #{dashboard_link} :rocket:"
+      "Reply to this thread to start chatting, or view in the #{dashboard_link} :rocket:" <>
+      "\n\n" <>
+      "(Start a message with `;;` or `\\\\` to send an <https://github.com/papercups-io/papercups/pull/562|internal note>.)"
   end
 
   @slack_chat_write_customize_scope "chat:write.customize"
@@ -880,6 +882,24 @@ defmodule ChatApi.Slack.Helpers do
               "text" => "*Status:*\n#{get_slack_conversation_status(conversation)}"
             }
           ]
+        },
+        %{
+          "type" => "divider"
+        },
+        %{
+          "type" => "actions",
+          "elements" => [
+            %{
+              "type" => "button",
+              "text" => %{
+                "type" => "plain_text",
+                "text" => "Resolve"
+              },
+              "value" => conversation.id,
+              "action_id" => "close_conversation",
+              "style" => "primary"
+            }
+          ]
         }
       ]
     }
@@ -943,6 +963,38 @@ defmodule ChatApi.Slack.Helpers do
           %{
             "type" => "mrkdwn",
             "text" => "*Status:*\n#{status}"
+          }
+        ]
+    end
+  end
+
+  @spec update_action_elements_with_conversation_status(Conversation.t()) :: [map()]
+  def update_action_elements_with_conversation_status(%Conversation{id: id, status: status}) do
+    case status do
+      "open" ->
+        [
+          %{
+            "type" => "button",
+            "text" => %{
+              "type" => "plain_text",
+              "text" => "Mark as resolved"
+            },
+            "value" => id,
+            "action_id" => "close_conversation",
+            "style" => "primary"
+          }
+        ]
+
+      "closed" ->
+        [
+          %{
+            "type" => "button",
+            "text" => %{
+              "type" => "plain_text",
+              "text" => "Reopen conversation"
+            },
+            "value" => id,
+            "action_id" => "open_conversation"
           }
         ]
     end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -146,7 +146,7 @@ defmodule ChatApiWeb.SlackController do
 
   @spec actions(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def actions(conn, %{"payload" => json}) do
-    Logger.debug("Payload from Slack webhook: #{inspect(json)}")
+    Logger.debug("Payload from Slack action: #{inspect(json)}")
 
     with {:ok, %{"actions" => actions}} <- Jason.decode(json) do
       Enum.each(actions, &handle_action/1)

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -3,7 +3,7 @@ defmodule ChatApiWeb.SlackController do
 
   require Logger
 
-  alias ChatApi.{Slack, SlackAuthorizations}
+  alias ChatApi.{Conversations, Slack, SlackAuthorizations}
   alias ChatApi.SlackAuthorizations.SlackAuthorization
 
   action_fallback(ChatApiWeb.FallbackController)
@@ -144,6 +144,17 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
+  @spec actions(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def actions(conn, %{"payload" => json}) do
+    Logger.debug("Payload from Slack webhook: #{inspect(json)}")
+
+    with {:ok, %{"actions" => actions}} <- Jason.decode(json) do
+      Enum.each(actions, &handle_action/1)
+    end
+
+    send_resp(conn, 200, "")
+  end
+
   @spec channels(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def channels(conn, payload) do
     # TODO: figure out the best way to handle errors here... should we just return
@@ -155,6 +166,44 @@ defmodule ChatApiWeb.SlackController do
          {:ok, result} <- Slack.Client.list_channels(access_token),
          %{body: %{"ok" => true, "channels" => channels}} <- result do
       json(conn, %{data: channels})
+    end
+  end
+
+  @spec handle_action(map()) :: any()
+  def handle_action(%{
+        "action_id" => "close_conversation",
+        "type" => "button",
+        "action_ts" => _action_ts,
+        "value" => conversation_id
+      }) do
+    conversation_id
+    |> Conversations.get_conversation!()
+    |> Conversations.update_conversation(%{"status" => "closed"})
+    |> case do
+      {:ok, conversation} ->
+        Conversations.Helpers.broadcast_conversation_updates_to_slack(conversation)
+
+      _ ->
+        nil
+    end
+  end
+
+  @spec handle_action(map()) :: any()
+  def handle_action(%{
+        "action_id" => "open_conversation",
+        "type" => "button",
+        "action_ts" => _action_ts,
+        "value" => conversation_id
+      }) do
+    conversation_id
+    |> Conversations.get_conversation!()
+    |> Conversations.update_conversation(%{"status" => "open"})
+    |> case do
+      {:ok, conversation} ->
+        Conversations.Helpers.broadcast_conversation_updates_to_slack(conversation)
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -64,6 +64,7 @@ defmodule ChatApiWeb.Router do
     get("/conversations/shared", ConversationController, :shared)
 
     post("/slack/webhook", SlackController, :webhook)
+    post("/slack/actions", SlackController, :actions)
     # TODO: move to protected route after testing?
     get("/hubspot/oauth", HubspotController, :oauth)
   end

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -304,6 +304,7 @@ defmodule ChatApi.SlackTest do
          %{customer: customer, conversation: conversation, thread: thread} do
       text = "Hello world"
       customer_email = "*Email:*\n#{customer.email}"
+      conversation_id = conversation.id
       channel = thread.slack_channel
 
       assert %{
@@ -335,6 +336,19 @@ defmodule ChatApi.SlackTest do
                      },
                      %{"text" => "*Status:*\n:wave: Unhandled"}
                    ]
+                 },
+                 %{"type" => "divider"},
+                 %{
+                   "elements" => [
+                     %{
+                       "action_id" => "close_conversation",
+                       "style" => "primary",
+                       "text" => %{"text" => "Resolve", "type" => "plain_text"},
+                       "type" => "button",
+                       "value" => ^conversation_id
+                     }
+                   ],
+                   "type" => "actions"
                  }
                ],
                "channel" => ^channel


### PR DESCRIPTION
### Description

- Make it possible to close/reopen conversations from Slack
- Update initial thread message text to include instructions for how to add internal private note

### Issue

https://github.com/papercups-io/papercups/issues/564

### Screenshots

![close-reopen-slack](https://user-images.githubusercontent.com/5264279/107275210-725a8f00-6a1f-11eb-846f-8752bad59cf5.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
