### PR TITLE
Fix how we delete associated resources when `customer` is deleted

### DIFF
--- a/priv/repo/migrations/20210303192043_fix_on_delete_customer_associations.exs
+++ b/priv/repo/migrations/20210303192043_fix_on_delete_customer_associations.exs
@@ -1,0 +1,39 @@
+defmodule ChatApi.Repo.Migrations.FixOnDeleteCustomerAssociations do
+  use Ecto.Migration
+
+  def up do
+    drop(constraint(:messages, "messages_customer_id_fkey"))
+    drop(constraint(:conversations, "conversations_customer_id_fkey"))
+    drop(constraint(:browser_sessions, "browser_sessions_customer_id_fkey"))
+
+    alter table(:messages) do
+      modify(:customer_id, references(:customers, type: :uuid, on_delete: :delete_all))
+    end
+
+    alter table(:conversations) do
+      modify(:customer_id, references(:customers, type: :uuid, on_delete: :delete_all))
+    end
+
+    alter table(:browser_sessions) do
+      modify(:customer_id, references(:customers, type: :uuid, on_delete: :delete_all))
+    end
+  end
+
+  def down do
+    drop(constraint(:messages, "messages_customer_id_fkey"))
+    drop(constraint(:conversations, "conversations_customer_id_fkey"))
+    drop(constraint(:browser_sessions, "browser_sessions_customer_id_fkey"))
+
+    alter table(:messages) do
+      modify(:customer_id, references(:customers, type: :uuid))
+    end
+
+    alter table(:conversations) do
+      modify(:customer_id, references(:customers, type: :uuid))
+    end
+
+    alter table(:browser_sessions) do
+      modify(:customer_id, references(:customers, type: :uuid))
+    end
+  end
+end


### PR DESCRIPTION
### Description

DB migration to fix how associated resources are deleted when a `customer` is deleted.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/601

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
