### PR TITLE
Add CRUD API boilerplate for canned response

### DIFF
--- a/lib/chat_api/accounts/account.ex
+++ b/lib/chat_api/accounts/account.ex
@@ -8,6 +8,7 @@ defmodule ChatApi.Accounts.Account do
   alias ChatApi.Messages.Message
   alias ChatApi.Users.User
   alias ChatApi.WidgetSettings.WidgetSetting
+  alias ChatApi.CannedResponses.CannedResponse
 
   @type t :: %__MODULE__{
           company_name: String.t(),
@@ -24,6 +25,7 @@ defmodule ChatApi.Accounts.Account do
           messages: any(),
           users: any(),
           widget_settings: any(),
+          canned_responses: any(),
           working_hours: any(),
           settings: any(),
           # Timestamps
@@ -48,6 +50,7 @@ defmodule ChatApi.Accounts.Account do
     has_many(:messages, Message)
     has_many(:users, User)
     has_one(:widget_settings, WidgetSetting)
+    has_many(:canned_responses, CannedResponse)
 
     embeds_one(:settings, Settings, on_replace: :delete)
     embeds_many(:working_hours, WorkingHours, on_replace: :delete)

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -8,15 +8,7 @@ defmodule ChatApi.CannedResponses do
 
   alias ChatApi.CannedResponses.CannedResponse
 
-  @doc """
-  Returns the list of canned_responses.
 
-  ## Examples
-
-      iex> list_canned_responses()
-      [%CannedResponse{}, ...]
-
-  """
   def list_canned_responses do
     Repo.all(CannedResponse)
   end
@@ -25,83 +17,24 @@ defmodule ChatApi.CannedResponses do
     CannedResponse |> where(account_id: ^account_id) |> Repo.all()
   end
 
-  @doc """
-  Gets a single canned_response.
-
-  Raises `Ecto.NoResultsError` if the Canned response does not exist.
-
-  ## Examples
-
-      iex> get_canned_response!(123)
-      %CannedResponse{}
-
-      iex> get_canned_response!(456)
-      ** (Ecto.NoResultsError)
-
-  """
   def get_canned_response!(id), do: Repo.get!(CannedResponse, id)
 
-  @doc """
-  Creates a canned_response.
-
-  ## Examples
-
-      iex> create_canned_response(%{field: value})
-      {:ok, %CannedResponse{}}
-
-      iex> create_canned_response(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def create_canned_response(attrs \\ %{}) do
     %CannedResponse{}
     |> CannedResponse.changeset(attrs)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a canned_response.
-
-  ## Examples
-
-      iex> update_canned_response(canned_response, %{field: new_value})
-      {:ok, %CannedResponse{}}
-
-      iex> update_canned_response(canned_response, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
   def update_canned_response(%CannedResponse{} = canned_response, attrs) do
     canned_response
     |> CannedResponse.changeset(attrs)
     |> Repo.update()
   end
 
-  @doc """
-  Deletes a canned_response.
-
-  ## Examples
-
-      iex> delete_canned_response(canned_response)
-      {:ok, %CannedResponse{}}
-
-      iex> delete_canned_response(canned_response)
-      {:error, %Ecto.Changeset{}}
-
-  """
   def delete_canned_response(%CannedResponse{} = canned_response) do
     Repo.delete(canned_response)
   end
 
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking canned_response changes.
-
-  ## Examples
-
-      iex> change_canned_response(canned_response)
-      %Ecto.Changeset{data: %CannedResponse{}}
-
-  """
   def change_canned_response(%CannedResponse{} = canned_response, attrs \\ %{}) do
     CannedResponse.changeset(canned_response, attrs)
   end

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -1,0 +1,108 @@
+defmodule ChatApi.CannedResponses do
+  @moduledoc """
+  The CannedResponses context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.CannedResponses.CannedResponse
+
+  @doc """
+  Returns the list of canned_responses.
+
+  ## Examples
+
+      iex> list_canned_responses()
+      [%CannedResponse{}, ...]
+
+  """
+  def list_canned_responses do
+    Repo.all(CannedResponse)
+  end
+
+  def list_canned_responses(account_id) do
+    CannedResponse |> where(account_id: ^account_id) |> Repo.all()
+  end
+
+  @doc """
+  Gets a single canned_response.
+
+  Raises `Ecto.NoResultsError` if the Canned response does not exist.
+
+  ## Examples
+
+      iex> get_canned_response!(123)
+      %CannedResponse{}
+
+      iex> get_canned_response!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_canned_response!(id), do: Repo.get!(CannedResponse, id)
+
+  @doc """
+  Creates a canned_response.
+
+  ## Examples
+
+      iex> create_canned_response(%{field: value})
+      {:ok, %CannedResponse{}}
+
+      iex> create_canned_response(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_canned_response(attrs \\ %{}) do
+    %CannedResponse{}
+    |> CannedResponse.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a canned_response.
+
+  ## Examples
+
+      iex> update_canned_response(canned_response, %{field: new_value})
+      {:ok, %CannedResponse{}}
+
+      iex> update_canned_response(canned_response, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_canned_response(%CannedResponse{} = canned_response, attrs) do
+    canned_response
+    |> CannedResponse.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a canned_response.
+
+  ## Examples
+
+      iex> delete_canned_response(canned_response)
+      {:ok, %CannedResponse{}}
+
+      iex> delete_canned_response(canned_response)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_canned_response(%CannedResponse{} = canned_response) do
+    Repo.delete(canned_response)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking canned_response changes.
+
+  ## Examples
+
+      iex> change_canned_response(canned_response)
+      %Ecto.Changeset{data: %CannedResponse{}}
+
+  """
+  def change_canned_response(%CannedResponse{} = canned_response, attrs \\ %{}) do
+    CannedResponse.changeset(canned_response, attrs)
+  end
+end

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -37,7 +37,7 @@ defmodule ChatApi.CannedResponses do
   end
 
   @spec delete_canned_response(CannedResponse.t()) ::
-          {:ok, Tag.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, CannedResponse.t()} | {:error, Ecto.Changeset.t()}
   def delete_canned_response(%CannedResponse{} = canned_response) do
     Repo.delete(canned_response)
   end

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -8,33 +8,41 @@ defmodule ChatApi.CannedResponses do
 
   alias ChatApi.CannedResponses.CannedResponse
 
-
+  @spec list_canned_responses() :: [CannedResponse.t()]
   def list_canned_responses do
     Repo.all(CannedResponse)
   end
 
+  @spec list_canned_responses(binary()) :: [CannedResponse.t()]
   def list_canned_responses(account_id) do
     CannedResponse |> where(account_id: ^account_id) |> Repo.all()
   end
 
+  @spec get_canned_response!(binary()) :: CannedResponse.t()
   def get_canned_response!(id), do: Repo.get!(CannedResponse, id)
 
+  @spec create_canned_response(map()) :: {:ok, CannedResponse.t()} | {:error, Ecto.Changeset.t()}
   def create_canned_response(attrs \\ %{}) do
     %CannedResponse{}
     |> CannedResponse.changeset(attrs)
     |> Repo.insert()
   end
 
+  @spec update_canned_response(CannedResponse.t(), map()) ::
+          {:ok, CannedResponse.t()} | {:error, Ecto.Changeset.t()}
   def update_canned_response(%CannedResponse{} = canned_response, attrs) do
     canned_response
     |> CannedResponse.changeset(attrs)
     |> Repo.update()
   end
 
+  @spec delete_canned_response(CannedResponse.t()) ::
+          {:ok, Tag.t()} | {:error, Ecto.Changeset.t()}
   def delete_canned_response(%CannedResponse{} = canned_response) do
     Repo.delete(canned_response)
   end
 
+  @spec change_canned_response(CannedResponse.t(), map()) :: Ecto.Changeset.t()
   def change_canned_response(%CannedResponse{} = canned_response, attrs \\ %{}) do
     CannedResponse.changeset(canned_response, attrs)
   end

--- a/lib/chat_api/canned_responses/canned_response.ex
+++ b/lib/chat_api/canned_responses/canned_response.ex
@@ -1,0 +1,36 @@
+defmodule ChatApi.CannedResponses.CannedResponse do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          content: String.t(),
+          # Foreign keys
+          account_id: any(),
+          account: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "canned_responses" do
+    field :content, :string
+    field :name, :string
+
+    belongs_to(:account, Account)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(canned_response, attrs) do
+    canned_response
+    |> cast(attrs, [:name, :content, :account_id])
+    |> validate_required([:name, :content, :account_id])
+    |> unique_constraint([:name, :account_id])
+  end
+end

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -1,0 +1,45 @@
+defmodule ChatApiWeb.CannedResponseController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.CannedResponses
+  alias ChatApi.CannedResponses.CannedResponse
+
+  action_fallback ChatApiWeb.FallbackController
+
+  def index(conn, _params) do
+    canned_responses = CannedResponses.list_canned_responses()
+    render(conn, "index.json", canned_responses: canned_responses)
+  end
+
+  def create(conn, %{"canned_response" => canned_response_params}) do
+    with {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.create_canned_response(canned_response_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.canned_response_path(conn, :show, canned_response))
+      |> render("show.json", canned_response: canned_response)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+    render(conn, "show.json", canned_response: canned_response)
+  end
+
+  def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.update_canned_response(canned_response, canned_response_params) do
+      render(conn, "show.json", canned_response: canned_response)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with {:ok, %CannedResponse{}} <- CannedResponses.delete_canned_response(canned_response) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -6,14 +6,21 @@ defmodule ChatApiWeb.CannedResponseController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    canned_responses = CannedResponses.list_canned_responses()
-    render(conn, "index.json", canned_responses: canned_responses)
+    with %{account_id: account_id} <- conn.assigns.current_user do
+      canned_responses = CannedResponses.list_canned_responses(account_id)
+      render(conn, "index.json", canned_responses: canned_responses)
+    end
   end
 
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(conn, %{"canned_response" => canned_response_params}) do
-    with {:ok, %CannedResponse{} = canned_response} <-
-           CannedResponses.create_canned_response(canned_response_params) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         {:ok, %CannedResponse{} = canned_response} <-
+           canned_response_params
+           |> Map.merge(%{"account_id" => account_id})
+           |> CannedResponses.create_canned_response() do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.canned_response_path(conn, :show, canned_response))
@@ -21,20 +28,25 @@ defmodule ChatApiWeb.CannedResponseController do
     end
   end
 
+  @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, %{"id" => id}) do
     canned_response = CannedResponses.get_canned_response!(id)
     render(conn, "show.json", canned_response: canned_response)
   end
 
