### PR TITLE
Improve error handling in Slack authorization flow

### DIFF
--- a/assets/src/components/companies/CreateCompanyPage.tsx
+++ b/assets/src/components/companies/CreateCompanyPage.tsx
@@ -151,6 +151,13 @@ class CreateCompanyPage extends React.Component<Props, State> {
 
                   return {id, key: id, label: `#${name}`, value: id};
                 })}
+                filterOption={(input: string, option: any) => {
+                  const {label = ''} = option;
+
+                  return (
+                    label.toLowerCase().indexOf(input.toLowerCase()) !== -1
+                  );
+                }}
               />
             </Box>
 

--- a/assets/src/components/companies/UpdateCompanyPage.tsx
+++ b/assets/src/components/companies/UpdateCompanyPage.tsx
@@ -214,6 +214,13 @@ class UpdateCompanyPage extends React.Component<Props, State> {
 
                   return {id, key: id, label: `#${name}`, value: id};
                 })}
+                filterOption={(input: string, option: any) => {
+                  const {label = ''} = option;
+
+                  return (
+                    label.toLowerCase().indexOf(input.toLowerCase()) !== -1
+                  );
+                }}
               />
             </Box>
 

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import qs from 'query-string';
-import {Button, Paragraph, Text, Title} from '../common';
+import {notification, Button, Paragraph, Text, Title} from '../common';
 import {PlusOutlined} from '../icons';
 import Spinner from '../Spinner';
 import * as API from '../../api';
@@ -172,7 +172,20 @@ class IntegrationsOverview extends React.Component<Props, State> {
           .then((result) =>
             logger.debug('Successfully authorized Slack:', result)
           )
-          .catch((err) => logger.error('Failed to authorize Slack:', err));
+          .catch((err) => {
+            logger.error('Failed to authorize Slack:', err);
+
+            const description =
+              err?.response?.body?.error?.message ||
+              err?.message ||
+              String(err);
+
+            notification.error({
+              message: 'Failed to authorize Slack',
+              duration: null,
+              description,
+            });
+          });
       case 'gmail':
         return API.authorizeGmailIntegration(code)
           .then((result) =>

--- a/lib/chat_api/slack_authorizations.ex
+++ b/lib/chat_api/slack_authorizations.ex
@@ -101,6 +101,9 @@ defmodule ChatApi.SlackAuthorizations do
       {:bot_user_id, value}, dynamic ->
         dynamic([r], ^dynamic and r.bot_user_id == ^value)
 
+      {:type, neq: value}, dynamic ->
+        dynamic([r], ^dynamic and r.type != ^value)
+
       {:type, value}, dynamic ->
         dynamic([r], ^dynamic and r.type == ^value)
 


### PR DESCRIPTION
### Description

- Improve error handling in Slack authorization flow
- Prevent users from connecting both Slack integrations to the same channel

### Screenshots

<img width="1009" alt="Screen Shot 2021-02-09 at 3 06 02 PM" src="https://user-images.githubusercontent.com/5264279/107421749-57a01d00-6ae8-11eb-9b7c-15348d12b123.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
