### PR TITLE
Webhook events for `conversation:created` and `conversation:updated`

### DIFF
--- a/lib/chat_api/conversations/helpers.ex
+++ b/lib/chat_api/conversations/helpers.ex
@@ -7,6 +7,10 @@ defmodule ChatApi.Conversations.Helpers do
   alias ChatApi.{Slack, SlackAuthorizations, SlackConversationThreads}
   alias ChatApi.Conversations.Conversation
 
+  @spec format(Conversation.t()) :: map()
+  def format(%Conversation{} = conversation),
+    do: ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
+
   @spec broadcast_conversation_updates_to_slack(Conversation.t()) :: any()
   def broadcast_conversation_updates_to_slack(
         %Conversation{id: conversation_id, account_id: account_id} = conversation

--- a/lib/chat_api/conversations/notification.ex
+++ b/lib/chat_api/conversations/notification.ex
@@ -43,7 +43,7 @@ defmodule ChatApi.Conversations.Notification do
       "conversation:updated",
       %{
         "id" => conversation_id,
-        "updates" => ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
+        "updates" => Helpers.format(conversation)
       }
     )
 

--- a/lib/chat_api/conversations/notification.ex
+++ b/lib/chat_api/conversations/notification.ex
@@ -3,9 +3,13 @@ defmodule ChatApi.Conversations.Notification do
   Notification handlers for conversations
   """
 
-  alias ChatApi.Conversations.Conversation
+  alias ChatApi.Conversations.{Conversation, Helpers}
+  alias ChatApi.EventSubscriptions
 
-  def broadcast_conversation_to_admin!(
+  require Logger
+
+  @spec broadcast_new_conversation_to_admin!(Conversation.t()) :: Conversation.t()
+  def broadcast_new_conversation_to_admin!(
         %Conversation{id: conversation_id, account_id: account_id} = conversation
       ) do
     ChatApiWeb.Endpoint.broadcast!("notification:" <> account_id, "conversation:created", %{
@@ -15,7 +19,8 @@ defmodule ChatApi.Conversations.Notification do
     conversation
   end
 
-  def broadcast_conversation_to_customer!(
+  @spec broadcast_new_conversation_to_customer!(Conversation.t()) :: Conversation.t()
+  def broadcast_new_conversation_to_customer!(
         %Conversation{id: conversation_id, customer_id: customer_id} = conversation
       ) do
     ChatApiWeb.Endpoint.broadcast!(
@@ -25,6 +30,48 @@ defmodule ChatApi.Conversations.Notification do
         "id" => conversation_id
       }
     )
+
+    conversation
+  end
+
+  @spec broadcast_conversation_update_to_admin!(Conversation.t()) :: Conversation.t()
+  def broadcast_conversation_update_to_admin!(
+        %Conversation{id: conversation_id, account_id: account_id} = conversation
+      ) do
+    ChatApiWeb.Endpoint.broadcast!(
+      "notification:" <> account_id,
+      "conversation:updated",
+      %{
+        "id" => conversation_id,
+        "updates" => ChatApiWeb.ConversationView.render("basic.json", conversation: conversation)
+      }
+    )
+
+    conversation
+  end
+
+  @spec notify(Conversation.t(), atom(), keyword()) :: Conversation.t()
+  def notify(conversation, type, opts \\ [])
+
+  def notify(%Conversation{account_id: account_id} = conversation, :webhooks, event: event) do
+    Logger.info("Sending conversation notification: :webhooks")
+
+    Task.start(fn ->
+      EventSubscriptions.notify_event_subscriptions(account_id, %{
+        "event" => event,
+        "payload" => Helpers.format(conversation)
+      })
+    end)
+
+    conversation
+  end
+
+  def notify(%Conversation{} = conversation, :slack, _opts) do
+    Logger.info("Sending conversation notification: :slack")
+
+    Task.start(fn ->
+      Helpers.broadcast_conversation_updates_to_slack(conversation)
+    end)
 
     conversation
   end

--- a/lib/chat_api/slack/event.ex
+++ b/lib/chat_api/slack/event.ex
@@ -317,8 +317,9 @@ defmodule ChatApi.Slack.Event do
              conversation_id: conversation.id
            }) do
       conversation
-      |> Conversations.Notification.broadcast_conversation_to_admin!()
-      |> Conversations.Notification.broadcast_conversation_to_customer!()
+      |> Conversations.Notification.broadcast_new_conversation_to_admin!()
+      |> Conversations.Notification.broadcast_new_conversation_to_customer!()
+      |> Conversations.Notification.notify(:webhooks, event: "conversation:created")
 
       Messages.get_message!(message.id)
       |> Messages.Notification.broadcast_to_customer!()

--- a/lib/chat_api/slack/sync.ex
+++ b/lib/chat_api/slack/sync.ex
@@ -125,8 +125,9 @@ defmodule ChatApi.Slack.Sync do
              conversation_id: conversation.id
            }) do
       conversation
-      |> Conversations.Notification.broadcast_conversation_to_admin!()
-      |> Conversations.Notification.broadcast_conversation_to_customer!()
+      |> Conversations.Notification.broadcast_new_conversation_to_admin!()
+      |> Conversations.Notification.broadcast_new_conversation_to_customer!()
+      |> Conversations.Notification.notify(:webhooks, event: "conversation:created")
 
       Enum.map(syncable_message_items, fn
         %{

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -27,7 +27,8 @@ defmodule ChatApiWeb.NotificationChannel do
   end
 
   def handle_in("read", %{"conversation_id" => id}, socket) do
-    {:ok, _conversation} = Conversations.mark_conversation_read(id)
+    {:ok, conversation} = Conversations.mark_conversation_read(id)
+    Conversations.Notification.notify(conversation, :webhooks, event: "conversation:updated")
 
     {:reply, :ok, socket}
   end

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -206,7 +206,9 @@ defmodule ChatApiWeb.SlackController do
     |> Conversations.update_conversation(%{"status" => "closed"})
     |> case do
       {:ok, conversation} ->
-        Conversations.Helpers.broadcast_conversation_updates_to_slack(conversation)
+        conversation
+        |> Conversations.Notification.notify(:slack)
+        |> Conversations.Notification.notify(:webhooks, event: "conversation:updated")
 
       _ ->
         nil
@@ -224,7 +226,9 @@ defmodule ChatApiWeb.SlackController do
     |> Conversations.update_conversation(%{"status" => "open"})
     |> case do
       {:ok, conversation} ->
-        Conversations.Helpers.broadcast_conversation_updates_to_slack(conversation)
+        conversation
+        |> Conversations.Notification.notify(:slack)
+        |> Conversations.Notification.notify(:webhooks, event: "conversation:updated")
 
       _ ->
         nil


### PR DESCRIPTION
### Description

At the moment we only send out webhook events for new messages. Now that we're setting up better docs for webhooks and APIs, we should support webhook events for `conversation:created` and `conversation:updated` as well.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