+  @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
     canned_response = CannedResponses.get_canned_response!(id)
 
-    with {:ok, %CannedResponse{} = canned_response} <-
-           CannedResponses.update_canned_response(canned_response, canned_response_params) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         params <- canned_response_params |> Map.merge(%{"account_id" => account_id}),
+         {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.update_canned_response(canned_response, params) do
       render(conn, "show.json", canned_response: canned_response)
     end
   end
 
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     canned_response = CannedResponses.get_canned_response!(id)
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -114,6 +114,7 @@ defmodule ChatApiWeb.Router do
     resources("/tags", TagController, except: [:new, :edit])
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
+    resources("/canned_responses", CannedResponseController, except: [:new, :edit])
 
     get("/slack_conversation_threads", SlackConversationThreadController, :index)
     get("/conversations/:conversation_id/previous", ConversationController, :previous)

--- a/lib/chat_api_web/views/canned_response_view.ex
+++ b/lib/chat_api_web/views/canned_response_view.ex
@@ -1,0 +1,16 @@
+defmodule ChatApiWeb.CannedResponseView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.CannedResponseView
+
+  def render("index.json", %{canned_responses: canned_responses}) do
+    %{data: render_many(canned_responses, CannedResponseView, "canned_response.json")}
+  end
+
+  def render("show.json", %{canned_response: canned_response}) do
+    %{data: render_one(canned_response, CannedResponseView, "canned_response.json")}
+  end
+
+  def render("canned_response.json", %{canned_response: canned_response}) do
+    %{id: canned_response.id, name: canned_response.name, content: canned_response.content}
+  end
+end

--- a/priv/repo/migrations/20210311143537_create_canned_responses.exs
+++ b/priv/repo/migrations/20210311143537_create_canned_responses.exs
@@ -1,0 +1,19 @@
+defmodule ChatApi.Repo.Migrations.CreateCannedResponses do
+  use Ecto.Migration
+
+  def change do
+    create table(:canned_responses, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :content, :text, null: false
+
+      add :account_id, references(:accounts, on_delete: :delete_all, type: :binary_id),
+        null: false
+
+      timestamps()
+    end
+
+    create index(:canned_responses, [:account_id])
+    create unique_index(:canned_responses, [:name, :account_id])
+  end
+end

--- a/test/chat_api/canned_responses_test.exs
+++ b/test/chat_api/canned_responses_test.exs
@@ -1,0 +1,89 @@
+defmodule ChatApi.CannedResponsesTest do
+  use ChatApi.DataCase
+
+  import ChatApi.Factory
+
+  alias ChatApi.CannedResponses
+
+  describe "canned_responses" do
+    alias ChatApi.CannedResponses.CannedResponse
+
+    @valid_attrs %{content: "some content", name: "some name"}
+    @update_attrs %{content: "some updated content", name: "some updated name"}
+    @invalid_attrs %{content: nil, name: nil}
+
+    setup do
+      account = insert(:account)
+      canned_response = insert(:canned_response, account: account)
+
+      {:ok, account: account, canned_response: canned_response}
+    end
+
+    test "list_canned_responses/0 returns all canned_responses", %{
+      account: account,
+      canned_response: canned_response
+    } do
+      canned_response_ids = CannedResponses.list_canned_responses(account.id) |> Enum.map(& &1.id)
+      assert canned_response_ids == [canned_response.id]
+    end
+
+    test "get_canned_response!/1 returns the canned_response with given id", %{
+      canned_response: canned_response
+    } do
+      assert canned_response =
+               CannedResponses.get_canned_response!(canned_response.id)
+               |> Repo.preload([:account])
+    end
+
+    test "create_canned_response/1 with valid data creates a canned_response" do
+      assert {:ok, %CannedResponse{} = canned_response} =
+               CannedResponses.create_canned_response(
+                 params_with_assocs(:canned_response, @valid_attrs)
+               )
+
+      assert canned_response.content == "some content"
+      assert canned_response.name == "some name"
+    end
+
+    test "create_canned_response/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = CannedResponses.create_canned_response(@invalid_attrs)
+    end
+
+    test "update_canned_response/2 with valid data updates the canned_response", %{
+      canned_response: canned_response
+    } do
+      assert {:ok, %CannedResponse{} = canned_response} =
+               CannedResponses.update_canned_response(canned_response, @update_attrs)
+
+      assert canned_response.content == "some updated content"
+      assert canned_response.name == "some updated name"
+    end
+
+    test "update_canned_response/2 with invalid data returns error changeset", %{
+      canned_response: canned_response
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               CannedResponses.update_canned_response(canned_response, @invalid_attrs)
+
+      assert canned_response ==
+               CannedResponses.get_canned_response!(canned_response.id)
+               |> Repo.preload([:account])
+    end
+
+    test "delete_canned_response/1 deletes the canned_response", %{
+      canned_response: canned_response
+    } do
+      assert {:ok, %CannedResponse{}} = CannedResponses.delete_canned_response(canned_response)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        CannedResponses.get_canned_response!(canned_response.id)
+      end
+    end
+
+    test "change_canned_response/1 returns a canned_response changeset", %{
+      canned_response: canned_response
+    } do
+      assert %Ecto.Changeset{} = CannedResponses.change_canned_response(canned_response)
+    end
+  end
+end

--- a/test/chat_api/canned_responses_test.exs
+++ b/test/chat_api/canned_responses_test.exs
@@ -19,7 +19,7 @@ defmodule ChatApi.CannedResponsesTest do
       {:ok, account: account, canned_response: canned_response}
     end
 
-    test "list_canned_responses/0 returns all canned_responses", %{
+    test "list_canned_responses/1 returns all canned_responses", %{
       account: account,
       canned_response: canned_response
     } do

--- a/test/chat_api_web/controllers/canned_response_controller_test.exs
+++ b/test/chat_api_web/controllers/canned_response_controller_test.exs
@@ -1,0 +1,153 @@
+defmodule ChatApiWeb.CannedResponseControllerTest do
+  use ChatApiWeb.ConnCase
+
+  import ChatApi.Factory
+
+  alias ChatApi.CannedResponses
+  alias ChatApi.CannedResponses.CannedResponse
+
+  @create_attrs %{name: "some name", content: "some content"}
+  @update_attrs %{
+    content: "some updated content",
+    name: "some updated name"
+  }
+  @invalid_attrs %{content: nil, name: nil}
+
+  def fixture(:canned_response) do
+    {:ok, canned_response} = CannedResponses.create_canned_response(@create_attrs)
+    canned_response
+  end
+
+  setup %{conn: conn} do
+    account = insert(:account)
+    user = insert(:user, account: account)
+
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account}
+  end
+
+  describe "index" do
+    test "lists all canned_responses", %{authed_conn: authed_conn} do
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create canned_response" do
+    test "renders canned_response when data is valid", %{authed_conn: authed_conn} do
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response: params_with_assocs(:canned_response, @create_attrs)
+        )
+
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "content" => "some content",
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders errors when there are two same name in a single account", %{
+      authed_conn: authed_conn,
+      account: account
+    } do
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response:
+            params_for(:canned_response, %{
+              account: account,
+              name: "some name",
+              content: "some content"
+            })
+        )
+
+      assert %{"id" => _id} = json_response(conn, 201)["data"]
+
+      conn =
+        post(authed_conn, Routes.canned_response_path(authed_conn, :create),
+          canned_response:
+            params_for(:canned_response, %{
+              account: account,
+              name: "some name",
+              content: "new content"
+            })
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update canned_response" do
+    setup [:create_canned_response]
+
+    test "renders canned_response when data is valid", %{
+      authed_conn: authed_conn,
+      canned_response: %CannedResponse{id: id} = canned_response
+    } do
+      conn =
+        put(authed_conn, Routes.canned_response_path(authed_conn, :update, canned_response),
+          canned_response: @update_attrs
+        )
+
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => id,
+               "content" => "some updated content",
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{
+      authed_conn: authed_conn,
+      canned_response: canned_response
+    } do
+      conn =
+        put(authed_conn, Routes.canned_response_path(authed_conn, :update, canned_response),
+          canned_response: @invalid_attrs
+        )
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete canned_response" do
+    setup [:create_canned_response]
+
+    test "deletes chosen canned_response", %{
+      authed_conn: authed_conn,
+      canned_response: canned_response
+    } do
+      conn =
+        delete(authed_conn, Routes.canned_response_path(authed_conn, :delete, canned_response))
+
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(authed_conn, Routes.canned_response_path(authed_conn, :show, canned_response))
+      end
+    end
+  end
+
+  defp create_canned_response(%{account: account}) do
+    canned_response = insert(:canned_response, account: account)
+    %{canned_response: canned_response}
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -34,6 +34,14 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def canned_response_factory do
+    %ChatApi.CannedResponses.CannedResponse{
+      account: build(:account),
+      name: sequence("some name"),
+      content: sequence("some content")
+    }
+  end
+
   def company_factory do
     %ChatApi.Companies.Company{
       account: build(:account),


### PR DESCRIPTION
### Description

Adds auto-generated files such as db migration, views, controller, context, and schema. Created unique index for name and account and implement unique_constraint in `canned_response` schema. 

Perform test including uniqueness of name  per account. I also added test factory for canned response for future usage.

### Issue

#623 


## Checklist

- [X] Everything passes when running `mix test`
- [X] Ran `mix format`
- [X] No frontend compilation warnings
