### PR TITLE
Add authorization to ConversationController, CustomerController, MessageController

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -45,20 +45,11 @@ defmodule ChatApi.Customers do
     |> Repo.paginate(pagination_params)
   end
 
-  @spec get_customer!(binary()) :: Customer.t() | nil
-  def get_customer!(id) do
-    # TODO: deprecate
+  @spec get_customer!(binary(), atom() | list(atom()) | keyword()) :: Customer.t() | nil
+  def get_customer!(id, preloads \\ [:company, :tags]) do
     Customer
     |> Repo.get!(id)
-    |> Repo.preload([:company, :tags])
-  end
-
-  @spec get_customer!(binary(), binary(), keyword()) :: Customer.t() | nil
-  def get_customer!(id, account_id, preloaded \\ []) do
-    Customer
-    |> where(account_id: ^account_id)
-    |> Repo.get!(id)
-    |> Repo.preload(preloaded)
+    |> Repo.preload(preloads)
   end
 
   @spec is_valid_association?(atom()) :: boolean()

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -7,6 +7,19 @@ defmodule ChatApiWeb.MessageController do
 
   action_fallback(ChatApiWeb.FallbackController)
 
+  plug :authorize when action in [:show, :update, :delete]
+
+  defp authorize(conn, _) do
+    id = conn.path_params["id"]
+
+    with %{id: user_id, account_id: account_id} <- conn.assigns.current_user,
+         message = %{account_id: ^account_id, user_id: ^user_id} <- Messages.get_message!(id) do
+      assign(conn, :current_message, message)
+    else
+      _ -> ChatApiWeb.FallbackController.call(conn, {:error, :not_found}) |> halt()
+    end
+  end
+
   def swagger_definitions do
     %{
       Message:
@@ -108,15 +121,16 @@ defmodule ChatApiWeb.MessageController do
   end
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, %{"id" => id}) do
-    message = Messages.get_message!(id)
+  def show(conn, _params) do
+    message = conn.assigns.current_message
     render(conn, "show.json", message: message)
   end
 
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update(conn, %{"id" => id, "message" => message_params}) do
-    with %Message{user_id: user_id} = message <- Messages.get_message!(id),
-         %{id: ^user_id, account_id: account_id} <- conn.assigns.current_user,
+  def update(conn, %{"message" => message_params}) do
+    message = conn.assigns.current_message
+
+    with %{account_id: account_id} <- conn.assigns.current_user,
          sanitized_updates <- Map.merge(message_params, %{"account_id" => account_id}),
          {:ok, %Message{} = message} <- Messages.update_message(message, sanitized_updates) do
       render(conn, "show.json", message: message)
@@ -124,8 +138,8 @@ defmodule ChatApiWeb.MessageController do
   end
 
   @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def delete(conn, %{"id" => id}) do
-    message = Messages.get_message!(id)
+  def delete(conn, _params) do
+    message = conn.assigns.current_message
 
     with {:ok, %Message{}} <- Messages.delete_message(message) do
       send_resp(conn, :no_content, "")

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -226,12 +226,12 @@ defmodule ChatApiWeb.ConversationControllerTest do
 
       assert json_response(resp, 404)["error"]["message"] == "Not found"
     end
-  end
 
-  defp unauthorized_conversation() do
-    account = insert(:account)
-    customer = insert(:customer, account: account)
+    defp unauthorized_conversation() do
+      account = insert(:account)
+      customer = insert(:customer, account: account)
 
-    insert(:conversation, account: account, customer: customer)
+      insert(:conversation, account: account, customer: customer)
+    end
   end
 end

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -200,4 +200,38 @@ defmodule ChatApiWeb.ConversationControllerTest do
       assert json_response(resp, 200)["data"]["ok"]
     end
   end
+
+  describe "authorization is required" do
+    test "for :show route", %{authed_conn: authed_conn} do
+      conversation = unauthorized_conversation()
+      resp = get(authed_conn, Routes.conversation_path(authed_conn, :show, conversation))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :update route", %{authed_conn: authed_conn} do
+      conversation = unauthorized_conversation()
+
+      resp =
+        put(authed_conn, Routes.conversation_path(authed_conn, :update, conversation),
+          conversation: @update_attrs
+        )
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :delete route", %{authed_conn: authed_conn} do
+      conversation = unauthorized_conversation()
+      resp = delete(authed_conn, Routes.conversation_path(authed_conn, :delete, conversation))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+  end
+
+  defp unauthorized_conversation() do
+    account = insert(:account)
+    customer = insert(:customer, account: account)
+
+    insert(:conversation, account: account, customer: customer)
+  end
 end

--- a/test/chat_api_web/controllers/customer_controller_test.exs
+++ b/test/chat_api_web/controllers/customer_controller_test.exs
@@ -336,4 +336,37 @@ defmodule ChatApiWeb.CustomerControllerTest do
              } = json_response(resp, 200)["data"]
     end
   end
+
+  describe "authorization is required" do
+    test "for :show route", %{authed_conn: authed_conn} do
+      customer = unauthorized_customer()
+      resp = get(authed_conn, Routes.customer_path(authed_conn, :show, customer))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :update route", %{authed_conn: authed_conn} do
+      customer = unauthorized_customer()
+
+      resp =
+        put(authed_conn, Routes.customer_path(authed_conn, :delete, customer),
+          customer: @update_attrs
+        )
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :delete route", %{authed_conn: authed_conn} do
+      customer = unauthorized_customer()
+      resp = delete(authed_conn, Routes.customer_path(authed_conn, :delete, customer))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    defp unauthorized_customer() do
+      account = insert(:account)
+
+      insert(:customer, account: account)
+    end
+  end
 end

--- a/test/chat_api_web/controllers/message_controller_test.exs
+++ b/test/chat_api_web/controllers/message_controller_test.exs
@@ -98,4 +98,39 @@ defmodule ChatApiWeb.MessageControllerTest do
       end)
     end
   end
+
+  describe "authorization is required" do
+    test "for :show route", %{authed_conn: authed_conn} do
+      message = unauthorized_message()
+      resp = get(authed_conn, Routes.message_path(authed_conn, :show, message))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :update route", %{authed_conn: authed_conn} do
+      message = unauthorized_message()
+
+      resp =
+        put(authed_conn, Routes.message_path(authed_conn, :update, message),
+          message: @update_attrs
+        )
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    test "for :delete route", %{authed_conn: authed_conn} do
+      message = unauthorized_message()
+      resp = delete(authed_conn, Routes.message_path(authed_conn, :delete, message))
+
+      assert json_response(resp, 404)["error"]["message"] == "Not found"
+    end
+
+    defp unauthorized_message() do
+      account = insert(:account)
+      user = insert(:user, account: account)
+      conversation = insert(:conversation, account: account)
+
+      insert(:message, account: account, conversation: conversation, user: user, customer: nil)
+    end
+  end
 end


### PR DESCRIPTION
Adds plug-based authorization for show/update/delete routes as suggested
in #638.
Also as suggested in #638, uses 404 status code when no authorized
resource was found.

### Issue
#638 

## Checklist

- [X] Everything passes when running `mix test`
- [X] Ran `mix format`
