### PR TITLE
Add CRUD API for canned_responses

### DIFF
--- a/lib/chat_api/accounts/account.ex
+++ b/lib/chat_api/accounts/account.ex
@@ -8,6 +8,7 @@ defmodule ChatApi.Accounts.Account do
   alias ChatApi.Messages.Message
   alias ChatApi.Users.User
   alias ChatApi.WidgetSettings.WidgetSetting
+  alias ChatApi.CannedResponses.CannedResponse
 
   @type t :: %__MODULE__{
           company_name: String.t(),
@@ -24,6 +25,7 @@ defmodule ChatApi.Accounts.Account do
           messages: any(),
           users: any(),
           widget_settings: any(),
+          canned_responses: any(),
           working_hours: any(),
           settings: any(),
           # Timestamps
@@ -48,6 +50,7 @@ defmodule ChatApi.Accounts.Account do
     has_many(:messages, Message)
     has_many(:users, User)
     has_one(:widget_settings, WidgetSetting)
+    has_many(:canned_responses, CannedResponse)
 
     embeds_one(:settings, Settings, on_replace: :delete)
     embeds_many(:working_hours, WorkingHours, on_replace: :delete)

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -1,0 +1,113 @@
+defmodule ChatApi.CannedResponses do
+  @moduledoc """
+  The ChatApi.CannedResponses context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.CannedResponses.CannedResponse
+
+  @doc """
+  Returns the list of canned_responses.
+
+  ## Examples
+
+      iex> list_canned_responses()
+      [%CannedResponse{}, ...]
+
+  """
+  def list_canned_responses do
+    Repo.all(CannedResponse)
+  end
+
+  @spec list_canned_responses_by_account(binary()) ::
+          CannedResponse.t() | {:error, Ecto.Changeset.t()}
+  def list_canned_responses_by_account(account_id) do
+    CannedResponse
+    |> where(account_id: ^account_id)
+    |> preload(:account)
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets a single canned_response.
+
+  Raises `Ecto.NoResultsError` if the Canned response does not exist.
+
+  ## Examples
+
+      iex> get_canned_response!(123)
+      %CannedResponse{}
+
+      iex> get_canned_response!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_canned_response!(id), do: Repo.get!(CannedResponse, id)
+
+  @doc """
+  Creates a canned_response.
+
+  ## Examples
+
+      iex> create_canned_response(%{field: value})
+      {:ok, %CannedResponse{}}
+
+      iex> create_canned_response(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_canned_response(attrs \\ %{}) do
+    %CannedResponse{}
+    |> CannedResponse.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a canned_response.
+
+  ## Examples
+
+      iex> update_canned_response(canned_response, %{field: new_value})
+      {:ok, %CannedResponse{}}
+
+      iex> update_canned_response(canned_response, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_canned_response(%CannedResponse{} = canned_response, attrs) do
+    canned_response
+    |> CannedResponse.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a canned_response.
+
+  ## Examples
+
+      iex> delete_canned_response(canned_response)
+      {:ok, %CannedResponse{}}
+
+      iex> delete_canned_response(canned_response)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_canned_response(%CannedResponse{} = canned_response) do
+    Repo.delete(canned_response)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking canned_response changes.
+
+  ## Examples
+
+      iex> change_canned_response(canned_response)
+      %Ecto.Changeset{data: %CannedResponse{}}
+
+  """
+  def change_canned_response(%CannedResponse{} = canned_response, attrs \\ %{}) do
+    CannedResponse.changeset(canned_response, attrs)
+  end
+end

--- a/lib/chat_api/canned_responses/canned_response.ex
+++ b/lib/chat_api/canned_responses/canned_response.ex
@@ -1,0 +1,39 @@
+defmodule ChatApi.CannedResponses.CannedResponse do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias ChatApi.Accounts.Account
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          content: String.t(),
+          # Foreign keys
+          account_id: any(),
+          account: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "canned_responses" do
+    field :content, :string
+    field :name, :string
+
+    belongs_to(:account, Account)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(canned_response, attrs) do
+    canned_response
+    |> cast(attrs, [:name, :content, :account_id])
+    |> validate_required([:name, :content, :account_id])
+    |> unique_constraint(
+      :unique_canned_response_per_account,
+      name: :unique_name_per_account,
+      message: "This account already has a canned response with this name."
+    )
+  end
+end

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -1,0 +1,45 @@
+defmodule ChatApiWeb.CannedResponseController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.CannedResponses
+  alias ChatApi.CannedResponses.CannedResponse
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(conn, _params) do
+    canned_responses = CannedResponses.list_canned_responses()
+    render(conn, "index.json", canned_responses: canned_responses)
+  end
+
+  def create(conn, %{"canned_response" => canned_response_params}) do
+    with {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.create_canned_response(canned_response_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.canned_response_path(conn, :show, canned_response))
+      |> render("show.json", canned_response: canned_response)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+    render(conn, "show.json", canned_response: canned_response)
+  end
+
+  def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.update_canned_response(canned_response, canned_response_params) do
+      render(conn, "show.json", canned_response: canned_response)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with {:ok, %CannedResponse{}} <- CannedResponses.delete_canned_response(canned_response) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -45,6 +45,7 @@ defmodule ChatApiWeb.CannedResponseController do
     end
   end
 
+  @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "content" => content, "name" => name}) do
     canned_response = CannedResponses.get_canned_response!(id)
 
@@ -58,6 +59,7 @@ defmodule ChatApiWeb.CannedResponseController do
     end
   end
 
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     canned_response = CannedResponses.get_canned_response!(id)
 

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -6,14 +6,29 @@ defmodule ChatApiWeb.CannedResponseController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    canned_responses = CannedResponses.list_canned_responses()
-    render(conn, "index.json", canned_responses: canned_responses)
+    with %{account_id: account_id} <- conn.assigns.current_user do
+      canned_responses = CannedResponses.list_canned_responses_by_account(account_id)
+      render(conn, "index.json", canned_responses: canned_responses)
+    end
   end
 
-  def create(conn, %{"canned_response" => canned_response_params}) do
-    with {:ok, %CannedResponse{} = canned_response} <-
-           CannedResponses.create_canned_response(canned_response_params) do
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def create(
+        conn,
+        %{
+          "content" => content,
+          "name" => name
+        }
+      ) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.create_canned_response(%{
+             content: content,
+             name: name,
+             account_id: account_id
+           }) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.canned_response_path(conn, :show, canned_response))
@@ -21,16 +36,17 @@ defmodule ChatApiWeb.CannedResponseController do
     end
   end
 
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     canned_response = CannedResponses.get_canned_response!(id)
     render(conn, "show.json", canned_response: canned_response)
   end
 
-  def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
+  def update(conn, %{"id" => id, "content" => content, "name" => name}) do
     canned_response = CannedResponses.get_canned_response!(id)
 
     with {:ok, %CannedResponse{} = canned_response} <-
-           CannedResponses.update_canned_response(canned_response, canned_response_params) do
+           CannedResponses.update_canned_response(canned_response, %{name: name, content: content}) do
       render(conn, "show.json", canned_response: canned_response)
     end
   end

--- a/lib/chat_api_web/controllers/fallback_controller.ex
+++ b/lib/chat_api_web/controllers/fallback_controller.ex
@@ -22,6 +22,17 @@ defmodule ChatApiWeb.FallbackController do
     })
   end
 
+  def call(conn, {:error, :forbidden}) do
+    conn
+    |> put_status(403)
+    |> json(%{
+      error: %{
+        status: 403,
+        message: "Forbidden"
+      }
+    })
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     errors = Changeset.traverse_errors(changeset, &ErrorHelpers.translate_error/1)
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -114,6 +114,7 @@ defmodule ChatApiWeb.Router do
     resources("/tags", TagController, except: [:new, :edit])
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
+    resources("/canned_responses", CannedResponseController)
 
     get("/slack_conversation_threads", SlackConversationThreadController, :index)
     get("/conversations/:conversation_id/previous", ConversationController, :previous)

--- a/lib/chat_api_web/views/canned_response_view.ex
+++ b/lib/chat_api_web/views/canned_response_view.ex
@@ -1,0 +1,21 @@
+defmodule ChatApiWeb.CannedResponseView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.CannedResponseView
+
+  def render("index.json", %{canned_responses: canned_responses}) do
+    %{data: render_many(canned_responses, CannedResponseView, "canned_response.json")}
+  end
+
+  def render("show.json", %{canned_response: canned_response}) do
+    %{data: render_one(canned_response, CannedResponseView, "canned_response.json")}
+  end
+
+  def render("canned_response.json", %{canned_response: canned_response}) do
+    %{
+      id: canned_response.id,
+      name: canned_response.name,
+      content: canned_response.content,
+      account_id: canned_response.id
+    }
+  end
+end

--- a/priv/repo/migrations/20210311011210_create_canned_responses.exs
+++ b/priv/repo/migrations/20210311011210_create_canned_responses.exs
@@ -1,0 +1,18 @@
+defmodule ChatApi.Repo.Migrations.CreateCannedResponses do
+  use Ecto.Migration
+
+  def change do
+    create table(:canned_responses, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :content, :text
+      add(:account_id, references(:accounts, type: :uuid, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create unique_index(:canned_responses, [:name, :account_id], name: :unique_name_per_account)
+
+    create index(:canned_responses, [:account_id])
+  end
+end

--- a/test/chat_api/canned_responses_test.exs
+++ b/test/chat_api/canned_responses_test.exs
@@ -35,7 +35,7 @@ defmodule ChatApi.ChatApi.CannedResponsesTest do
       assert CannedResponses.list_canned_responses_by_account(account.id) == [canned_response]
 
       # insert another canned_response with the same account and assert that we're getting both now
-      second_canned_response = insert(:canned_response, account: account, name: "another name")
+      insert(:canned_response, account: account, name: "another name")
 
       assert CannedResponses.list_canned_responses_by_account(account.id) |> length() == 2
     end

--- a/test/chat_api/canned_responses_test.exs
+++ b/test/chat_api/canned_responses_test.exs
@@ -1,0 +1,132 @@
+defmodule ChatApi.ChatApi.CannedResponsesTest do
+  use ChatApi.DataCase
+
+  import ChatApi.Factory
+
+  alias ChatApi.CannedResponses
+
+  describe "canned_responses" do
+    alias ChatApi.CannedResponses.CannedResponse
+
+    @update_attrs %{content: "some updated content", name: "some updated name"}
+    @invalid_attrs %{content: nil, name: nil}
+
+    setup do
+      account = insert(:account)
+      canned_response = insert(:canned_response, account: account)
+
+      {:ok, canned_response: canned_response, account: account}
+    end
+
+    test "list_canned_responses/0 returns all canned_responses",
+         %{canned_response: canned_response} do
+      canned_response_list = CannedResponses.list_canned_responses()
+
+      canned_response_ids = canned_response_list |> Enum.map(& &1.id)
+      assert canned_response_ids == [canned_response.id]
+
+      # we want accounts not to be preloaded
+      canned_response_account_ids = canned_response_list |> Enum.map(& &1.account_id)
+      assert canned_response_account_ids == [canned_response.account_id]
+    end
+
+    test "list_canned_responses_by_account/1 returns all canned_responses for a given account id",
+         %{canned_response: canned_response, account: account} do
+      assert CannedResponses.list_canned_responses_by_account(account.id) == [canned_response]
+
+      # insert another canned_response with the same account and assert that we're getting both now
+      second_canned_response = insert(:canned_response, account: account, name: "another name")
+
+      assert CannedResponses.list_canned_responses_by_account(account.id) |> length() == 2
+    end
+
+    test "get_canned_response!/1 returns the canned_response with given id",
+         %{canned_response: canned_response, account: account} do
+      canned_response_by_id = CannedResponses.get_canned_response!(canned_response.id)
+
+      assert canned_response_by_id.id == canned_response.id
+      assert canned_response_by_id.account_id == account.id
+    end
+
+    test "create_canned_response/1 with valid data creates a canned_response",
+         %{canned_response: _canned_response, account: account} do
+      assert {:ok, %CannedResponse{} = canned_response} =
+               CannedResponses.create_canned_response(%{
+                 content: "some content",
+                 name: "some name",
+                 account_id: account.id
+               })
+
+      assert canned_response.content == "some content"
+      assert canned_response.name == "some name"
+
+      assert CannedResponses.list_canned_responses_by_account(account.id) |> length() == 2
+    end
+
+    test "create_canned_response/1 with invalid data returns error changeset",
+         %{canned_response: _canned_response} do
+      assert {:error, %Ecto.Changeset{}} = CannedResponses.create_canned_response(@invalid_attrs)
+    end
+
+    test "create_canned_response/1 with duplicate name returns error changeset",
+         %{canned_response: canned_response, account: account} do
+      assert CannedResponses.list_canned_responses_by_account(account.id) == [
+               canned_response
+             ]
+
+      assert {:error, %Ecto.Changeset{}} =
+               CannedResponses.create_canned_response(%{
+                 account_id: account.id,
+                 name: canned_response.name,
+                 content: "Other content"
+               })
+
+      assert CannedResponses.list_canned_responses_by_account(account.id) |> length() == 1
+    end
+
+    test "update_canned_response/2 with valid data updates the canned_response",
+         %{canned_response: canned_response} do
+      assert {:ok, %CannedResponse{} = canned_response} =
+               CannedResponses.update_canned_response(canned_response, @update_attrs)
+
+      assert canned_response.content == "some updated content"
+      assert canned_response.name == "some updated name"
+    end
+
+    test "update_canned_response/2 with invalid data returns error changeset",
+         %{canned_response: canned_response} do
+      assert {:error, %Ecto.Changeset{}} =
+               CannedResponses.update_canned_response(canned_response, @invalid_attrs)
+
+      assert canned_response.id == CannedResponses.get_canned_response!(canned_response.id).id
+    end
+
+    test "update_canned_response/2 with duplicate name returns error changeset",
+         %{canned_response: canned_response, account: account} do
+      second_canned_response = insert(:canned_response, account: account, name: "another name")
+
+      assert {:error, %Ecto.Changeset{}} =
+               CannedResponses.update_canned_response(second_canned_response, %{
+                 account_id: account.id,
+                 name: canned_response.name,
+                 content: "other content"
+               })
+
+      assert canned_response.id == CannedResponses.get_canned_response!(canned_response.id).id
+    end
+
+    test "delete_canned_response/1 deletes the canned_response",
+         %{canned_response: canned_response} do
+      assert {:ok, %CannedResponse{}} = CannedResponses.delete_canned_response(canned_response)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CannedResponses.get_canned_response!(canned_response.id)
+      end
+    end
+
+    test "change_canned_response/1 returns a canned_response changeset",
+         %{canned_response: canned_response} do
+      assert %Ecto.Changeset{} = CannedResponses.change_canned_response(canned_response)
+    end
+  end
+end

--- a/test/chat_api_web/controllers/canned_response_controller_test.exs
+++ b/test/chat_api_web/controllers/canned_response_controller_test.exs
@@ -1,0 +1,174 @@
+defmodule ChatApiWeb.CannedResponseControllerTest do
+  use ChatApiWeb.ConnCase
+  import ChatApi.Factory
+
+  @update_attrs %{
+    content: "some updated content",
+    name: "some updated name"
+  }
+  @invalid_attrs %{content: nil, name: nil}
+
+  setup %{conn: conn} do
+    account = insert(:account)
+    user = insert(:user, account: account)
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account}
+  end
+
+  describe "index" do
+    test "lists all canned_responses",
+         %{authed_conn: authed_conn} do
+      authed_conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
+      assert json_response(authed_conn, 200)["data"] == []
+    end
+  end
+
+  describe "create canned_response" do
+    test "renders canned_response when data is valid", %{
+      authed_conn: authed_conn,
+      account: account
+    } do
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response: %{
+            content: "some content",
+            name: "some name",
+            account_id: account.id
+          }
+        )
+
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "content" => "some content",
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders errors when submitting canned response with duplicate name for the same account",
+         %{authed_conn: authed_conn, account: account} do
+      first_canned_response =
+        insert(:canned_response, %{
+          name: "First response name",
+          content: "First response content",
+          account: account
+        })
+
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response: %{
+            name: first_canned_response.name,
+            content: "New content",
+            account_id: account.id
+          }
+        )
+
+      assert json_response(conn, 422)["error"]["errors"]
+             |> Map.has_key?("unique_canned_response_per_account")
+    end
+  end
+
+  describe "update canned_response" do
+    test "renders canned_response when data is valid", %{
+      authed_conn: authed_conn,
+      account: account
+    } do
+      canned_response =
+        insert(:canned_response, %{name: "Name", content: "Content", account: account})
+
+      id = canned_response.id
+
+      conn =
+        put(authed_conn, Routes.canned_response_path(authed_conn, :update, canned_response),
+          canned_response: @update_attrs
+        )
+
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "content" => "some updated content",
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{
+      authed_conn: authed_conn,
+      account: account
+    } do
+      canned_response =
+        insert(:canned_response, %{name: "Name", content: "Content", account: account})
+
+      conn =
+        put(authed_conn, Routes.canned_response_path(authed_conn, :update, canned_response),
+          canned_response: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders errors when editing canned response to have duplicated name for the same account",
+         %{authed_conn: authed_conn, account: account} do
+      first_canned_response =
+        insert(:canned_response, %{
+          name: "First response name",
+          content: "First response content",
+          account: account
+        })
+
+      second_canned_response =
+        insert(:canned_response, %{
+          name: "Second response name",
+          content: "Second response content",
+          account: account
+        })
+
+      conn =
+        put(
+          authed_conn,
+          Routes.canned_response_path(authed_conn, :update, second_canned_response),
+          canned_response: %{
+            name: first_canned_response.name,
+            content: "New content",
+            account_id: account.id
+          }
+        )
+
+      assert json_response(conn, 422)["error"]["errors"]
+             |> Map.has_key?("unique_canned_response_per_account")
+    end
+  end
+
+  describe "delete canned_response" do
+    test "deletes chosen canned_response", %{
+      authed_conn: authed_conn
+    } do
+      canned_response = insert(:canned_response, %{name: "Name", content: "Content"})
+
+      conn =
+        delete(authed_conn, Routes.canned_response_path(authed_conn, :delete, canned_response))
+
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(authed_conn, Routes.canned_response_path(authed_conn, :show, canned_response))
+      end
+    end
+  end
+end

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -66,6 +66,23 @@ defmodule ChatApiWeb.TagControllerTest do
       conn = put(authed_conn, Routes.tag_path(authed_conn, :update, tag), tag: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    # test "renders errors when editing another account's tag",
+    #      %{conn: conn, account: account, tag: %Tag{id: id} = tag} do
+    #   new_account = insert(:account)
+    #   new_user = insert(:user, account: new_account)
+    #   new_conn = put_req_header(conn, "accept", "application/json")
+    #   new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
+
+    #   conn =
+    #     put(
+    #       new_authed_conn,
+    #       Routes.tag_path(new_authed_conn, :update, tag),
+    #       tag: @update_attrs
+    #     )
+
+    #   assert json_response(conn, 401)["error"]["errors"]
+    # end
   end
 
   describe "delete tag" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -34,6 +34,14 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def canned_response_factory do
+    %ChatApi.CannedResponses.CannedResponse{
+      account: build(:account),
+      name: "Test response name",
+      content: "Test response content"
+    }
+  end
+
   def company_factory do
     %ChatApi.Companies.Company{
       account: build(:account),


### PR DESCRIPTION
### Description

Adds migration, tests, schema, context, controllers, and views for a new `canned_responses` CRUD API.

Includes tests and code for preventing creation and updating of `canned_responses` that would have a duplicate `:name` per account.

### Related issue

#623 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
