### PR TITLE
Add filter options to messages index API

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -306,14 +306,44 @@ defmodule ChatApi.Customers do
       {"company_id", value}, dynamic ->
         dynamic([r], ^dynamic and r.company_id == ^value)
 
+      {"account_id", value}, dynamic ->
+        dynamic([r], ^dynamic and r.account_id == ^value)
+
+      {"external_id", value}, dynamic ->
+        dynamic([r], ^dynamic and r.external_id == ^value)
+
+      {"browser_version", value}, dynamic ->
+        dynamic([r], ^dynamic and r.browser_version == ^value)
+
+      {"browser_language", value}, dynamic ->
+        dynamic([r], ^dynamic and r.browser_language == ^value)
+
       {"name", value}, dynamic ->
         dynamic([r], ^dynamic and ilike(r.name, ^value))
 
       {"email", value}, dynamic ->
         dynamic([r], ^dynamic and ilike(r.email, ^value))
 
+      {"phone", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.phone, ^value))
+
       {"host", value}, dynamic ->
         dynamic([r], ^dynamic and ilike(r.host, ^value))
+
+      {"browser", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.browser, ^value))
+
+      {"os", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.os, ^value))
+
+      {"current_url", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.current_url, ^value))
+
+      {"pathname", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.pathname, ^value))
+
+      {"time_zone", value}, dynamic ->
+        dynamic([r], ^dynamic and ilike(r.time_zone, ^value))
 
       {_, _}, dynamic ->
         # Not a where parameter

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -48,9 +48,9 @@ defmodule ChatApiWeb.MessageController do
   end
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def index(conn, _params) do
+  def index(conn, params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
-      messages = Messages.list_messages(account_id)
+      messages = Messages.list_messages(account_id, params)
       render(conn, "index.json", messages: messages)
     end
   end


### PR DESCRIPTION
### Description

Add support for filtering messages by:
- `customer_id`
- `user_id`
- `conversation_id`
- `account_id`
- `source`
- `type`
- `body`

### Issue

Improvements to public API

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
