### PR TITLE
Load previous conversations within main conversation UI

### DIFF
--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -50,6 +50,14 @@ body {
   color: #fff;
 }
 
+.Button--faded {
+  opacity: 0.6;
+}
+
+.Button--faded:hover {
+  opacity: 1;
+}
+
 /* Mimic behavior of antd "text"-type Button */
 a.RelatedCustomerConversation--link {
   display: block;

--- a/assets/src/components/conversations/AllConversations.tsx
+++ b/assets/src/components/conversations/AllConversations.tsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import {useConversations} from './ConversationsProvider';
-import ConversationsContainer from './ConversationsContainer';
+import ConversationsDashboard from './ConversationsDashboard';
 
 const AllConversations = () => {
   const {
     loading,
     currentUser,
     account,
-    isNewUser,
     all = [],
-    conversationsById = {},
     messagesByConversation = {},
-    currentlyOnline = {},
     fetchAllConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -19,16 +16,16 @@ const AllConversations = () => {
     onSendMessage,
   } = useConversations();
 
+  if (!currentUser) {
+    return null;
+  }
+
   return (
-    <ConversationsContainer
+    <ConversationsDashboard
       loading={loading}
       title="All conversations"
       account={account}
-      currentUser={currentUser}
-      currentlyOnline={currentlyOnline}
-      showGetStarted={isNewUser}
       conversationIds={all}
-      conversationsById={conversationsById}
       messagesByConversation={messagesByConversation}
       fetch={fetchAllConversations}
       onSelectConversation={onSelectConversation}

--- a/assets/src/components/conversations/ClosedConversations.tsx
+++ b/assets/src/components/conversations/ClosedConversations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ConversationsContainer from './ConversationsContainer';
+import ConversationsDashboard from './ConversationsDashboard';
 import {useConversations} from './ConversationsProvider';
 
 const ClosedConversations = () => {
@@ -7,11 +7,8 @@ const ClosedConversations = () => {
     loading,
     currentUser,
     account,
-    isNewUser,
     closed = [],
-    conversationsById = {},
     messagesByConversation = {},
-    currentlyOnline = {},
     fetchAllConversations,
     fetchClosedConversations,
     onSelectConversation,
@@ -29,16 +26,16 @@ const ClosedConversations = () => {
     return results;
   };
 
+  if (!currentUser) {
+    return null;
+  }
+
   return (
-    <ConversationsContainer
+    <ConversationsDashboard
       loading={loading}
       title="Closed"
       account={account}
-      currentUser={currentUser}
-      currentlyOnline={currentlyOnline}
-      showGetStarted={isNewUser}
       conversationIds={closed}
-      conversationsById={conversationsById}
       messagesByConversation={messagesByConversation}
       fetch={fetch}
       onSelectConversation={onSelectConversation}

--- a/assets/src/components/conversations/ConversationContainer.tsx
+++ b/assets/src/components/conversations/ConversationContainer.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Message} from '../../types';
+import {useConversations} from './ConversationsProvider';
+import ConversationHeader from './ConversationHeader';
+import ConversationMessages from './ConversationMessages';
+import ConversationFooter from './ConversationFooter';
+import ConversationDetailsSidebar from './ConversationDetailsSidebar';
+
+const ConversationContainer = ({
+  loading,
+  selectedConversationId,
+  isClosing,
+  setScrollRef,
+  onAssignUser,
+  onMarkPriority,
+  onRemovePriority,
+  onCloseConversation,
+  onReopenConversation,
+  onDeleteConversation,
+  onSendMessage,
+}: {
+  loading: boolean;
+  selectedConversationId: string | null;
+  isClosing: boolean;
+  // TODO: handle scrolling within this component?
+  setScrollRef: (el: any) => void;
+  onAssignUser: (conversationId: string, userId: string) => void;
+  onMarkPriority: (conversationId: string) => void;
+  onRemovePriority: (conversationId: string) => void;
+  onCloseConversation: (conversationId: string) => void;
+  onReopenConversation: (conversationId: string) => void;
+  onDeleteConversation: (conversationId: string) => void;
+  onSendMessage: (message: Partial<Message>) => void;
+}) => {
+  // TODO: handle loading better?
+  const {
+    currentUser,
+    account,
+    conversationsById,
+    messagesByConversation,
+    isNewUser,
+    isCustomerOnline,
+  } = useConversations();
+
+  const users = (account && account.users) || [];
+  const messages = selectedConversationId
+    ? messagesByConversation[selectedConversationId]
+    : [];
+  const conversation = selectedConversationId
+    ? conversationsById[selectedConversationId]
+    : null;
+  const customer = conversation ? conversation.customer : null;
+  const isOnline = customer ? isCustomerOnline(customer.id) : false;
+
+  return (
+    <>
+      <ConversationHeader
+        conversation={conversation}
+        users={users}
+        onAssignUser={onAssignUser}
+        onMarkPriority={onMarkPriority}
+        onRemovePriority={onRemovePriority}
+        onCloseConversation={onCloseConversation}
+        onReopenConversation={onReopenConversation}
+        onDeleteConversation={onDeleteConversation}
+      />
+      <Flex
+        sx={{
+          position: 'relative',
+          flex: 1,
+          flexDirection: 'column',
+          minHeight: 0,
+          minWidth: 640,
+          pr: 240, // TODO: animate this if we make it toggle-able
+        }}
+      >
+        <ConversationMessages
+          messages={messages}
+          currentUser={currentUser}
+          loading={loading}
+          isClosing={isClosing}
+          showGetStarted={isNewUser}
+          setScrollRef={setScrollRef}
+        />
+
+        {conversation && (
+          // NB: the `key` forces a rerender so the input can clear
+          // any text from the last conversation and trigger autofocus
+          <ConversationFooter
+            key={conversation.id}
+            onSendMessage={onSendMessage}
+            currentUser={currentUser}
+          />
+        )}
+
+        {customer && conversation && (
+          <Box
+            sx={{
+              width: 240,
+              height: '100%',
+              overflowY: 'scroll',
+              position: 'absolute',
+              right: 0,
+            }}
+          >
+            <ConversationDetailsSidebar
+              customer={customer}
+              isOnline={isOnline}
+              conversation={conversation}
+            />
+          </Box>
+        )}
+      </Flex>
+    </>
+  );
+};
+
+export default ConversationContainer;

--- a/assets/src/components/conversations/ConversationMessages.tsx
+++ b/assets/src/components/conversations/ConversationMessages.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Button, colors, Result} from '../common';
-import {SmileOutlined} from '../icons';
+import {colors, Button, Divider, Result} from '../common';
+import {SmileOutlined, UpOutlined} from '../icons';
 import Spinner from '../Spinner';
 import ChatMessage from './ChatMessage';
-import {Message, User} from '../../types';
+import {Conversation, Message, User} from '../../types';
+
+const noop = () => {};
 
 const EmptyMessagesPlaceholder = () => {
   return (
@@ -38,24 +40,35 @@ const GettingStartedRedirect = () => {
 };
 
 const ConversationMessages = ({
+  conversationId,
   messages,
   currentUser,
   loading,
   isClosing,
   showGetStarted,
+  isLoadingPreviousConversation,
+  hasPreviousConversations,
+  history = [],
   sx = {},
   setScrollRef,
   isAgentMessage,
+  onLoadPreviousConversation = noop,
 }: {
+  conversationId?: string | null;
   messages: Array<Message>;
   currentUser?: User | null;
   loading?: boolean;
   isClosing?: boolean;
   showGetStarted?: boolean;
+  isLoadingPreviousConversation?: boolean;
+  hasPreviousConversations?: boolean;
+  history?: Array<Conversation>;
   sx?: any;
   setScrollRef: (el: any) => void;
   isAgentMessage?: (message: Message) => boolean;
+  onLoadPreviousConversation?: (conversationId: string) => void;
 }) => {
+  const [historyRefs, setHistoryRefs] = React.useState<Array<any>>([]);
   // Sets old behavior as default, but eventually we may just want to show
   // any message with a `user_id` (as opposed to `customer_id`) as an agent
   // (Note that this will require an update to the <ChatMessage /> UI component
@@ -66,6 +79,38 @@ const ConversationMessages = ({
     typeof isAgentMessage === 'function'
       ? isAgentMessage
       : isAgentMessageDefaultFn;
+
+  const addToHistoryRefs = (el: any) => {
+    if (el && el.id) {
+      const ids = historyRefs.map((el) => el.id);
+
+      if (ids.includes(el.id)) {
+        return;
+      }
+
+      setHistoryRefs([el, ...historyRefs]);
+
+      // TODO: figure out the best way to handle this scroll behavior...
+      // might be nice to add a nice animation when the previous conversation is loaded
+      el.scrollIntoView({
+        behavior: 'auto',
+        block: 'start',
+        inline: 'nearest',
+      });
+    }
+  };
+
+  const handleLoadPrevious = () => {
+    if (history && history.length) {
+      const [{id: earliestConversationId}] = history;
+
+      onLoadPreviousConversation(earliestConversationId);
+    } else if (conversationId) {
+      onLoadPreviousConversation(conversationId);
+    } else {
+      // No conversation detected yet; do nothing
+    }
+  };
 
   return (
     <Box
@@ -91,20 +136,85 @@ const ConversationMessages = ({
           backgroundColor={colors.white}
           sx={{minHeight: '100%', p: 4, ...sx}}
         >
+          {hasPreviousConversations ? (
+            <Flex
+              sx={{
+                justifyContent: 'center',
+                alignItems: 'center',
+                position: 'relative',
+                top: -16,
+              }}
+            >
+              <Button
+                className="Button--faded"
+                size="small"
+                icon={<UpOutlined />}
+                loading={isLoadingPreviousConversation}
+                onClick={handleLoadPrevious}
+              >
+                Load previous conversation
+              </Button>
+            </Flex>
+          ) : (
+            <Box pt={1} mb={3} />
+          )}
+
+          {history && history.length
+            ? history.map((conversation: Conversation) => {
+                const {id: conversationId, messages = []} = conversation;
+
+                return (
+                  <React.Fragment key={conversationId}>
+                    <Box sx={{opacity: 0.6}}>
+                      {messages.map((message: Message, key: number) => {
+                        // Slight hack
+                        const next = messages[key + 1];
+                        const {
+                          id: messageId,
+                          customer_id: customerId,
+                        } = message;
+                        const isMe = isAgentMsg(message);
+                        const isLastInGroup = next
+                          ? customerId !== next.customer_id
+                          : true;
+
+                        // TODO: fix `isMe` logic for multiple agents
+                        return (
+                          <ChatMessage
+                            key={messageId}
+                            message={message}
+                            isMe={isMe}
+                            isLastInGroup={isLastInGroup}
+                            shouldDisplayTimestamp={isLastInGroup}
+                          />
+                        );
+                      })}
+                    </Box>
+                    <div
+                      id={`ConversationMessages-history--${conversationId}`}
+                      ref={addToHistoryRefs}
+                    />
+                    <Divider />
+                  </React.Fragment>
+                );
+              })
+            : null}
+
           {messages.length ? (
-            messages.map((msg: Message, key: number) => {
+            messages.map((message: Message, key: number) => {
               // Slight hack
               const next = messages[key + 1];
-              const isMe = isAgentMsg(msg);
+              const {id: messageId, customer_id: customerId} = message;
+              const isMe = isAgentMsg(message);
               const isLastInGroup = next
-                ? msg.customer_id !== next.customer_id
+                ? customerId !== next.customer_id
                 : true;
 
               // TODO: fix `isMe` logic for multiple agents
               return (
                 <ChatMessage
-                  key={key}
-                  message={msg}
+                  key={messageId}
+                  message={message}
                   isMe={isMe}
                   isLastInGroup={isLastInGroup}
                   shouldDisplayTimestamp={isLastInGroup}

--- a/assets/src/components/conversations/ConversationsDashboard.tsx
+++ b/assets/src/components/conversations/ConversationsDashboard.tsx
@@ -10,16 +10,10 @@ import ConversationContainer from './ConversationContainer';
 type Props = {
   title?: string;
   account: Account | null;
-  // currentUser: User | null;
-  // currentlyOnline?: any;
   loading: boolean;
-  // showGetStarted: boolean;
   conversationIds: Array<string>;
-  // conversationsById: {[key: string]: Conversation};
   messagesByConversation: {[key: string]: Array<Message>};
   fetch: () => Promise<Array<string>>;
-  // fetchById: (id: string) => Promise<Array<string>>;
-  // isCustomerOnline: (customerId: string) => boolean;
   onSelectConversation: (id: string | null, fn?: () => void) => void;
   onUpdateConversation: (id: string, params: any) => Promise<void>;
   onDeleteConversation: (id: string) => Promise<void>;

--- a/assets/src/components/conversations/ConversationsDashboard.tsx
+++ b/assets/src/components/conversations/ConversationsDashboard.tsx
@@ -1,28 +1,25 @@
 import React from 'react';
-import {Box, Flex} from 'theme-ui';
+import {Box} from 'theme-ui';
 import qs from 'query-string';
-import {colors, Layout, notification, Sider, Text, Title} from '../common';
+import {colors, Layout, notification, Sider, Title} from '../common';
 import {sleep} from '../../utils';
-import {Account, Conversation, Message, User} from '../../types';
-import ConversationHeader from './ConversationHeader';
-import ConversationItem from './ConversationItem';
-import ConversationClosing from './ConversationClosing';
-import ConversationMessages from './ConversationMessages';
-import ConversationFooter from './ConversationFooter';
-import ConversationDetailsSidebar from './ConversationDetailsSidebar';
-import {getColorByUuid} from './support';
+import {Account, Message} from '../../types';
+import ConversationsPreviewList from './ConversationsPreviewList';
+import ConversationContainer from './ConversationContainer';
 
 type Props = {
   title?: string;
   account: Account | null;
-  currentUser: User | null;
-  currentlyOnline?: any;
+  // currentUser: User | null;
+  // currentlyOnline?: any;
   loading: boolean;
-  showGetStarted: boolean;
+  // showGetStarted: boolean;
   conversationIds: Array<string>;
-  conversationsById: {[key: string]: Conversation};
+  // conversationsById: {[key: string]: Conversation};
   messagesByConversation: {[key: string]: Array<Message>};
   fetch: () => Promise<Array<string>>;
+  // fetchById: (id: string) => Promise<Array<string>>;
+  // isCustomerOnline: (customerId: string) => boolean;
   onSelectConversation: (id: string | null, fn?: () => void) => void;
   onUpdateConversation: (id: string, params: any) => Promise<void>;
   onDeleteConversation: (id: string) => Promise<void>;
@@ -31,14 +28,14 @@ type Props = {
 
 type State = {
   loading: boolean;
-  selected: string | null;
+  selectedConversationId: string | null;
   closing: Array<string>;
 };
 
-class ConversationsContainer extends React.Component<Props, State> {
+class ConversationsDashboard extends React.Component<Props, State> {
   scrollToEl: any = null;
 
-  state: State = {loading: true, selected: null, closing: []};
+  state: State = {loading: true, selectedConversationId: null, closing: []};
 
   componentDidMount() {
     const q = qs.parse(window.location.search);
@@ -66,15 +63,16 @@ class ConversationsContainer extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prev: Props) {
-    if (!this.state.selected) {
+    if (!this.state.selectedConversationId) {
       return null;
     }
 
-    const {selected} = this.state;
+    const {selectedConversationId} = this.state;
     const {messagesByConversation: prevMessagesByConversation} = prev;
     const {messagesByConversation} = this.props;
-    const prevMessages = prevMessagesByConversation[selected] || [];
-    const messages = messagesByConversation[selected] || [];
+    const prevMessages =
+      prevMessagesByConversation[selectedConversationId] || [];
+    const messages = messagesByConversation[selectedConversationId] || [];
 
     if (messages.length > prevMessages.length) {
       this.scrollIntoView();
@@ -101,6 +99,8 @@ class ConversationsContainer extends React.Component<Props, State> {
       return null;
     }
 
+    const {selectedConversationId} = this.state;
+
     // TODO: clean up a bit
     switch (key) {
       case 'ArrowDown':
@@ -115,27 +115,29 @@ class ConversationsContainer extends React.Component<Props, State> {
         e.preventDefault();
 
         return (
-          this.state.selected &&
-          this.handleCloseConversation(this.state.selected)
+          selectedConversationId &&
+          this.handleCloseConversation(selectedConversationId)
         );
       case 'p':
         e.preventDefault();
 
         return (
-          this.state.selected && this.handleMarkPriority(this.state.selected)
+          selectedConversationId &&
+          this.handleMarkPriority(selectedConversationId)
         );
       case 'u':
         e.preventDefault();
 
         return (
-          this.state.selected && this.handleMarkUnpriority(this.state.selected)
+          selectedConversationId &&
+          this.handleMarkUnpriority(selectedConversationId)
         );
       case 'o':
         e.preventDefault();
 
         return (
-          this.state.selected &&
-          this.handleReopenConversation(this.state.selected)
+          selectedConversationId &&
+          this.handleReopenConversation(selectedConversationId)
         );
       default:
         return null;
@@ -143,7 +145,7 @@ class ConversationsContainer extends React.Component<Props, State> {
   };
 
   getNextConversationId = () => {
-    const {selected} = this.state;
+    const {selectedConversationId} = this.state;
     const {conversationIds = []} = this.props;
 
     if (conversationIds.length === 0) {
@@ -152,17 +154,17 @@ class ConversationsContainer extends React.Component<Props, State> {
 
     const lastConversationId = conversationIds[conversationIds.length - 1];
 
-    if (!selected) {
+    if (!selectedConversationId) {
       return lastConversationId;
     }
 
-    const index = conversationIds.indexOf(selected);
+    const index = conversationIds.indexOf(selectedConversationId);
 
     return conversationIds[index + 1] || lastConversationId || null;
   };
 
   getPreviousConversationId = () => {
-    const {selected} = this.state;
+    const {selectedConversationId} = this.state;
     const {conversationIds = []} = this.props;
 
     if (conversationIds.length === 0) {
@@ -171,21 +173,23 @@ class ConversationsContainer extends React.Component<Props, State> {
 
     const firstConversationId = conversationIds[0];
 
-    if (!selected) {
+    if (!selectedConversationId) {
       return firstConversationId;
     }
 
-    const index = conversationIds.indexOf(selected);
+    const index = conversationIds.indexOf(selectedConversationId);
 
     return conversationIds[index - 1] || firstConversationId;
   };
 
   // TODO: make sure this works as expected
   refreshSelectedConversation = async () => {
-    const {selected} = this.state;
+    const {selectedConversationId} = this.state;
     const nextId = this.getNextConversationId();
     const updatedIds = await this.props.fetch();
-    const hasValidSelectedId = selected && updatedIds.indexOf(selected) !== -1;
+    const hasValidSelectedId =
+      selectedConversationId &&
+      updatedIds.indexOf(selectedConversationId) !== -1;
 
     if (!hasValidSelectedId) {
       const hasValidNextId = nextId && updatedIds.indexOf(nextId) !== -1;
@@ -195,19 +199,8 @@ class ConversationsContainer extends React.Component<Props, State> {
     }
   };
 
-  isCustomerOnline = (customerId: string) => {
-    if (!customerId) {
-      return false;
-    }
-
-    const {currentlyOnline = {}} = this.props;
-    const key = `customer:${customerId}`;
-
-    return !!(currentlyOnline && currentlyOnline[key]);
-  };
-
   handleSelectConversation = (id: string | null) => {
-    this.setState({selected: id}, () => {
+    this.setState({selectedConversationId: id}, () => {
       this.scrollIntoView();
     });
 
@@ -219,7 +212,7 @@ class ConversationsContainer extends React.Component<Props, State> {
 
     // TODO: figure out the best way to handle this when closing multiple
     // conversations in a row very quickly
-    await sleep(1000);
+    await sleep(400);
     await this.props.onUpdateConversation(conversationId, {status: 'closed'});
     await this.refreshSelectedConversation();
 
@@ -283,7 +276,7 @@ class ConversationsContainer extends React.Component<Props, State> {
   };
 
   handleSendMessage = (message: Partial<Message>) => {
-    const {selected: conversationId} = this.state;
+    const {selectedConversationId: conversationId} = this.state;
 
     if (!conversationId) {
       return null;
@@ -298,35 +291,12 @@ class ConversationsContainer extends React.Component<Props, State> {
   };
 
   render() {
-    const {selected: selectedConversationId, closing = []} = this.state;
-    const {
-      title,
-      account,
-      currentUser,
-      showGetStarted,
-      conversationIds = [],
-      conversationsById = {},
-      messagesByConversation = {},
-    } = this.props;
-    const users = (account && account.users) || [];
-
-    const messages = selectedConversationId
-      ? messagesByConversation[selectedConversationId]
-      : [];
-    const selectedConversation = selectedConversationId
-      ? conversationsById[selectedConversationId]
-      : null;
-    const selectedCustomer = selectedConversation
-      ? selectedConversation.customer
-      : null;
-
+    const {selectedConversationId, closing = []} = this.state;
+    const {title, conversationIds = []} = this.props;
     const loading = this.props.loading || this.state.loading;
     const isClosingSelected =
       !!selectedConversationId &&
       closing.indexOf(selectedConversationId) !== -1;
-    const isSelectedCustomerOnline = selectedCustomer
-      ? this.isCustomerOnline(selectedCustomer.id)
-      : false;
 
     return (
       <Layout style={{background: colors.white}}>
@@ -347,109 +317,34 @@ class ConversationsContainer extends React.Component<Props, State> {
             </Title>
           </Box>
 
-          <Box>
-            {!loading && conversationIds.length ? (
-              conversationIds.map((conversationId, idx) => {
-                const conversation = conversationsById[conversationId];
-                const messages = messagesByConversation[conversationId];
-                const {customer_id: customerId} = conversation;
-                const isCustomerOnline = this.isCustomerOnline(customerId);
-                const isHighlighted = conversationId === selectedConversationId;
-                const isClosing = closing.indexOf(conversationId) !== -1;
-                const color = getColorByUuid(customerId);
-
-                if (isClosing) {
-                  return (
-                    <ConversationClosing
-                      key={conversationId}
-                      isHighlighted={isHighlighted}
-                    />
-                  );
-                }
-
-                return (
-                  <ConversationItem
-                    key={conversationId}
-                    conversation={conversation}
-                    messages={messages}
-                    isHighlighted={isHighlighted}
-                    isCustomerOnline={isCustomerOnline}
-                    color={color}
-                    onSelectConversation={this.handleSelectConversation}
-                  />
-                );
-              })
-            ) : (
-              <Box p={3}>
-                <Text type="secondary">
-                  {loading ? 'Loading...' : 'No conversations'}
-                </Text>
-              </Box>
-            )}
-          </Box>
+          <ConversationsPreviewList
+            loading={loading}
+            selectedConversationId={selectedConversationId}
+            conversationIds={conversationIds}
+            isConversationClosing={(conversationId) =>
+              closing.indexOf(conversationId) !== -1
+            }
+            onSelectConversation={this.handleSelectConversation}
+          />
         </Sider>
         <Layout style={{marginLeft: 280, background: colors.white}}>
-          <ConversationHeader
-            conversation={selectedConversation}
-            users={users}
+          <ConversationContainer
+            loading={loading}
+            selectedConversationId={selectedConversationId}
+            isClosing={isClosingSelected}
+            setScrollRef={(el: any) => (this.scrollToEl = el)}
             onAssignUser={this.handleAssignUser}
             onMarkPriority={this.handleMarkPriority}
             onRemovePriority={this.handleMarkUnpriority}
             onCloseConversation={this.handleCloseConversation}
             onReopenConversation={this.handleReopenConversation}
             onDeleteConversation={this.handleDeleteConversation}
+            onSendMessage={this.handleSendMessage}
           />
-          <Flex
-            sx={{
-              position: 'relative',
-              flex: 1,
-              flexDirection: 'column',
-              minHeight: 0,
-              minWidth: 640,
-              pr: 240, // TODO: animate this if we make it toggle-able
-            }}
-          >
-            <ConversationMessages
-              messages={messages}
-              currentUser={currentUser}
-              loading={loading}
-              isClosing={isClosingSelected}
-              showGetStarted={showGetStarted}
-              setScrollRef={(el) => (this.scrollToEl = el)}
-            />
-
-            {selectedConversation && (
-              // NB: the `key` forces a rerender so the input can clear
-              // any text from the last conversation and trigger autofocus
-              <ConversationFooter
-                key={selectedConversation.id}
-                onSendMessage={this.handleSendMessage}
-                currentUser={currentUser}
-              />
-            )}
-
-            {selectedCustomer && selectedConversation && (
-              <Box
-                sx={{
-                  width: 240,
-                  height: '100%',
-                  overflowY: 'scroll',
-                  position: 'absolute',
-                  right: 0,
-                }}
-              >
-                <ConversationDetailsSidebar
-                  customer={selectedCustomer}
-                  isOnline={isSelectedCustomerOnline}
-                  conversation={selectedConversation}
-                />
-              </Box>
-            )}
-          </Flex>
         </Layout>
       </Layout>
     );
   }
 }
 
-export default ConversationsContainer;
+export default ConversationsDashboard;

--- a/assets/src/components/conversations/ConversationsPreviewList.tsx
+++ b/assets/src/components/conversations/ConversationsPreviewList.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import {Text} from '../common';
+import ConversationItem from './ConversationItem';
+import ConversationClosing from './ConversationClosing';
+import {getColorByUuid} from './support';
+import {useConversations} from './ConversationsProvider';
+
+const ConversationsPreviewList = ({
+  loading,
+  selectedConversationId,
+  conversationIds,
+  isConversationClosing,
+  onSelectConversation,
+}: {
+  loading: boolean;
+  selectedConversationId: string | null;
+  conversationIds: Array<string>;
+  isConversationClosing: (conversationId: string) => boolean;
+  onSelectConversation: (conversationId: string | null) => any;
+}) => {
+  const {
+    conversationsById,
+    messagesByConversation,
+    isCustomerOnline,
+  } = useConversations();
+
+  return (
+    <Box>
+      {!loading && conversationIds.length ? (
+        conversationIds.map((conversationId) => {
+          const conversation = conversationsById[conversationId];
+          // TODO: we only care about the most recent message?
+          const messages = messagesByConversation[conversationId];
+          const {customer_id: customerId} = conversation;
+          const isOnline = isCustomerOnline(customerId);
+          const isHighlighted = conversationId === selectedConversationId;
+          const isClosing = isConversationClosing(conversationId);
+          const color = getColorByUuid(customerId);
+
+          if (isClosing) {
+            return (
+              <ConversationClosing
+                key={conversationId}
+                isHighlighted={isHighlighted}
+              />
+            );
+          }
+
+          return (
+            <ConversationItem
+              key={conversationId}
+              conversation={conversation}
+              messages={messages}
+              isHighlighted={isHighlighted}
+              isCustomerOnline={isOnline}
+              color={color}
+              onSelectConversation={onSelectConversation}
+            />
+          );
+        })
+      ) : (
+        <Box p={3}>
+          <Text type="secondary">
+            {loading ? 'Loading...' : 'No conversations'}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ConversationsPreviewList;

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -452,7 +452,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
   };
 
   handleSelectConversation = (id: string | null) => {
-    this.setState({selectedConversationId: id}, async () => {
+    this.setState({selectedConversationId: id}, () => {
       if (!id) {
         return;
       }

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import {Channel, Socket} from 'phoenix';
-import {throttle} from 'lodash';
+import {debounce, throttle} from 'lodash';
 import * as API from '../../api';
 import {notification} from '../common';
 import {Account, Conversation, Message, User} from '../../types';
@@ -26,6 +26,8 @@ export const ConversationsContext = React.createContext<{
   conversationsById: {[key: string]: any};
   messagesByConversation: {[key: string]: any};
   currentlyOnline: {[key: string]: any};
+
+  isCustomerOnline: (customerId: string) => boolean;
 
   onSelectConversation: (id: string | null) => any;
   onUpdateConversation: (id: string, params: any) => Promise<any>;
@@ -53,6 +55,7 @@ export const ConversationsContext = React.createContext<{
   messagesByConversation: {},
   currentlyOnline: {},
 
+  isCustomerOnline: () => false,
   onSelectConversation: () => {},
   onSendMessage: () => {},
   onUpdateConversation: () => Promise.resolve(),
@@ -194,10 +197,9 @@ export class ConversationsProvider extends React.Component<Props, State> {
       account,
       isNewUser: numTotalMessages === 0,
     });
-    const conversationIds = await this.fetchAllConversations();
     const {id: accountId} = account;
 
-    this.joinNotificationChannel(accountId, conversationIds);
+    this.joinNotificationChannel(accountId);
   }
 
   componentWillUnmount() {
@@ -210,10 +212,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     }
   }
 
-  joinNotificationChannel = (
-    accountId: string,
-    conversationIds: Array<string>
-  ) => {
+  joinNotificationChannel = (accountId: string) => {
     if (this.socket && this.socket.disconnect) {
       logger.debug('Existing socket:', this.socket);
       this.socket.disconnect();
@@ -240,9 +239,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
 
     // TODO: If no conversations exist, should we create a conversation with us
     // so new users can play around with the chat right away and give us feedback?
-    this.channel = this.socket.channel(`notification:${accountId}`, {
-      ids: conversationIds,
-    });
+    this.channel = this.socket.channel(`notification:${accountId}`, {});
 
     // TODO: rename to message:created?
     this.channel.on('shout', (message) => {
@@ -259,7 +256,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     // TODO: can probably use this for more things
     this.channel.on('conversation:updated', ({id, updates}) => {
       // Handle conversation updated
-      this.handleConversationUpdated(id, updates);
+      debounce(() => this.handleConversationUpdated(id, updates), 1000);
     });
 
     this.channel.on('presence_state', (state) => {
@@ -278,10 +275,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
       .receive('error', (err) => {
         logger.error('Unable to join', err);
         // TODO: double check that this works (retries after 10s)
-        setTimeout(
-          () => this.joinNotificationChannel(accountId, conversationIds),
-          10000
-        );
+        setTimeout(() => this.joinNotificationChannel(accountId), 10000);
       });
   };
 
@@ -307,6 +301,17 @@ export class ConversationsProvider extends React.Component<Props, State> {
     this.setState({presence: latest});
   };
 
+  isCustomerOnline = (customerId: string) => {
+    if (!customerId) {
+      return false;
+    }
+
+    const {presence = {}} = this.state;
+    const key = `customer:${customerId}`;
+
+    return !!(presence && presence[key]);
+  };
+
   playNotificationSound = async (volume: number) => {
     try {
       const file = '/alert-v2.mp3';
@@ -328,12 +333,8 @@ export class ConversationsProvider extends React.Component<Props, State> {
   handleNewMessage = async (message: Message) => {
     logger.debug('New message!', message);
 
-    const {
-      messagesByConversation,
-      selectedConversationId,
-      conversationsById,
-    } = this.state;
-    const {conversation_id: conversationId, customer_id: customerId} = message;
+    const {messagesByConversation} = this.state;
+    const {conversation_id: conversationId} = message;
     const existingMessages = messagesByConversation[conversationId] || [];
     const updatedMessagesByConversation = {
       ...messagesByConversation,
@@ -344,46 +345,60 @@ export class ConversationsProvider extends React.Component<Props, State> {
       {
         messagesByConversation: updatedMessagesByConversation,
       },
-      () => {
-        if (isWindowHidden(document || window.document)) {
-          // Play a slightly louder sound if this is the first message
-          const volume = existingMessages.length === 0 ? 0.2 : 0.1;
-
-          this.throttledNotificationSound(volume);
-        }
-        // TODO: this is a bit hacky... there's probably a better way to
-        // handle listening for changes on conversation records...
-        if (selectedConversationId === conversationId) {
-          // If the new message matches the id of the selected conversation,
-          // mark it as read right away and scroll to the latest message
-          this.handleConversationRead(selectedConversationId);
-        } else {
-          // Otherwise, find the updated conversation and mark it as unread
-          const conversation = conversationsById[conversationId];
-          const shouldDisplayAlert =
-            !!customerId && conversation && conversation.status === 'open';
-
-          this.setState({
-            conversationsById: {
-              ...conversationsById,
-              [conversationId]: {...conversation, read: false},
-            },
-          });
-
-          if (shouldDisplayAlert) {
-            notification.open({
-              message: 'New message',
-              description: (
-                <a href={`/conversations/all?cid=${conversationId}`}>
-                  {message.body}
-                </a>
-              ),
-            });
-          }
-        }
-      }
+      () =>
+        this.debouncedNewMessagesCallback(message, {
+          isFirstMessage: existingMessages.length === 0,
+        })
     );
   };
+
+  debouncedNewMessagesCallback = debounce(
+    (message: Message, {isFirstMessage}: {isFirstMessage: boolean}) => {
+      const {selectedConversationId, conversationsById} = this.state;
+      const {
+        conversation_id: conversationId,
+        customer_id: customerId,
+      } = message;
+
+      if (isWindowHidden(document || window.document)) {
+        // Play a slightly louder sound if this is the first message
+        const volume = isFirstMessage ? 0.2 : 0.1;
+
+        this.throttledNotificationSound(volume);
+      }
+      // TODO: this is a bit hacky... there's probably a better way to
+      // handle listening for changes on conversation records...
+      if (selectedConversationId === conversationId) {
+        // If the new message matches the id of the selected conversation,
+        // mark it as read right away and scroll to the latest message
+        this.handleConversationRead(selectedConversationId);
+      } else {
+        // Otherwise, find the updated conversation and mark it as unread
+        const conversation = conversationsById[conversationId];
+        const shouldDisplayAlert =
+          !!customerId && conversation && conversation.status === 'open';
+
+        this.setState({
+          conversationsById: {
+            ...conversationsById,
+            [conversationId]: {...conversation, read: false},
+          },
+        });
+
+        if (shouldDisplayAlert) {
+          notification.open({
+            message: 'New message',
+            description: (
+              <a href={`/conversations/all?cid=${conversationId}`}>
+                {message.body}
+              </a>
+            ),
+          });
+        }
+      }
+    },
+    1000
+  );
 
   handleConversationRead = (conversationId: string | null) => {
     if (!this.channel || !conversationId) {
@@ -437,7 +452,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
   };
 
   handleSelectConversation = (id: string | null) => {
-    this.setState({selectedConversationId: id}, () => {
+    this.setState({selectedConversationId: id}, async () => {
       if (!id) {
         return;
       }
@@ -718,6 +733,8 @@ export class ConversationsProvider extends React.Component<Props, State> {
           conversationsById,
           messagesByConversation,
           currentlyOnline: presence,
+
+          isCustomerOnline: this.isCustomerOnline,
 
           onSelectConversation: this.handleSelectConversation,
           onUpdateConversation: this.handleUpdateConversation,

--- a/assets/src/components/conversations/MyConversations.tsx
+++ b/assets/src/components/conversations/MyConversations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ConversationsContainer from './ConversationsContainer';
+import ConversationsDashboard from './ConversationsDashboard';
 import {useConversations} from './ConversationsProvider';
 
 const MyConversations = () => {
@@ -7,11 +7,8 @@ const MyConversations = () => {
     loading,
     currentUser,
     account,
-    isNewUser,
     mine = [],
-    conversationsById = {},
     messagesByConversation = {},
-    currentlyOnline = {},
     fetchMyConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -19,16 +16,16 @@ const MyConversations = () => {
     onSendMessage,
   } = useConversations();
 
+  if (!currentUser) {
+    return null;
+  }
+
   return (
-    <ConversationsContainer
+    <ConversationsDashboard
       loading={loading}
       title="Assigned to me"
       account={account}
-      currentUser={currentUser}
-      currentlyOnline={currentlyOnline}
-      showGetStarted={isNewUser}
       conversationIds={mine}
-      conversationsById={conversationsById}
       messagesByConversation={messagesByConversation}
       fetch={fetchMyConversations}
       onSelectConversation={onSelectConversation}

--- a/assets/src/components/conversations/PriorityConversations.tsx
+++ b/assets/src/components/conversations/PriorityConversations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ConversationsContainer from './ConversationsContainer';
+import ConversationsDashboard from './ConversationsDashboard';
 import {useConversations} from './ConversationsProvider';
 
 const PriorityConversations = () => {
@@ -7,11 +7,8 @@ const PriorityConversations = () => {
     loading,
     currentUser,
     account,
-    isNewUser,
     priority = [],
-    conversationsById = {},
     messagesByConversation = {},
-    currentlyOnline = {},
     fetchPriorityConversations,
     onSelectConversation,
     onUpdateConversation,
@@ -19,16 +16,16 @@ const PriorityConversations = () => {
     onSendMessage,
   } = useConversations();
 
+  if (!currentUser) {
+    return null;
+  }
+
   return (
-    <ConversationsContainer
+    <ConversationsDashboard
       loading={loading}
       title="Prioritized"
       account={account}
-      currentUser={currentUser}
-      currentlyOnline={currentlyOnline}
-      showGetStarted={isNewUser}
       conversationIds={priority}
-      conversationsById={conversationsById}
       messagesByConversation={messagesByConversation}
       fetch={fetchPriorityConversations}
       onSelectConversation={onSelectConversation}

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -55,6 +55,7 @@ export type Company = {
 export type MessageType = 'reply' | 'note';
 
 export type Message = {
+  id: string;
   body: string;
   type?: 'reply' | 'note';
   private?: boolean;


### PR DESCRIPTION
### Description

This PR refactors some of the conversations dashboard frontend code to fix some minor UX issues and redundant API requests.

It also will set the stage for loading previous conversations within the same view more easily.

### Issue

TODO

### Screenshots

![load-previous-convo](https://user-images.githubusercontent.com/5264279/107700951-32e1ac00-6c86-11eb-88af-2bf3a196b09f.gif)


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
