### PR TITLE
[Reporting] Add resolution metrics and download JSON button

### DIFF
--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -234,7 +234,7 @@ class ReportingDashboard extends React.Component<Props, State> {
     metrics: Array<MetricsByWeek> = [],
     field: 'average' | 'median'
   ) => {
-    const [current, next] = metrics;
+    const [current, previous] = metrics;
 
     if (!current) {
       return {};
@@ -242,15 +242,15 @@ class ReportingDashboard extends React.Component<Props, State> {
 
     const currentValue = current[field];
 
-    if (!next) {
+    if (!previous) {
       return {
         title: this.formatDurationInSeconds(currentValue),
         description: null,
       };
     }
 
-    const nextValue = next[field];
-    const percentage = (currentValue - nextValue) / (nextValue || 1);
+    const previousValue = previous[field];
+    const percentage = (currentValue - previousValue) / (previousValue || 1);
     const sign = percentage < 0 ? '-' : '+';
 
     return {

--- a/lib/chat_api_web/controllers/reporting_controller.ex
+++ b/lib/chat_api_web/controllers/reporting_controller.ex
@@ -5,7 +5,7 @@ defmodule ChatApiWeb.ReportingController do
 
   alias ChatApi.Reporting
 
-  action_fallback ChatApiWeb.FallbackController
+  action_fallback(ChatApiWeb.FallbackController)
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(%{assigns: %{current_user: %{account_id: account_id}}} = conn, %{
@@ -21,15 +21,17 @@ defmodule ChatApiWeb.ReportingController do
         conversations_by_date: Reporting.count_conversations_by_date(account_id, filters),
         messages_per_user: Reporting.count_messages_per_user(account_id, filters),
         messages_by_weekday: Reporting.count_messages_by_weekday(account_id, filters),
-        first_response_time_by_weekday:
-          Reporting.first_response_time_by_weekday(account_id, filters),
         sent_messages_by_date: Reporting.count_sent_messages_by_date(account_id, filters),
         received_messages_by_date: Reporting.count_received_messages_by_date(account_id, filters),
         average_time_to_first_reply:
           Reporting.average_seconds_to_first_reply(account_id, filters),
         median_time_to_first_reply: Reporting.median_seconds_to_first_reply(account_id, filters),
         first_reply_metrics_by_week:
-          Reporting.seconds_to_first_reply_metrics_by_week(account_id, filters)
+          Reporting.seconds_to_first_reply_metrics_by_week(account_id, filters),
+        average_time_to_resolution: Reporting.average_seconds_to_resolution(account_id, filters),
+        median_time_to_resolution: Reporting.median_seconds_to_resolution(account_id, filters),
+        resolution_metrics_by_week:
+          Reporting.seconds_to_resolution_metrics_by_week(account_id, filters)
         # NB: this are currently unused
         # customer_breakdown_by_browser:
         #   Reporting.get_customer_breakdown(account_id, :browser, filters),

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -29,6 +29,7 @@ defmodule ChatApiWeb.SlackController do
          } <- body,
          %{"id" => authed_user_id} <- authed_user,
          %{"id" => team_id, "name" => team_name} <- team,
+         # TODO: validate that `channel_id` doesn't match account integration with different `type`
          %{
            "channel" => channel,
            "channel_id" => channel_id,

--- a/test/chat_api/reporting_test.exs
+++ b/test/chat_api/reporting_test.exs
@@ -506,6 +506,265 @@ defmodule ChatApi.ReportingTest do
     end
   end
 
+  describe "average_seconds_to_resolution" do
+    test "gets the average seconds it takes to close", %{
+      account: account
+    } do
+      inserted_at = ~N[2020-09-01 12:00:00]
+      closed_at = ~N[2020-09-01 12:30:00]
+
+      insert_list(
+        3,
+        :conversation,
+        account: account,
+        inserted_at: inserted_at,
+        closed_at: closed_at
+      )
+
+      average_resolution_time = Reporting.average_seconds_to_resolution(account.id)
+      assert average_resolution_time == Time.diff(closed_at, inserted_at)
+    end
+
+    test "gets average resolution time of multiple times", %{account: account} do
+      # 31 seconds
+      inserted_at_1 = ~N[2020-09-01 12:00:00]
+      closed_at_1 = ~N[2020-09-01 12:00:31]
+
+      # 671 seconds
+      inserted_at_2 = ~N[2020-09-02 12:00:00]
+      closed_at_2 = ~N[2020-09-02 12:11:11]
+
+      # 3665 seconds
+      inserted_at_3 = ~N[2020-09-01 10:00:00]
+      closed_at_3 = ~N[2020-09-01 11:01:05]
+
+      # 90000 seconds
+      inserted_at_4 = ~N[2020-09-02 10:00:00]
+      closed_at_4 = ~N[2020-09-03 11:00:00]
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_1,
+        closed_at: closed_at_1
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_2,
+        closed_at: closed_at_2
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_3,
+        closed_at: closed_at_3
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_4,
+        closed_at: closed_at_4
+      )
+
+      average_resolution_time = Reporting.average_seconds_to_resolution(account.id)
+      assert average_resolution_time == (31 + 671 + 3665 + 90000) / 4
+    end
+
+    test "gets average resolution time of multiple times with filters", %{account: account} do
+      # 31 seconds
+      inserted_at_1 = ~N[2020-10-01 12:00:00]
+      closed_at_1 = ~N[2020-10-01 12:00:31]
+
+      # 671 seconds
+      inserted_at_2 = ~N[2020-10-02 12:00:00]
+      closed_at_2 = ~N[2020-10-02 12:11:11]
+
+      # 3665 seconds
+      inserted_at_3 = ~N[2020-10-03 10:00:00]
+      closed_at_3 = ~N[2020-10-03 11:01:05]
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_1,
+        closed_at: closed_at_1
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_2,
+        closed_at: closed_at_2
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_3,
+        closed_at: closed_at_3
+      )
+
+      average_resolution_time =
+        Reporting.average_seconds_to_resolution(account.id, %{
+          from_date: ~N[2020-10-01 11:00:00],
+          to_date: ~N[2020-10-02 13:00:00]
+        })
+
+      assert average_resolution_time == (31 + 671) / 2
+    end
+
+    test "when closed_at is nil", %{
+      account: account
+    } do
+      inserted_at = ~N[2020-09-01 12:00:00]
+      closed_at = nil
+
+      insert_list(
+        3,
+        :conversation,
+        account: account,
+        inserted_at: inserted_at,
+        closed_at: closed_at
+      )
+
+      average_resolution_time = Reporting.average_seconds_to_resolution(account.id)
+      assert average_resolution_time == 0.0
+    end
+  end
+
+  describe "median_seconds_to_resolution" do
+    test "gets the median seconds it takes to close", %{
+      account: account
+    } do
+      inserted_at = ~N[2020-09-01 12:00:00]
+      closed_at = ~N[2020-09-01 12:30:00]
+
+      insert_list(
+        3,
+        :conversation,
+        account: account,
+        inserted_at: inserted_at,
+        closed_at: closed_at
+      )
+
+      median_resolution_time = Reporting.median_seconds_to_resolution(account.id)
+      assert median_resolution_time == Time.diff(closed_at, inserted_at)
+    end
+
+    test "gets median resolution time of multiple times", %{account: account} do
+      # 31 seconds
+      inserted_at_1 = ~N[2020-09-01 12:00:00]
+      closed_at_1 = ~N[2020-09-01 12:00:31]
+
+      # 671 seconds
+      inserted_at_2 = ~N[2020-09-02 12:00:00]
+      closed_at_2 = ~N[2020-09-02 12:11:11]
+
+      # 3665 seconds
+      inserted_at_3 = ~N[2020-09-01 10:00:00]
+      closed_at_3 = ~N[2020-09-01 11:01:05]
+
+      # 90000 seconds
+      inserted_at_4 = ~N[2020-09-02 10:00:00]
+      closed_at_4 = ~N[2020-09-03 11:00:00]
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_1,
+        closed_at: closed_at_1
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_2,
+        closed_at: closed_at_2
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_3,
+        closed_at: closed_at_3
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_4,
+        closed_at: closed_at_4
+      )
+
+      median_resolution_time = Reporting.median_seconds_to_resolution(account.id)
+      assert median_resolution_time == (671 + 3665) / 2
+    end
+
+    test "gets median resolution time of multiple times with filters", %{account: account} do
+      # 31 seconds
+      inserted_at_1 = ~N[2020-10-01 12:00:00]
+      closed_at_1 = ~N[2020-10-01 12:00:31]
+
+      # 671 seconds
+      inserted_at_2 = ~N[2020-10-02 12:00:00]
+      closed_at_2 = ~N[2020-10-02 12:11:11]
+
+      # 3665 seconds
+      inserted_at_3 = ~N[2020-10-03 10:00:00]
+      closed_at_3 = ~N[2020-10-03 11:01:05]
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_1,
+        closed_at: closed_at_1
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_2,
+        closed_at: closed_at_2
+      )
+
+      insert(
+        :conversation,
+        account: account,
+        inserted_at: inserted_at_3,
+        closed_at: closed_at_3
+      )
+
+      median_resolution_time =
+        Reporting.median_seconds_to_resolution(account.id, %{
+          from_date: ~N[2020-10-01 11:00:00],
+          to_date: ~N[2020-10-02 13:00:00]
+        })
+
+      assert median_resolution_time == (31 + 671) / 2
+    end
+
+    test "when closed_at is nil", %{
+      account: account
+    } do
+      inserted_at = ~N[2020-09-01 12:00:00]
+      closed_at = nil
+
+      insert_list(
+        3,
+        :conversation,
+        account: account,
+        inserted_at: inserted_at,
+        closed_at: closed_at
+      )
+
+      assert 0 = Reporting.median_seconds_to_resolution(account.id)
+    end
+  end
+
   describe "get_customer_breakdown/1" do
     setup do
       account = insert(:account)
@@ -581,87 +840,6 @@ defmodule ChatApi.ReportingTest do
                  from_date: ~N[2020-10-10 12:00:00],
                  to_date: ~N[2020-10-12 13:00:00]
                })
-    end
-  end
-
-  describe "first_response_time_by_weekday/2" do
-    test "correctly calculates total and avg of customer messages per day", %{account: account} do
-      # Monday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-09-28 10:00:00],
-        first_replied_at: ~N[2020-09-28 11:02:03]
-      )
-
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-05 10:00:00],
-        first_replied_at: ~N[2020-10-05 11:00:03]
-      )
-
-      # Tuesday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-09-29 10:00:00],
-        first_replied_at: ~N[2020-09-29 11:02:03]
-      )
-
-      # Wednesday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-09-30 12:00:00],
-        first_replied_at: ~N[2020-09-30 12:02:03]
-      )
-
-      # Thursday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-01 12:00:00],
-        first_replied_at: ~N[2020-10-01 12:02:03]
-      )
-
-      # Friday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-02 12:00:00],
-        first_replied_at: ~N[2020-10-02 12:00:03]
-      )
-
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-02 12:00:00],
-        first_replied_at: ~N[2020-10-03 12:00:00]
-      )
-
-      # Saturday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-03 12:00:00],
-        first_replied_at: ~N[2020-10-03 12:00:03]
-      )
-
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-03 10:00:00],
-        first_replied_at: ~N[2020-10-03 11:10:00]
-      )
-
-      # Sunday
-      insert(:conversation,
-        account: account,
-        inserted_at: ~N[2020-10-04 10:00:00],
-        first_replied_at: ~N[2020-10-04 11:00:03]
-      )
-
-      assert [
-               %{day: "Monday", average: 3663.0, unit: :seconds},
-               %{day: "Tuesday", average: 3723.0, unit: :seconds},
-               %{day: "Wednesday", average: 123.0, unit: :seconds},
-               %{day: "Thursday", average: 123.0, unit: :seconds},
-               %{day: "Friday", average: 43201.5, unit: :seconds},
-               %{day: "Saturday", average: 2101.5, unit: :seconds},
-               %{day: "Sunday", average: 3603.0, unit: :seconds}
-             ] = Reporting.first_response_time_by_weekday(account.id)
     end
   end
 
