### PR TITLE
Add away_message field to widget settings

### DIFF
--- a/assets/src/components/account/GettingStartedOverview.tsx
+++ b/assets/src/components/account/GettingStartedOverview.tsx
@@ -30,6 +30,7 @@ type State = {
   title: string;
   subtitle: string;
   greeting?: string;
+  awayMessage?: string;
   newMessagePlaceholder?: string;
   currentUser: User | null;
   showAgentAvailability: boolean;
@@ -48,6 +49,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
     title: 'Welcome!',
     subtitle: 'Ask us anything in the chat window below 😊',
     greeting: '',
+    awayMessage: '',
     newMessagePlaceholder: 'Start typing...',
     showAgentAvailability: false,
     agentAvailableText: `We're online right now!`,
@@ -77,6 +79,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
         agent_unavailable_text: agentUnavailableText,
         require_email_upfront: requireEmailUpfront,
         icon_variant: iconVariant,
+        away_message: awayMessage,
       } = widgetSettings;
 
       this.setState({
@@ -84,6 +87,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
         account,
         currentUser,
         greeting,
+        awayMessage,
         color: color || this.state.color,
         subtitle: subtitle || this.state.subtitle,
         title: title || `Welcome to ${company}`,
@@ -126,6 +130,13 @@ class GettingStartedOverview extends React.Component<Props, State> {
   handleChangeGreeting = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState(
       {greeting: e.target.value},
+      this.debouncedUpdateWidgetSettings
+    );
+  };
+
+  handleChangeAwayMessage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState(
+      {awayMessage: e.target.value},
       this.debouncedUpdateWidgetSettings
     );
   };
@@ -186,6 +197,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
       title,
       subtitle,
       greeting,
+      awayMessage,
       newMessagePlaceholder,
       showAgentAvailability,
       agentAvailableText,
@@ -199,6 +211,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
       title,
       subtitle,
       greeting,
+      away_message: awayMessage,
       new_message_placeholder: newMessagePlaceholder,
       show_agent_availability: showAgentAvailability,
       agent_available_text: agentAvailableText,
@@ -237,6 +250,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
       title,
       subtitle,
       greeting,
+      awayMessage,
       newMessagePlaceholder,
       showAgentAvailability,
       agentAvailableText,
@@ -313,6 +327,21 @@ class GettingStartedOverview extends React.Component<Props, State> {
               placeholder="Hello! Any questions?"
               value={greeting}
               onChange={this.handleChangeGreeting}
+              onBlur={this.updateWidgetSettings}
+            />
+          </Box>
+
+          <Box mb={3}>
+            <label htmlFor="away_message">
+              Set an away message (will replace greeting message outside working
+              hours):
+            </label>
+            <Input
+              id="away_message"
+              type="text"
+              placeholder="Sorry, we're away at the moment!"
+              value={awayMessage}
+              onChange={this.handleChangeAwayMessage}
               onBlur={this.updateWidgetSettings}
             />
           </Box>

--- a/assets/src/components/account/GettingStartedOverview.tsx
+++ b/assets/src/components/account/GettingStartedOverview.tsx
@@ -462,6 +462,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
             subtitle={subtitle}
             primaryColor={color}
             greeting={greeting}
+            awayMessage={awayMessage}
             showAgentAvailability={showAgentAvailability}
             agentAvailableText={agentAvailableText}
             agentUnavailableText={agentUnavailableText}
@@ -494,6 +495,7 @@ class GettingStartedOverview extends React.Component<Props, State> {
           subtitle={subtitle}
           color={color}
           greeting={greeting}
+          awayMessage={awayMessage}
           newMessagePlaceholder={newMessagePlaceholder}
           showAgentAvailability={showAgentAvailability}
           agentAvailableText={agentAvailableText}
@@ -544,6 +546,7 @@ const CodeSnippet: FunctionComponent<Pick<
   | 'subtitle'
   | 'color'
   | 'greeting'
+  | 'awayMessage'
   | 'newMessagePlaceholder'
   | 'showAgentAvailability'
   | 'agentAvailableText'
@@ -556,6 +559,7 @@ const CodeSnippet: FunctionComponent<Pick<
   subtitle,
   color,
   greeting,
+  awayMessage,
   newMessagePlaceholder,
   showAgentAvailability,
   agentAvailableText,
@@ -589,6 +593,7 @@ window.Papercups = {
     subtitle: "${subtitle}",
     primaryColor: "${color}",
     greeting: "${greeting || ''}",
+    awayMessage: "${awayMessage || ''}",
     newMessagePlaceholder: "${newMessagePlaceholder || ''}",
     showAgentAvailability: ${showAgentAvailability},
     agentAvailableText: "${agentAvailableText}",
@@ -662,6 +667,7 @@ const ExamplePage = () => {
         subtitle="${subtitle}"
         primaryColor="${color}"
         greeting="${greeting || ''}"
+        awayMessage="${awayMessage || ''}"
         newMessagePlaceholder="${newMessagePlaceholder}"
         showAgentAvailability={${showAgentAvailability}}
         agentAvailableText="${agentAvailableText}"

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -148,6 +148,7 @@ export type WidgetSettings = {
   subtitle?: string;
   color?: string;
   greeting?: string;
+  away_message?: string;
   new_message_placeholder?: string;
   show_agent_availability?: boolean;
   agent_available_text?: string;

--- a/lib/chat_api/widget_settings/widget_setting.ex
+++ b/lib/chat_api/widget_settings/widget_setting.ex
@@ -25,6 +25,7 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
           host: String.t() | nil,
           pathname: String.t() | nil,
           last_seen_at: DateTime.t() | nil,
+          away_message: String.t() | nil,
           # Foreign keys
           account_id: Ecto.UUID.t(),
           # Timestamps
@@ -52,6 +53,7 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
     field(:email_input_placeholder, :string)
     field(:new_messages_notification_text, :string)
     field(:base_url, :string)
+    field(:away_message, :string)
 
     field(:host, :string)
     field(:pathname, :string)
@@ -86,7 +88,8 @@ defmodule ChatApi.WidgetSettings.WidgetSetting do
       :account_id,
       :host,
       :pathname,
-      :last_seen_at
+      :last_seen_at,
+      :away_message
     ])
     |> validate_required([:account_id])
     |> unique_constraint(:account_id)

--- a/lib/chat_api_web/views/widget_settings_view.ex
+++ b/lib/chat_api_web/views/widget_settings_view.ex
@@ -30,7 +30,8 @@ defmodule ChatApiWeb.WidgetSettingsView do
       email_input_placeholder: widget_settings.email_input_placeholder,
       new_messages_notification_text: widget_settings.new_messages_notification_text,
       is_branding_hidden: widget_settings.is_branding_hidden,
-      base_url: widget_settings.base_url
+      base_url: widget_settings.base_url,
+      away_message: widget_settings.away_message
     }
   end
 
@@ -54,6 +55,7 @@ defmodule ChatApiWeb.WidgetSettingsView do
       new_messages_notification_text: widget_settings.new_messages_notification_text,
       is_branding_hidden: widget_settings.is_branding_hidden,
       base_url: widget_settings.base_url,
+      away_message: widget_settings.away_message,
       account: render_one(widget_settings.account, AccountView, "basic.json")
     }
   end

--- a/priv/repo/migrations/20210310235842_add_away_message.exs
+++ b/priv/repo/migrations/20210310235842_add_away_message.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddAwayMessage do
+  use Ecto.Migration
+
+  def change do
+    alter table(:widget_settings) do
+      add(:away_message, :text)
+    end
+  end
+end

--- a/test/chat_api/widget_settings_test.exs
+++ b/test/chat_api/widget_settings_test.exs
@@ -12,7 +12,8 @@ defmodule ChatApi.WidgetSettingsTest do
       subtitle: "some updated subtitle",
       title: "some updated title",
       pathname:
-        "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe"
+        "/test/ls2bPjyYDELWL6VRpDKs9K6MrRv3O7E3F4XNZs7z4_A9gyLwBXsBZprWanwpRRNamQNFRCz9zWkixYgBPRq4mb79RF_153UHxpMg1Ct-uDfQ6SwnEGiwheWI8SraUwuEjs_GD8Cm85ziMEdFkrzNfj9NqpFOQch91YSq3wTq-7PDV4nbNd2z-IGW4CpQgXKS7DNWvrA6yKOgCSmI2OXqFNX_-PLrCseuWNJH6aYXPBKrlVZxzwOtobFV1vgWafoe",
+      away_message: "some away message"
     }
 
     @valid_metadata %{"host" => "app.papercups.io", "pathname" => "/"}
@@ -47,6 +48,7 @@ defmodule ChatApi.WidgetSettingsTest do
       assert widget_setting.subtitle == @update_attrs.subtitle
       assert widget_setting.title == @update_attrs.title
       assert widget_setting.pathname == @update_attrs.pathname
+      assert widget_setting.away_message == @update_attrs.away_message
     end
 
     test "update_widget_metadata/2 with valid data updates the metadata if no settings exist yet",

--- a/test/chat_api_web/controllers/widget_settings_controller_test.exs
+++ b/test/chat_api_web/controllers/widget_settings_controller_test.exs
@@ -21,7 +21,8 @@ defmodule ChatApiWeb.WidgetSettingsControllerTest do
       settings = %{
         title: "Test title",
         subtitle: "Test subtitle",
-        color: "Test color"
+        color: "Test color",
+        away_message: "Test away message"
       }
 
       resp =
@@ -33,7 +34,8 @@ defmodule ChatApiWeb.WidgetSettingsControllerTest do
                "object" => "widget_settings",
                "title" => "Test title",
                "subtitle" => "Test subtitle",
-               "color" => "Test color"
+               "color" => "Test color",
+               "away_message" => "Test away message"
              } = json_response(resp, 200)["data"]
 
       resp =


### PR DESCRIPTION
### Description

Adds a new field to the widget_settings schema, views, and tests. Adds a db migration.

Adds an input to the Getting Started UI to set this widget setting.

Hope it's OK in one PR! 

### Issue

https://github.com/papercups-io/papercups/issues/621
https://github.com/papercups-io/papercups/issues/622

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings


https://user-images.githubusercontent.com/7440689/110807273-dbb50400-8250-11eb-8300-d98ee1a151f1.mov


