### PR TITLE
Add UI to manage personal API keys

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1172,3 +1172,43 @@ export const fetchReportingData = async (
     .set('Authorization', token)
     .then((res) => res.body.data);
 };
+
+export const fetchPersonalApiKeys = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/personal_api_keys`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const createPersonalApiKey = async (
+  label: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/personal_api_keys`)
+    .send({label})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const deletePersonalApiKey = async (
+  id: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/personal_api_keys/${id}`)
+    .set('Authorization', token)
+    .then((res) => res.body);
+};

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -211,7 +211,12 @@ const IntegrationsTable = ({
   ];
 
   return (
-    <Table loading={loading} dataSource={integrations} columns={columns} />
+    <Table
+      loading={loading}
+      dataSource={integrations}
+      columns={columns}
+      pagination={false}
+    />
   );
 };
 

--- a/assets/src/components/integrations/NewApiKeyModal.tsx
+++ b/assets/src/components/integrations/NewApiKeyModal.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import {Button, Divider, Input, Modal, Paragraph, Text} from '../common';
+import * as API from '../../api';
+import {PersonalApiKey} from '../../types';
+import logger from '../../logger';
+
+const NewApiKeyModal = ({
+  visible,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  onSuccess: (personalApiKey: PersonalApiKey) => void;
+  onCancel: () => void;
+}) => {
+  const [name, setName] = React.useState('');
+  const [isSaving, setSaving] = React.useState(false);
+
+  const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setName(e.target.value);
+
+  const handleGenerateApiKey = async () => {
+    setSaving(true);
+
+    API.createPersonalApiKey(name)
+      .then((personalApiKey) => {
+        onSuccess(personalApiKey);
+        setName('');
+      })
+      .catch((err) => logger.log('Error generating API key:', err))
+      .finally(() => setSaving(false));
+  };
+
+  const handleCancelApiKey = () => {
+    onCancel();
+    setName('');
+  };
+
+  return (
+    <Modal
+      title="Generate new API key"
+      visible={visible}
+      onOk={handleGenerateApiKey}
+      onCancel={handleCancelApiKey}
+      footer={[
+        <Button key="cancel" onClick={handleCancelApiKey}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleGenerateApiKey}
+        >
+          Generate API key
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Box>
+          <label htmlFor="name">
+            <Text strong>Description</Text>
+          </label>
+
+          <Input
+            key={visible ? 'visible' : 'invisible'}
+            id="name"
+            size="large"
+            type="text"
+            value={name}
+            autoFocus={visible}
+            placeholder="Test API Key"
+            onChange={handleChangeName}
+          />
+        </Box>
+
+        <Divider />
+
+        <Paragraph>
+          <Text type="secondary">
+            This will generate a new API key for your personal use. Please do
+            not check this key into version control (e.g. GitHub) or share it
+            with anybody outside of your organization.
+          </Text>
+        </Paragraph>
+      </Box>
+    </Modal>
+  );
+};
+
+export default NewApiKeyModal;

--- a/assets/src/components/integrations/NewWebhookModal.tsx
+++ b/assets/src/components/integrations/NewWebhookModal.tsx
@@ -4,7 +4,7 @@ import {Button, Divider, Input, Modal, Paragraph, Text} from '../common';
 import * as API from '../../api';
 import {sleep} from '../../utils';
 import logger from '../../logger';
-import {WebhookEventSubscription} from './support';
+import {EventSubscription} from '../../types';
 
 // TODO: clean up a bit
 const NewWebhookModal = ({
@@ -13,9 +13,9 @@ const NewWebhookModal = ({
   onSuccess,
   onCancel,
 }: {
-  webhook?: WebhookEventSubscription | null;
+  webhook?: EventSubscription | null;
   visible: boolean;
-  onSuccess: (webhook: WebhookEventSubscription) => void;
+  onSuccess: (webhook: EventSubscription) => void;
   onCancel: () => void;
 }) => {
   const defaultWebhookUrl = webhook?.webhook_url ?? '';

--- a/assets/src/components/integrations/PersonalApiKeysTable.tsx
+++ b/assets/src/components/integrations/PersonalApiKeysTable.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {notification, Button, Input, Popconfirm, Table, Text} from '../common';
+import {PersonalApiKey} from '../../types';
+
+const ApiKeyInput = ({value}: {value: string}) => {
+  const [isRevealed, setRevealed] = React.useState(false);
+  const ref = React.useRef<any>(null);
+
+  const highlightAndCopyInput = () => {
+    const input = ref.current;
+
+    if (!input) {
+      return;
+    }
+
+    input.focus();
+
+    // NB: Not sure why the setTimeout is necessary here, but seems to not work otherwise...
+    setTimeout(() => {
+      input.select();
+
+      if (document.queryCommandSupported('copy')) {
+        document.execCommand('copy');
+        notification.open({
+          message: 'Copied to clipboard!',
+          description: 'Please be sure to keep your API keys secret.',
+        });
+      }
+    });
+  };
+
+  const toggle = () => {
+    if (isRevealed) {
+      setRevealed(false);
+    } else {
+      setRevealed(true);
+      highlightAndCopyInput();
+    }
+  };
+
+  return (
+    <Flex>
+      <Input ref={ref} type={isRevealed ? 'text' : 'password'} value={value} />
+      <Box ml={1}>
+        <Button onClick={toggle}>{isRevealed ? 'Hide' : 'Reveal'}</Button>
+      </Box>
+    </Flex>
+  );
+};
+
+const PersonalApiKeysTable = ({
+  personalApiKeys,
+  onDeleteApiKey,
+}: {
+  personalApiKeys: Array<PersonalApiKey>;
+  onDeleteApiKey: (personalApiKey: PersonalApiKey) => void;
+}) => {
+  const columns = [
+    {
+      title: 'Label',
+      dataIndex: 'label',
+      key: 'label',
+      render: (value: string, record: any) => {
+        return <Text>{value}</Text>;
+      },
+    },
+    {
+      title: 'API key',
+      dataIndex: 'value',
+      key: 'value',
+      flex: 1,
+      render: (value: string) => {
+        return <ApiKeyInput value={value} />;
+      },
+    },
+
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (action: any, record: any) => {
+        return (
+          <Flex sx={{justifyContent: 'center'}}>
+            <Popconfirm
+              title="Are you sure you want to delete this API key?"
+              okText="Yes"
+              cancelText="No"
+              placement="topLeft"
+              onConfirm={() => onDeleteApiKey(record)}
+            >
+              <Button danger>Delete API key</Button>
+            </Popconfirm>
+          </Flex>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Table
+      rowKey="id"
+      dataSource={personalApiKeys}
+      columns={columns}
+      pagination={false}
+    />
+  );
+};
+
+export default PersonalApiKeysTable;

--- a/assets/src/components/integrations/WebhooksTable.tsx
+++ b/assets/src/components/integrations/WebhooksTable.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import {colors, Button, Popconfirm, Table, Tag, Text} from '../common';
-import {WebhookEventSubscription} from './support';
+import {EventSubscription} from '../../types';
 
 const WebhooksTable = ({
   webhooks,
   onUpdateWebhook,
   onDeleteWebhook,
 }: {
-  webhooks: Array<WebhookEventSubscription>;
-  onUpdateWebhook: (webhook: WebhookEventSubscription) => void;
-  onDeleteWebhook: (webhook: WebhookEventSubscription) => void;
+  webhooks: Array<EventSubscription>;
+  onUpdateWebhook: (webhook: EventSubscription) => void;
+  onDeleteWebhook: (webhook: EventSubscription) => void;
 }) => {
   const columns = [
     {
@@ -54,7 +54,7 @@ const WebhooksTable = ({
       title: '',
       dataIndex: 'action',
       key: 'action',
-      render: (action: any, record: WebhookEventSubscription) => {
+      render: (action: any, record: EventSubscription) => {
         return (
           <Flex mx={-1}>
             <Box mx={1}>
@@ -78,7 +78,14 @@ const WebhooksTable = ({
     },
   ];
 
-  return <Table rowKey="id" dataSource={webhooks} columns={columns} />;
+  return (
+    <Table
+      rowKey="id"
+      dataSource={webhooks}
+      columns={columns}
+      pagination={false}
+    />
+  );
 };
 
 export default WebhooksTable;

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -14,10 +14,3 @@ export type IntegrationType = {
   icon: string;
   description?: string;
 };
-
-export type WebhookEventSubscription = {
-  id?: string;
-  webhook_url: string;
-  verified: boolean;
-  created_at?: string | null;
-};

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -126,6 +126,20 @@ export type BrowserSession = {
   ts?: string | Date;
 };
 
+export type EventSubscription = {
+  id?: string;
+  webhook_url: string;
+  verified: boolean;
+  created_at?: string | null;
+};
+
+export type PersonalApiKey = {
+  id?: string;
+  label: string;
+  value: string;
+  created_at?: string | null;
+};
+
 export enum Alignment {
   Right = 'right',
   Left = 'left',

--- a/lib/chat_api_web/controllers/personal_api_key_controller.ex
+++ b/lib/chat_api_web/controllers/personal_api_key_controller.ex
@@ -4,8 +4,9 @@ defmodule ChatApiWeb.PersonalApiKeyController do
   alias ChatApi.ApiKeys
   alias ChatApi.ApiKeys.PersonalApiKey
 
-  action_fallback ChatApiWeb.FallbackController
+  action_fallback(ChatApiWeb.FallbackController)
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(
         %{assigns: %{current_user: %{account_id: account_id, id: user_id}}} = conn,
         _params
@@ -14,21 +15,21 @@ defmodule ChatApiWeb.PersonalApiKeyController do
     render(conn, "index.json", personal_api_keys: personal_api_keys)
   end
 
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(%{assigns: %{current_user: %{account_id: account_id, id: user_id}}} = conn, %{
         "label" => personal_api_key_label
       }) do
-    with params <- %{
-           label: personal_api_key_label,
-           user_id: user_id,
-           account_id: account_id,
-           value:
-             ApiKeys.generate_random_token(personal_api_key_label,
-               user_id: user_id,
-               account_id: account_id
-             )
-         },
-         {:ok, %PersonalApiKey{} = personal_api_key} <-
-           ApiKeys.create_personal_api_key(params) do
+    with {:ok, %PersonalApiKey{} = personal_api_key} <-
+           ApiKeys.create_personal_api_key(%{
+             label: personal_api_key_label,
+             user_id: user_id,
+             account_id: account_id,
+             value:
+               ApiKeys.generate_random_token(personal_api_key_label,
+                 user_id: user_id,
+                 account_id: account_id
+               )
+           }) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.personal_api_key_path(conn, :show, personal_api_key))
@@ -36,12 +37,14 @@ defmodule ChatApiWeb.PersonalApiKeyController do
     end
   end
 
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     # TODO: filter by user_id/account_id?
     personal_api_key = ApiKeys.get_personal_api_key!(id)
     render(conn, "show.json", personal_api_key: personal_api_key)
   end
 
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     personal_api_key = ApiKeys.get_personal_api_key!(id)
 


### PR DESCRIPTION
### Description

Add UI to manage personal API keys. This will be necessary for the API docs.

### Screenshots

Generate a new API key:
<img width="656" alt="Screen Shot 2021-02-24 at 6 03 34 PM" src="https://user-images.githubusercontent.com/5264279/109077907-d2615e80-76ca-11eb-88a1-dce4a416dc47.png">

View and copy API key:
![api-key-reveal](https://user-images.githubusercontent.com/5264279/109077872-cf666e00-76ca-11eb-94c9-205fd517c8ec.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
