### PR TITLE
Set up pricing for EU edition

### DIFF
--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -32,9 +32,10 @@ import {
   calculateSubscriptionDiscount,
   calculateSubscriptionPrice,
 } from './support';
+import {isEuEdition} from '../../config';
 import logger from '../../logger';
-import './Billing.css';
 import {LITE_PRICE, STARTER_PRICE, TEAM_PRICE} from '../../constants';
+import './Billing.css';
 
 const stripe = loadStripe(
   process.env.REACT_APP_STRIPE_PUBLIC_KEY || 'pk_test_xxxxx'

--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -32,7 +32,6 @@ import {
   calculateSubscriptionDiscount,
   calculateSubscriptionPrice,
 } from './support';
-import {isEuEdition} from '../../config';
 import logger from '../../logger';
 import {LITE_PRICE, STARTER_PRICE, TEAM_PRICE} from '../../constants';
 import './Billing.css';

--- a/assets/src/components/billing/support.ts
+++ b/assets/src/components/billing/support.ts
@@ -98,6 +98,10 @@ type SubscriptionUsage = {
   numMessages?: number;
 };
 
+export const isSupportedCurrency = (currency: string) => {
+  return currency.toLowerCase() === 'usd';
+};
+
 export const shouldRequirePlanUpdate = (
   plan: SubscriptionPlan,
   usage: SubscriptionUsage
@@ -152,6 +156,15 @@ export const calculateSubscriptionPrice = (
   }
 
   const {prices = []} = subscription;
+  const hasValidCurrency = prices.every(({currency}) =>
+    isSupportedCurrency(currency)
+  );
+
+  if (!hasValidCurrency) {
+    throw new Error(
+      'Prices should all have the same currency (in either USD or EUR)'
+    );
+  }
 
   return prices.reduce((total: number, price: any) => {
     const {
@@ -162,7 +175,7 @@ export const calculateSubscriptionPrice = (
       unit_amount: amount = 0,
     } = price;
     const isValidPrice =
-      currency.toLowerCase() === 'usd' &&
+      isSupportedCurrency(currency) &&
       interval === 'month' &&
       intervalCount === 1;
 
@@ -203,7 +216,7 @@ export const calculateSubscriptionDiscount = (
     return 0;
   }
 
-  const isValidCurrency = currency ? currency.toLowerCase() === 'usd' : true;
+  const isValidCurrency = currency ? isSupportedCurrency(currency) : true;
 
   if (!valid || !isValidCurrency) {
     throw new Error(`Invalid discount: ${JSON.stringify(discount)}`);

--- a/assets/src/config.ts
+++ b/assets/src/config.ts
@@ -10,6 +10,10 @@ export const isDev = Boolean(
 
 export const isHostedProd = window.location.hostname === 'app.papercups.io';
 
+export const isEuEdition =
+  process.env.REACT_APP_EU_EDITION === 'true' ||
+  process.env.REACT_APP_EU_EDITION === '1';
+
 export const REACT_URL = process.env.REACT_APP_URL || 'app.papercups.io';
 
 export const BASE_URL = isDev

--- a/assets/src/constants.ts
+++ b/assets/src/constants.ts
@@ -1,3 +1,5 @@
-export const STARTER_PRICE = 0;
+import {isEuEdition} from './config';
+
+export const STARTER_PRICE = isEuEdition ? 7 : 0;
 export const LITE_PRICE = 32;
 export const TEAM_PRICE = 94;

--- a/assets/src/constants.ts
+++ b/assets/src/constants.ts
@@ -1,5 +1,5 @@
 import {isEuEdition} from './config';
 
 export const STARTER_PRICE = isEuEdition ? 7 : 0;
-export const LITE_PRICE = 32;
-export const TEAM_PRICE = 94;
+export const LITE_PRICE = isEuEdition ? 39 : 32;
+export const TEAM_PRICE = isEuEdition ? 99 : 94;


### PR DESCRIPTION
### Description

Sets up code changes required for pricing for EU edition.

_(NB: This will require us to set the `REACT_APP_EU_EDITION=true` env variable in our EU deployment.)_

### Screenshots

<img width="1059" alt="Screen Shot 2021-03-12 at 3 11 31 PM" src="https://user-images.githubusercontent.com/5264279/110993408-3fb8f480-8345-11eb-9364-2616d71b92d3.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