@@ -1033,6 +1211,239 @@ defmodule ChatApi.ReportingTest do
                }
              ] =
                Reporting.seconds_to_first_reply_metrics_by_week(account.id, %{
+                 from_date: ~N[2020-10-01 12:00:00],
+                 to_date: ~N[2020-10-04 13:00:00]
+               })
+    end
+  end
+
+  describe "conversation_seconds_to_resolution_by_date/2" do
+    test "correctly calculates resolution time metrics by date", %{account: account} do
+      # 2020-09-28
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-09-28 10:00:00],
+        closed_at: ~N[2020-09-28 11:02:03]
+      )
+
+      # 2020-10-02
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 12:00:00],
+        closed_at: ~N[2020-10-02 12:00:20]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 11:00:00],
+        closed_at: ~N[2020-10-02 11:05:30]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 10:00:00],
+        closed_at: ~N[2020-10-02 10:02:20]
+      )
+
+      # 2020-10-03
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 12:00:00],
+        closed_at: ~N[2020-10-03 12:00:05]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 11:00:00],
+        closed_at: ~N[2020-10-03 11:10:15]
+      )
+
+      sorted =
+        account.id
+        |> Reporting.conversation_seconds_to_resolution_by_date()
+        |> Enum.map(fn record ->
+          %{
+            record
+            | seconds_to_resolution_list: Enum.sort(record.seconds_to_resolution_list)
+          }
+        end)
+
+      assert [
+               %{
+                 average: 3723.0,
+                 date: ~D[2020-09-28],
+                 median: 3723,
+                 seconds_to_resolution_list: [3723]
+               },
+               %{
+                 average: 163.33333333333334,
+                 date: ~D[2020-10-02],
+                 median: 140,
+                 seconds_to_resolution_list: [20, 140, 330]
+               },
+               %{
+                 average: 310.0,
+                 date: ~D[2020-10-03],
+                 median: 310.0,
+                 seconds_to_resolution_list: [5, 615]
+               }
+             ] = sorted
+    end
+
+    test "correctly calculates resolution time metrics by date with filters", %{account: account} do
+      # 2020-09-28
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-09-28 10:00:00],
+        closed_at: ~N[2020-09-28 11:02:03]
+      )
+
+      # 2020-10-02
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 12:00:00],
+        closed_at: ~N[2020-10-02 12:00:20]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 11:00:00],
+        closed_at: ~N[2020-10-02 11:05:30]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 10:00:00],
+        closed_at: ~N[2020-10-02 10:02:20]
+      )
+
+      # 2020-10-03
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 12:00:00],
+        closed_at: ~N[2020-10-03 12:00:05]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 11:00:00],
+        closed_at: ~N[2020-10-03 11:10:15]
+      )
+
+      sorted =
+        account.id
+        |> Reporting.conversation_seconds_to_resolution_by_date(%{
+          from_date: ~N[2020-10-01 12:00:00],
+          to_date: ~N[2020-10-04 13:00:00]
+        })
+        |> Enum.map(fn record ->
+          %{
+            record
+            | seconds_to_resolution_list: Enum.sort(record.seconds_to_resolution_list)
+          }
+        end)
+
+      assert [
+               %{
+                 average: 163.33333333333334,
+                 date: ~D[2020-10-02],
+                 median: 140,
+                 seconds_to_resolution_list: [20, 140, 330]
+               },
+               %{
+                 average: 310.0,
+                 date: ~D[2020-10-03],
+                 median: 310.0,
+                 seconds_to_resolution_list: [5, 615]
+               }
+             ] = sorted
+    end
+
+    test "correctly handles empty data", %{account: account} do
+      assert [] =
+               Reporting.conversation_seconds_to_resolution_by_date(account.id, %{
+                 from_date: ~N[2020-10-01 12:00:00],
+                 to_date: ~N[2020-10-04 13:00:00]
+               })
+    end
+  end
+
+  describe "seconds_to_resolution_metrics_by_week/2" do
+    test "correctly calculates resolution time metrics by date", %{account: account} do
+      # 2020-09-28
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-09-28 10:00:00],
+        closed_at: ~N[2020-09-28 11:02:03]
+      )
+
+      # 2020-10-02
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 12:00:00],
+        closed_at: ~N[2020-10-02 12:00:20]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 11:00:00],
+        closed_at: ~N[2020-10-02 11:05:30]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-02 10:00:00],
+        closed_at: ~N[2020-10-02 10:02:20]
+      )
+
+      # 2020-10-03
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 12:00:00],
+        closed_at: ~N[2020-10-03 12:00:05]
+      )
+
+      insert(:conversation,
+        account: account,
+        inserted_at: ~N[2020-10-03 11:00:00],
+        closed_at: ~N[2020-10-03 11:10:15]
+      )
+
+      sorted =
+        account.id
+        |> Reporting.seconds_to_resolution_metrics_by_week(%{
+          from_date: ~N[2020-09-28 10:00:00],
+          to_date: ~N[2020-10-04 13:00:00]
+        })
+        |> Enum.map(fn record ->
+          %{
+            record
+            | seconds_to_resolution_list: Enum.sort(record.seconds_to_resolution_list)
+          }
+        end)
+
+      assert [
+               %{
+                 average: 222.0,
+                 end_date: ~D[2020-10-03],
+                 median: 140,
+                 seconds_to_resolution_list: [5, 20, 140, 330, 615],
+                 start_date: ~D[2020-09-27]
+               }
+             ] = sorted
+    end
+
+    test "correctly handles empty data", %{account: account} do
+      assert [
+               %{
+                 average: 0.0,
+                 end_date: ~D[2020-10-03],
+                 median: 0,
+                 seconds_to_resolution_list: [],
+                 start_date: ~D[2020-09-27]
+               }
+             ] =
+               Reporting.seconds_to_resolution_metrics_by_week(account.id, %{
                  from_date: ~N[2020-10-01 12:00:00],
                  to_date: ~N[2020-10-04 13:00:00]
                })


### PR DESCRIPTION
### Description

- Adds resolution metrics to Reporting dashboard
- Adds button to download metrics data as JSON
- Improve responsiveness on smaller screens

### Issue

Fixes https://github.com/papercups-io/papercups/issues/531
Fixes https://github.com/papercups-io/papercups/issues/532
Fixes https://github.com/papercups-io/papercups/issues/533

### Screenshots

<img width="1081" alt="reporting-enhancements" src="https://user-images.githubusercontent.com/5264279/107399802-2830e680-6acf-11eb-8a5a-4b649bc0c012.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
