### PR TITLE
Add authorization for note resource

### DIFF
--- a/test/chat_api_web/controllers/note_controller_test.exs
+++ b/test/chat_api_web/controllers/note_controller_test.exs
@@ -127,4 +127,38 @@ defmodule ChatApiWeb.NoteControllerTest do
       end
     end
   end
+
+  describe "check if account is authorized" do
+    test "render error if note does not belong to the current account", %{
+      authed_conn: authed_conn
+    } do
+      note = unauthorized_note()
+      conn = get(authed_conn, Routes.note_path(authed_conn, :show, note))
+
+      assert json_response(conn, 404)
+    end
+
+    test "render error if note to update does not belong to the current account", %{
+      authed_conn: authed_conn
+    } do
+      note = unauthorized_note()
+      conn = put(authed_conn, Routes.note_path(authed_conn, :update, note), note: @update_attrs)
+
+      assert json_response(conn, 404)
+    end
+
+    test "render error if note to delete does not belong to the current account", %{
+      authed_conn: authed_conn
+    } do
+      note = unauthorized_note()
+      conn = delete(authed_conn, Routes.note_path(authed_conn, :delete, note))
+
+      assert json_response(conn, 404)
+    end
+
+    defp unauthorized_note() do
+      account = insert(:account)
+      insert(:note, account: account)
+    end
+  end
 end


### PR DESCRIPTION
### Description

Adds plug to handle authorization for `show`, `update` and `delete` action in `Note_Controller`.


### Issue

#642 

## Checklist

- [X] Everything passes when running `mix test`
- [X] Ran `mix format`
- [X] No frontend compilation warnings
