### PR TITLE
Add authorize plug for canned responses show, update, delete

### DIFF
--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -6,6 +6,19 @@ defmodule ChatApiWeb.CannedResponseController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  plug :authorize when action in [:show, :update, :delete]
+
+  defp authorize(conn, _) do
+    id = conn.path_params["id"]
+
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         canned_response = %{account_id: ^account_id} <- CannedResponses.get_canned_response!(id) do
+      assign(conn, :current_canned_response, canned_response)
+    else
+      _ -> ChatApiWeb.FallbackController.call(conn, {:error, :not_found}) |> halt()
+    end
+  end
+
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
@@ -29,28 +42,25 @@ defmodule ChatApiWeb.CannedResponseController do
   end
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, %{"id" => id}) do
-    canned_response = CannedResponses.get_canned_response!(id)
-    render(conn, "show.json", canned_response: canned_response)
+  def show(conn, _params) do
+    render(conn, "show.json", canned_response: conn.assigns.current_canned_response)
   end
 
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
-    canned_response = CannedResponses.get_canned_response!(id)
-
-    with %{account_id: account_id} <- conn.assigns.current_user,
-         params <- canned_response_params |> Map.merge(%{"account_id" => account_id}),
-         {:ok, %CannedResponse{} = canned_response} <-
-           CannedResponses.update_canned_response(canned_response, params) do
-      render(conn, "show.json", canned_response: canned_response)
+  def update(conn, %{"canned_response" => canned_response_params}) do
+    with {:ok, %CannedResponse{} = updated_canned_response} <-
+           CannedResponses.update_canned_response(
+             conn.assigns.current_canned_response,
+             canned_response_params
+           ) do
+      render(conn, "show.json", canned_response: updated_canned_response)
     end
   end
 
   @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def delete(conn, %{"id" => id}) do
-    canned_response = CannedResponses.get_canned_response!(id)
-
-    with {:ok, %CannedResponse{}} <- CannedResponses.delete_canned_response(canned_response) do
+  def delete(conn, _params) do
+    with {:ok, %CannedResponse{}} <-
+           CannedResponses.delete_canned_response(conn.assigns.current_canned_response) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/test/chat_api_web/controllers/canned_response_controller_test.exs
+++ b/test/chat_api_web/controllers/canned_response_controller_test.exs
@@ -70,6 +70,26 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
   end
 
   describe "show canned_response" do
+    test "shows canned_response by id", %{
+      account: account,
+      authed_conn: authed_conn
+    } do
+      canned_response =
+        insert(:canned_response, %{
+          name: "Another canned response name",
+          content: "Another canned response content",
+          account: account
+        })
+
+      conn =
+        get(
+          authed_conn,
+          Routes.canned_response_path(authed_conn, :show, canned_response.id)
+        )
+
+      assert json_response(conn, 200)["data"]
+    end
+
     test "renders 404 when asking for another user's canned_response", %{
       authed_conn: authed_conn
     } do

--- a/test/chat_api_web/controllers/canned_response_controller_test.exs
+++ b/test/chat_api_web/controllers/canned_response_controller_test.exs
@@ -33,6 +33,69 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
       conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
       assert json_response(conn, 200)["data"] == []
     end
+
+    test "returns unauthorized when auth is invalid", %{conn: conn} do
+      conn = get(conn, Routes.canned_response_path(conn, :index))
+
+      assert json_response(conn, 401)["errors"] != %{}
+    end
+
+    test "lists canned_responses only for this account",
+         %{authed_conn: authed_conn, account: account} do
+      insert(:canned_response, %{
+        name: "First response name",
+        content: "First response content",
+        account: account
+      })
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
+
+      assert json_response(conn, 200)["data"] |> length() == 1
+
+      # Nw, make another account and canned response, and make sure we can't see that one in our query
+
+      another_account = insert(:account)
+
+      insert(:canned_response, %{
+        name: "Another canned response name",
+        content: "Another canned response content",
+        account: another_account
+      })
+
+      conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
+
+      assert json_response(conn, 200)["data"] |> length() == 1
+    end
+  end
+
+  describe "show canned_response" do
+    test "renders 404 when asking for another user's canned_response", %{
+      conn: conn,
+      account: account
+    } do
+      # Make a canned_response with a first user
+      canned_response =
+        insert(:canned_response, %{
+          name: "First response name",
+          content: "First response content",
+          account: account
+        })
+
+      # Make a new account and session
+      new_account = insert(:account)
+      new_user = insert(:user, account: new_account)
+      new_conn = put_req_header(conn, "accept", "application/json")
+      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
+
+      # Using the new account/session, try to get the other user's canned_response
+      conn =
+        get(
+          new_authed_conn,
+          Routes.canned_response_path(new_authed_conn, :show, canned_response.id)
+        )
+
+      assert json_response(conn, 404)
+    end
   end
 
   describe "create canned_response" do
