### PR TITLE
Minor improvements to `widget_settings` table and "Getting Started" page

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1,7 +1,7 @@
 import request from 'superagent';
 import qs from 'query-string';
 import {getAuthTokens} from './storage';
-import {Conversation, Tag, User} from './types';
+import {Account, Conversation, Tag, User, WidgetSettings} from './types';
 
 // TODO: handle this on the server instead
 function now() {
@@ -31,19 +31,6 @@ export type RegisterParams = LoginParams & {
 export type ResetPasswordParams = {
   password: string;
   passwordConfirmation: string;
-};
-
-export type WidgetSettingsParams = {
-  id?: string;
-  title: string;
-  subtitle: string;
-  color: string;
-  greeting?: string;
-  new_message_placeholder?: string;
-  show_agent_availability?: boolean;
-  agent_available_text?: string;
-  agent_unavailable_text?: string;
-  require_email_upfront?: boolean;
 };
 
 export type EventSubscriptionParams = {
@@ -283,7 +270,9 @@ export const createNewConversation = async (
     .then((res) => res.body.data);
 };
 
-export const fetchAccountInfo = async (token = getAccessToken()) => {
+export const fetchAccountInfo = async (
+  token = getAccessToken()
+): Promise<Account> => {
   if (!token) {
     throw new Error('Invalid token!');
   }
@@ -802,7 +791,7 @@ export const authorizeGoogleIntegration = async (
 };
 
 export const updateWidgetSettings = async (
-  widgetSettingsParams: WidgetSettingsParams,
+  widgetSettingsParams: Partial<WidgetSettings>,
   token = getAccessToken()
 ) => {
   if (!token) {

--- a/assets/src/components/icons.tsx
+++ b/assets/src/components/icons.tsx
@@ -10,6 +10,7 @@ import DeleteTwoTone from '@ant-design/icons/DeleteTwoTone';
 import DownOutlined from '@ant-design/icons/DownOutlined';
 import GlobalOutlined from '@ant-design/icons/GlobalOutlined';
 import InfoCircleOutlined from '@ant-design/icons/InfoCircleOutlined';
+import InfoCircleTwoTone from '@ant-design/icons/InfoCircleTwoTone';
 import LineChartOutlined from '@ant-design/icons/LineChartOutlined';
 import LinkOutlined from '@ant-design/icons/LinkOutlined';
 import LoadingOutlined from '@ant-design/icons/LoadingOutlined';
@@ -44,6 +45,7 @@ export {
   DownOutlined,
   GlobalOutlined,
   InfoCircleOutlined,
+  InfoCircleTwoTone,
   LineChartOutlined,
   LinkOutlined,
   LoadingOutlined,

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -4,7 +4,7 @@ export type Account = {
   time_zone?: string;
   subscription_plan?: string;
   users?: Array<User>;
-  widget_settings: any;
+  widget_settings: WidgetSettings;
   working_hours: Array<any>;
 };
 
@@ -138,6 +138,34 @@ export type PersonalApiKey = {
   label: string;
   value: string;
   created_at?: string | null;
+};
+
+export type WidgetIconVariant = 'outlined' | 'filled';
+
+export type WidgetSettings = {
+  id?: string;
+  title?: string;
+  subtitle?: string;
+  color?: string;
+  greeting?: string;
+  new_message_placeholder?: string;
+  show_agent_availability?: boolean;
+  agent_available_text?: string;
+  agent_unavailable_text?: string;
+  require_email_upfront?: boolean;
+  is_open_by_default?: boolean;
+  custom_icon_url?: string;
+  iframe_url_override?: string;
+  icon_variant?: WidgetIconVariant;
+  email_input_placeholder?: string;
+  new_messages_notification_text?: string;
+  base_url?: string;
+  host?: string;
+  pathname?: string;
+  last_seen_at: string | null;
+  account_id: string;
+  inserted_at: string | null;
+  updated_at: string | null;
 };
 
 export enum Alignment {

--- a/lib/chat_api/widget_settings/widget_setting.ex
+++ b/lib/chat_api/widget_settings/widget_setting.ex
@@ -10,6 +10,16 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
           color: String.t() | nil,
           greeting: String.t() | nil,
           new_message_placeholder: String.t() | nil,
+          show_agent_availability: boolean() | nil,
+          agent_available_text: String.t() | nil,
+          agent_unavailable_text: String.t() | nil,
+          require_email_upfront: boolean() | nil,
+          is_open_by_default: boolean() | nil,
+          custom_icon_url: String.t() | nil,
+          iframe_url_override: String.t() | nil,
+          icon_variant: String.t() | nil,
+          email_input_placeholder: String.t() | nil,
+          new_messages_notification_text: String.t() | nil,
           base_url: String.t() | nil,
           host: String.t() | nil,
           pathname: String.t() | nil,
@@ -24,20 +34,26 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "widget_settings" do
-    field :title, :string
-    field :subtitle, :string
-    field :color, :string
-    field :greeting, :string
-    field :new_message_placeholder, :string
-    field :show_agent_availability, :boolean
-    field :agent_available_text, :string
-    field :agent_unavailable_text, :string
-    field :require_email_upfront, :boolean
-    field :base_url, :string
+    field(:title, :string)
+    field(:subtitle, :string)
+    field(:color, :string)
+    field(:greeting, :string)
+    field(:new_message_placeholder, :string)
+    field(:show_agent_availability, :boolean)
+    field(:agent_available_text, :string)
+    field(:agent_unavailable_text, :string)
+    field(:require_email_upfront, :boolean)
+    field(:is_open_by_default, :boolean, default: false)
+    field(:custom_icon_url, :string)
+    field(:iframe_url_override, :string)
+    field(:icon_variant, :string, default: "outlined")
+    field(:email_input_placeholder, :string)
+    field(:new_messages_notification_text, :string)
+    field(:base_url, :string)
 
-    field :host, :string
-    field :pathname, :string
-    field :last_seen_at, :utc_datetime
+    field(:host, :string)
+    field(:pathname, :string)
+    field(:last_seen_at, :utc_datetime)
 
     belongs_to(:account, Account)
 
@@ -57,6 +73,12 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
       :agent_available_text,
       :agent_unavailable_text,
       :require_email_upfront,
+      :is_open_by_default,
+      :custom_icon_url,
+      :iframe_url_override,
+      :icon_variant,
+      :email_input_placeholder,
+      :new_messages_notification_text,
       :base_url,
       :account_id,
       :host,

--- a/lib/chat_api_web/views/widget_settings_view.ex
+++ b/lib/chat_api_web/views/widget_settings_view.ex
@@ -23,6 +23,12 @@ defmodule ChatApiWeb.WidgetSettingsView do
       agent_available_text: widget_settings.agent_available_text,
       agent_unavailable_text: widget_settings.agent_unavailable_text,
       require_email_upfront: widget_settings.require_email_upfront,
+      is_open_by_default: widget_settings.is_open_by_default,
+      custom_icon_url: widget_settings.custom_icon_url,
+      iframe_url_override: widget_settings.iframe_url_override,
+      icon_variant: widget_settings.icon_variant,
+      email_input_placeholder: widget_settings.email_input_placeholder,
+      new_messages_notification_text: widget_settings.new_messages_notification_text,
       base_url: widget_settings.base_url
     }
   end
@@ -39,6 +45,12 @@ defmodule ChatApiWeb.WidgetSettingsView do
       agent_available_text: widget_settings.agent_available_text,
       agent_unavailable_text: widget_settings.agent_unavailable_text,
       require_email_upfront: widget_settings.require_email_upfront,
+      is_open_by_default: widget_settings.is_open_by_default,
+      custom_icon_url: widget_settings.custom_icon_url,
+      iframe_url_override: widget_settings.iframe_url_override,
+      icon_variant: widget_settings.icon_variant,
+      email_input_placeholder: widget_settings.email_input_placeholder,
+      new_messages_notification_text: widget_settings.new_messages_notification_text,
       base_url: widget_settings.base_url,
       account: render_one(widget_settings.account, AccountView, "basic.json")
     }

--- a/priv/repo/migrations/20210226191952_add_more_fields_to_widget_settings.exs
+++ b/priv/repo/migrations/20210226191952_add_more_fields_to_widget_settings.exs
@@ -1,0 +1,14 @@
+defmodule ChatApi.Repo.Migrations.AddMoreFieldsToWidgetSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:widget_settings) do
+      add(:is_open_by_default, :boolean, default: false)
+      add(:icon_variant, :string, default: "outlined")
+      add(:custom_icon_url, :string)
+      add(:iframe_url_override, :string)
+      add(:email_input_placeholder, :string)
+      add(:new_messages_notification_text, :string)
+    end
+  end
+end


### PR DESCRIPTION
### Description

- [x] Add more widget config fields to the `widget_settings` table
- [x] Add ability to customize `iconVariant` in the "Getting Started" page
- [x] Show a tooltip with info about the `requireEmailUpfront` option in the meantime until we're able to demo this better

### Issue

Improvements to onboarding.

### Screenshots

Icon style selector:
![icon-variant-toggle](https://user-images.githubusercontent.com/5264279/109347413-24c48b80-7841-11eb-8982-eab5cac471cf.gif)

Require email upfront tooltip:
<img width="584" alt="Screen Shot 2021-02-26 at 2 42 46 PM" src="https://user-images.githubusercontent.com/5264279/109347428-2aba6c80-7841-11eb-8dac-9fcc31b14a2b.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
