### PR TITLE
Add conversations.last_activity_at 

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -455,6 +455,16 @@ defmodule ChatApi.Conversations do
     |> Repo.delete()
   end
 
+  @spec mark_activity(Conversation.t()) ::
+          {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}
+  def mark_activity(id) do
+    %Conversation{id: id}
+    |> Conversation.last_activity_changeset(%{
+      last_activity_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Repo.update()
+  end
+
   #####################
   # Private methods
   #####################

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -455,7 +455,7 @@ defmodule ChatApi.Conversations do
     |> Repo.delete()
   end
 
-  @spec mark_activity(Conversation.t()) ::
+  @spec mark_activity(String.t()) ::
           {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}
   def mark_activity(id) do
     %Conversation{id: id}

--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -17,6 +17,7 @@ defmodule ChatApi.Conversations.Conversation do
           read: boolean(),
           archived_at: any(),
           closed_at: any(),
+          last_activity_at: any(),
           metadata: any(),
           # Relations
           assignee_id: any(),
@@ -44,6 +45,7 @@ defmodule ChatApi.Conversations.Conversation do
     field(:archived_at, :utc_datetime)
     field(:first_replied_at, :utc_datetime)
     field(:closed_at, :utc_datetime)
+    field(:last_activity_at, :utc_datetime)
     field(:metadata, :map)
 
     has_many(:messages, Message)
@@ -78,6 +80,11 @@ defmodule ChatApi.Conversations.Conversation do
     |> put_closed_at()
     |> foreign_key_constraint(:account_id)
     |> foreign_key_constraint(:customer_id)
+  end
+
+  def last_activity_changeset(conversation, attrs) do
+    conversation
+    |> cast(attrs, [:last_activity_at])
   end
 
   defp put_closed_at(%Ecto.Changeset{valid?: true, changes: %{status: status}} = changeset) do

--- a/lib/chat_api/messages.ex
+++ b/lib/chat_api/messages.ex
@@ -131,7 +131,8 @@ defmodule ChatApi.Messages do
   end
 
   defp after_message_created({:ok, message} = params) do
-    Workers.MessageCreatedActions.new(%{"id" => message.id})
+    %{"id" => message.id}
+    |> Workers.MessageCreatedActions.new()
     |> Oban.insert()
 
     params

--- a/lib/workers/message_created_actions.ex
+++ b/lib/workers/message_created_actions.ex
@@ -1,0 +1,18 @@
+defmodule ChatApi.Workers.MessageCreatedActions do
+  use Oban.Worker, queue: :events
+  alias ChatApi.Conversations
+  alias ChatApi.Messages
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"id" => id}}) do
+    message = Messages.get_message!(id)
+
+    with {:ok, _} <- Conversations.mark_activity(message.conversation_id) do
+      :ok
+    else
+      err -> err
+    end
+  end
+end

--- a/priv/repo/migrations/20210312222205_add_conversations_last_activity_at.exs
+++ b/priv/repo/migrations/20210312222205_add_conversations_last_activity_at.exs
@@ -1,0 +1,21 @@
+defmodule ChatApi.Repo.Migrations.AddConversationsLastActivityAt do
+  use Ecto.Migration
+
+  def up do
+    alter table(:conversations) do
+      add(:last_activity_at, :utc_datetime)
+    end
+
+    execute("""
+    UPDATE conversations SET last_activity_at = subquery.recent_inserted_at
+    FROM (SELECT conversation_id, MAX(inserted_at) AS recent_inserted_at FROM messages GROUP BY conversation_id) AS subquery
+    WHERE subquery.conversation_id = conversations.id;
+    """)
+  end
+
+  def down do
+    alter table(:conversations) do
+      remove(:last_activity_at)
+    end
+  end
+end

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -34,6 +34,13 @@ defmodule ChatApi.MessagesTest do
       assert message.source == "chat"
     end
 
+    test "create_message/1 sets conversation's last activity time" do
+      attrs = params_with_assocs(:message, body: "valid message body")
+
+      assert {:ok, %Message{} = message} = Messages.create_message(attrs)
+      assert ChatApi.Conversations.get_conversation!(message.conversation_id).last_activity_at != nil
+    end
+
     test "create_message/1 with invalid source returns error changeset" do
       assert {:error, %Ecto.Changeset{errors: errors}} =
                Messages.create_message(%{body: "Hello world!", source: "unknown"})

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -38,7 +38,9 @@ defmodule ChatApi.MessagesTest do
       attrs = params_with_assocs(:message, body: "valid message body")
 
       assert {:ok, %Message{} = message} = Messages.create_message(attrs)
-      assert ChatApi.Conversations.get_conversation!(message.conversation_id).last_activity_at != nil
+
+      assert ChatApi.Conversations.get_conversation!(message.conversation_id).last_activity_at !=
+               nil
     end
 
     test "create_message/1 with invalid source returns error changeset" do

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -3,7 +3,9 @@ defmodule ChatApi.MessagesTest do
 
   import ChatApi.Factory
   alias ChatApi.Messages
+  alias ChatApi.Workers
   alias ChatApi.Messages.Message
+  use Oban.Testing, repo: ChatApi.Repo
 
   describe "messages" do
     @update_attrs %{body: "some updated body"}
@@ -34,13 +36,12 @@ defmodule ChatApi.MessagesTest do
       assert message.source == "chat"
     end
 
-    test "create_message/1 sets conversation's last activity time" do
+    test "create_message/1 queues a MessageCreatedActions job " do
       attrs = params_with_assocs(:message, body: "valid message body")
 
       assert {:ok, %Message{} = message} = Messages.create_message(attrs)
 
-      assert ChatApi.Conversations.get_conversation!(message.conversation_id).last_activity_at !=
-               nil
+      assert_enqueued worker: Workers.MessageCreatedActions, args: %{"id" => message.id}
     end
 
     test "create_message/1 with invalid source returns error changeset" do

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -41,7 +41,7 @@ defmodule ChatApi.MessagesTest do
 
       assert {:ok, %Message{} = message} = Messages.create_message(attrs)
 
-      assert_enqueued worker: Workers.MessageCreatedActions, args: %{"id" => message.id}
+      assert_enqueued(worker: Workers.MessageCreatedActions, args: %{"id" => message.id})
     end
 
     test "create_message/1 with invalid source returns error changeset" do


### PR DESCRIPTION
### Description

Create a new field `conversations.last_activity` that gets populated when a message is created

### Issue
#451 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
