### PR TITLE
Download all customer data as JSON

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -159,13 +159,20 @@ export const fetchCustomers = async (
     .then((res) => res.body.data);
 };
 
-export const fetchCustomer = async (id: string, token = getAccessToken()) => {
+export const fetchCustomer = async (
+  id: string,
+  query: {expand?: Array<string>} = {},
+  token = getAccessToken()
+) => {
   if (!token) {
     throw new Error('Invalid token!');
   }
 
+  const {expand = []} = query;
+
   return request
     .get(`/api/customers/${id}`)
+    .query(qs.stringify({expand}, {arrayFormat: 'bracket'}))
     .set('Authorization', token)
     .then((res) => res.body.data);
 };

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -93,7 +93,7 @@ const CustomerCompanyDetails = ({customerId}: {customerId: string}) => {
   React.useEffect(() => {
     setLoading(true);
 
-    API.fetchCustomer(customerId)
+    API.fetchCustomer(customerId, {expand: ['company']})
       .then((customer) => {
         const {company} = customer;
 

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -15,10 +15,12 @@ import {
   Tag,
   Text,
   Tooltip,
+  Popover,
 } from '../common';
 import {
   CalendarOutlined,
   GlobalOutlined,
+  InfoCircleOutlined,
   LinkOutlined,
   MailOutlined,
   PhoneOutlined,
@@ -35,6 +37,7 @@ import RelatedCustomerConversations from './RelatedCustomerConversations';
 import SlackConversationThreads from './SlackConversationThreads';
 import * as API from '../../api';
 import {Company, Conversation, Customer} from '../../types';
+import {download} from '../../utils';
 import logger from '../../logger';
 
 // TODO: create date utility methods so we don't have to do this everywhere
@@ -174,6 +177,18 @@ const CustomerDetails = ({
   const formattedTimezone =
     timezone && timezone.length ? timezone.split('_').join(' ') : null;
 
+  const exportCustomerData = async () => {
+    try {
+      const customer = await API.fetchCustomer(customerId, {
+        expand: ['company', 'conversations', 'messages', 'tags', 'notes'],
+      });
+
+      download(customer, `customer-${customerId}`);
+    } catch (err) {
+      logger.error('Failed to export customer:', err);
+    }
+  };
+
   return (
     <Box px={2} py={3}>
       <Box px={2} mb={3}>
@@ -181,9 +196,34 @@ const CustomerDetails = ({
       </Box>
 
       <DetailsSectionCard>
-        <Box mb={2}>
+        <Flex
+          mb={2}
+          sx={{justifyContent: 'space-between', alignItems: 'baseline'}}
+        >
           <Text strong>{name || 'Anonymous User'}</Text>
-        </Box>
+
+          <Popover
+            placement="left"
+            content={
+              <Box>
+                <Button
+                  type="primary"
+                  style={{width: '100%'}}
+                  onClick={exportCustomerData}
+                >
+                  Download
+                </Button>
+              </Box>
+            }
+            title="Export customer data as JSON"
+          >
+            <Box>
+              <InfoCircleOutlined
+                style={{color: colors.secondary, opacity: 0.8}}
+              />
+            </Box>
+          </Popover>
+        </Flex>
 
         <Flex mb={1} sx={{alignItems: 'center'}}>
           <MailOutlined style={{color: colors.primary}} />

--- a/assets/src/components/conversations/SidebarTagSection.tsx
+++ b/assets/src/components/conversations/SidebarTagSection.tsx
@@ -108,7 +108,10 @@ export const SidebarCustomerTags = ({customerId}: {customerId: string}) => {
   }
 
   async function refreshLatestTags() {
-    return Promise.all([API.fetchCustomer(customerId), API.fetchAllTags()])
+    return Promise.all([
+      API.fetchCustomer(customerId, {expand: ['tags']}),
+      API.fetchAllTags(),
+    ])
       .then(([customer, tags]) => {
         dispatch({
           type: 'tags/init',

--- a/assets/src/components/reporting/ReportingDashboard.tsx
+++ b/assets/src/components/reporting/ReportingDashboard.tsx
@@ -17,7 +17,7 @@ import MessagesPerUserChart from './MessagesPerUserChart';
 import MessagesSentVsReceivedChart from './MessagesSentVsReceivedChart';
 import MessagesByDayOfWeekChart from './MessagesByDayOfWeekChart';
 import {ReportingDatum} from './support';
-import {formatSecondsToHoursAndMinutes} from '../../utils';
+import {download, formatSecondsToHoursAndMinutes} from '../../utils';
 import logger from '../../logger';
 
 type DateCount = {
@@ -266,20 +266,12 @@ class ReportingDashboard extends React.Component<Props, State> {
     };
   };
 
-  download = () => {
-    // Taken from https://stackoverflow.com/a/55613750
-    const {rawReportingData = {}} = this.state;
-    const json = JSON.stringify(rawReportingData);
-    const blob = new Blob([json], {type: 'application/json'});
-    const href = URL.createObjectURL(blob);
-    const link = document.createElement('a');
+  exportReportingData = () => {
+    const {fromDate, toDate, rawReportingData = {}} = this.state;
+    const from = fromDate.format('YYYYMMDD');
+    const to = toDate.format('YYYYMMDD');
 
-    link.href = href;
-    link.download = 'analytics.json';
-
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    download(rawReportingData, `analytics-${from}-${to}`);
   };
 
   render() {
@@ -441,7 +433,9 @@ class ReportingDashboard extends React.Component<Props, State> {
           <Divider />
 
           <Flex sx={{justifyContent: 'flex-end'}}>
-            <Button onClick={this.download}>Download data as JSON</Button>
+            <Button onClick={this.exportReportingData}>
+              Download data as JSON
+            </Button>
           </Flex>
 
           {/* Hiding customer breakdown charts for now since they aren't particularly useful ¯\_(ツ)_/¯ */}

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -176,3 +176,18 @@ export const addVisibilityEventListener = (
 
   return () => document.removeEventListener(event, handler);
 };
+
+export const download = (data = {}, name = 'data') => {
+  // Taken from https://stackoverflow.com/a/55613750
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], {type: 'application/json'});
+  const href = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+
+  link.href = href;
+  link.download = `${name}-${+new Date()}.json`;
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -47,7 +47,26 @@ defmodule ChatApi.Customers do
 
   @spec get_customer!(binary()) :: Customer.t() | nil
   def get_customer!(id) do
-    Customer |> Repo.get!(id) |> Repo.preload([:company, :tags])
+    # TODO: deprecate
+    Customer
+    |> Repo.get!(id)
+    |> Repo.preload([:company, :tags])
+  end
+
+  @spec get_customer!(binary(), binary(), keyword()) :: Customer.t() | nil
+  def get_customer!(id, account_id, preloaded \\ []) do
+    Customer
+    |> where(account_id: ^account_id)
+    |> Repo.get!(id)
+    |> Repo.preload(preloaded)
+  end
+
+  @spec is_valid_association?(atom()) :: boolean()
+  def is_valid_association?(field) do
+    Enum.any?(
+      [:messages, :conversations, :notes, :tags, :company],
+      fn association -> association == field end
+    )
   end
 
   @spec find_by_external_id(binary(), binary(), map()) :: Customer.t() | nil

--- a/lib/chat_api_web/controllers/customer_controller.ex
+++ b/lib/chat_api_web/controllers/customer_controller.ex
@@ -46,6 +46,19 @@ defmodule ChatApiWeb.CustomerController do
   end
 
   @spec show(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def show(conn, %{"id" => id, "expand" => expand}) do
+    with %{account_id: account_id} <- conn.assigns.current_user do
+      preloaded =
+        expand
+        |> Stream.map(&String.to_atom/1)
+        |> Enum.filter(&Customers.is_valid_association?/1)
+
+      customer = Customers.get_customer!(id, account_id, preloaded)
+
+      render(conn, "show.json", customer: customer)
+    end
+  end
+
   def show(conn, %{"id" => id}) do
     customer = Customers.get_customer!(id)
     render(conn, "show.json", customer: customer)


### PR DESCRIPTION
### Description

- Update `GET /api/customers/:id` to support expanding more fields
- Add button to download all customer data as JSON

### Issue

Fixes https://github.com/papercups-io/papercups/issues/602

### Screenshots

Just adding the button in a tooltip for now, didn't want it to be super prominent:
![export-customer](https://user-images.githubusercontent.com/5264279/109721212-10ea9380-7b79-11eb-80f5-1dd721150f94.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