@@ -126,6 +189,32 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
 
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "renders 404 when editing another account's canned response",
+         %{conn: conn, account: account} do
+      # Add a canned response for the first account
+      canned_response =
+        insert(:canned_response, %{
+          name: "Canned response name",
+          content: "Canned response content",
+          account: account
+        })
+
+      new_account = insert(:account)
+      new_user = insert(:user, account: new_account)
+      new_conn = put_req_header(conn, "accept", "application/json")
+      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
+
+      conn =
+        put(
+          new_authed_conn,
+          Routes.canned_response_path(new_authed_conn, :update, canned_response),
+          name: "New name",
+          content: "New content"
+        )
+
+      assert json_response(conn, 404)
+    end
   end
 
   describe "delete canned_response" do
@@ -143,6 +232,30 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
       assert_error_sent 404, fn ->
         get(authed_conn, Routes.canned_response_path(authed_conn, :show, canned_response))
       end
+    end
+
+    test "renders 404 when deleting another account's canned response",
+         %{conn: conn, account: account} do
+      # Add a canned response for the first account
+      canned_response =
+        insert(:canned_response, %{
+          name: "Canned response name",
+          content: "Canned response content",
+          account: account
+        })
+
+      new_account = insert(:account)
+      new_user = insert(:user, account: new_account)
+      new_conn = put_req_header(conn, "accept", "application/json")
+      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
+
+      conn =
+        delete(
+          new_authed_conn,
+          Routes.canned_response_path(new_authed_conn, :delete, canned_response)
+        )
+
+      assert json_response(conn, 404)
     end
   end
 

--- a/test/chat_api_web/controllers/canned_response_controller_test.exs
+++ b/test/chat_api_web/controllers/canned_response_controller_test.exs
@@ -52,7 +52,7 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
 
       assert json_response(conn, 200)["data"] |> length() == 1
 
-      # Nw, make another account and canned response, and make sure we can't see that one in our query
+      # Add another account and canned response
 
       another_account = insert(:account)
 
@@ -64,34 +64,30 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
 
       conn = get(authed_conn, Routes.canned_response_path(authed_conn, :index))
 
+      # Make sure we don't get the original canned_response when checking as the new user
       assert json_response(conn, 200)["data"] |> length() == 1
     end
   end
 
   describe "show canned_response" do
     test "renders 404 when asking for another user's canned_response", %{
-      conn: conn,
-      account: account
+      authed_conn: authed_conn
     } do
-      # Make a canned_response with a first user
+      # Create a new account and give it a canned_response
+      another_account = insert(:account)
+
       canned_response =
         insert(:canned_response, %{
-          name: "First response name",
-          content: "First response content",
-          account: account
+          name: "Another canned response name",
+          content: "Another canned response content",
+          account: another_account
         })
 
-      # Make a new account and session
-      new_account = insert(:account)
-      new_user = insert(:user, account: new_account)
-      new_conn = put_req_header(conn, "accept", "application/json")
-      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
-
-      # Using the new account/session, try to get the other user's canned_response
+      # Using the original session, try to delete the new account's canned_response
       conn =
         get(
-          new_authed_conn,
-          Routes.canned_response_path(new_authed_conn, :show, canned_response.id)
+          authed_conn,
+          Routes.canned_response_path(authed_conn, :show, canned_response.id)
         )
 
       assert json_response(conn, 404)
@@ -191,24 +187,22 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
     end
 
     test "renders 404 when editing another account's canned response",
-         %{conn: conn, account: account} do
-      # Add a canned response for the first account
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a canned_response
+      another_account = insert(:account)
+
       canned_response =
         insert(:canned_response, %{
-          name: "Canned response name",
-          content: "Canned response content",
-          account: account
+          name: "Another canned response name",
+          content: "Another canned response content",
+          account: another_account
         })
 
-      new_account = insert(:account)
-      new_user = insert(:user, account: new_account)
-      new_conn = put_req_header(conn, "accept", "application/json")
-      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
-
+      # Using the original session, try to update the new account's canned_response
       conn =
         put(
-          new_authed_conn,
-          Routes.canned_response_path(new_authed_conn, :update, canned_response),
+          authed_conn,
+          Routes.canned_response_path(authed_conn, :update, canned_response),
           name: "New name",
           content: "New content"
         )
@@ -235,24 +229,22 @@ defmodule ChatApiWeb.CannedResponseControllerTest do
     end
 
     test "renders 404 when deleting another account's canned response",
-         %{conn: conn, account: account} do
-      # Add a canned response for the first account
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a canned_response
+      another_account = insert(:account)
+
       canned_response =
         insert(:canned_response, %{
-          name: "Canned response name",
-          content: "Canned response content",
-          account: account
+          name: "Another canned response name",
+          content: "Another canned response content",
+          account: another_account
         })
 
-      new_account = insert(:account)
-      new_user = insert(:user, account: new_account)
-      new_conn = put_req_header(conn, "accept", "application/json")
-      new_authed_conn = Pow.Plug.assign_current_user(new_conn, new_user, [])
-
+      # Using the original session, try to delete the new account's canned_response
       conn =
         delete(
-          new_authed_conn,
-          Routes.canned_response_path(new_authed_conn, :delete, canned_response)
+          authed_conn,
+          Routes.canned_response_path(authed_conn, :delete, canned_response)
         )
 
       assert json_response(conn, 404)


### PR DESCRIPTION
### Description

Adds a plug (nice, now I know how those work) to check authorization for show, update and delete actions on canned responses.

Adds some tests!

### Issue

https://github.com/papercups-io/papercups/issues/640

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
