### PR TITLE
Add field to widget settings table to hide branding

### DIFF
--- a/lib/chat_api/widget_settings/widget_setting.ex
+++ b/lib/chat_api/widget_settings/widget_setting.ex
@@ -15,6 +15,7 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
           agent_unavailable_text: String.t() | nil,
           require_email_upfront: boolean() | nil,
           is_open_by_default: boolean() | nil,
+          is_branding_hidden: boolean() | nil,
           custom_icon_url: String.t() | nil,
           iframe_url_override: String.t() | nil,
           icon_variant: String.t() | nil,
@@ -44,6 +45,7 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
     field(:agent_unavailable_text, :string)
     field(:require_email_upfront, :boolean)
     field(:is_open_by_default, :boolean, default: false)
+    field(:is_branding_hidden, :boolean, default: false)
     field(:custom_icon_url, :string)
     field(:iframe_url_override, :string)
     field(:icon_variant, :string, default: "outlined")
@@ -74,6 +76,7 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
       :agent_unavailable_text,
       :require_email_upfront,
       :is_open_by_default,
+      :is_branding_hidden,
       :custom_icon_url,
       :iframe_url_override,
       :icon_variant,

--- a/lib/chat_api_web/views/widget_settings_view.ex
+++ b/lib/chat_api_web/views/widget_settings_view.ex
@@ -29,6 +29,7 @@ defmodule ChatApiWeb.WidgetSettingsView do
       icon_variant: widget_settings.icon_variant,
       email_input_placeholder: widget_settings.email_input_placeholder,
       new_messages_notification_text: widget_settings.new_messages_notification_text,
+      is_branding_hidden: widget_settings.is_branding_hidden,
       base_url: widget_settings.base_url
     }
   end
@@ -51,6 +52,7 @@ defmodule ChatApiWeb.WidgetSettingsView do
       icon_variant: widget_settings.icon_variant,
       email_input_placeholder: widget_settings.email_input_placeholder,
       new_messages_notification_text: widget_settings.new_messages_notification_text,
+      is_branding_hidden: widget_settings.is_branding_hidden,
       base_url: widget_settings.base_url,
       account: render_one(widget_settings.account, AccountView, "basic.json")
     }

--- a/priv/repo/migrations/20210302200041_add_is_branding_hidden_to_widget_settings.exs
+++ b/priv/repo/migrations/20210302200041_add_is_branding_hidden_to_widget_settings.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddIsBrandingHiddenToWidgetSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:widget_settings) do
+      add(:is_branding_hidden, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
### Description

This will make it possible to enable/disable branding on accounts with the "team" plan.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
