### PR TITLE
Add authorize plug to tag and company controllers

### DIFF
--- a/lib/chat_api_web/controllers/company_controller.ex
+++ b/lib/chat_api_web/controllers/company_controller.ex
@@ -6,7 +6,7 @@ defmodule ChatApiWeb.CompanyController do
 
   action_fallback ChatApiWeb.FallbackController
 
-  plug :authorize when action not in [:index, :create]
+  plug :authorize when action in [:show, :update, :delete]
 
   defp authorize(conn, _) do
     id = conn.path_params["id"]

--- a/lib/chat_api_web/controllers/company_controller.ex
+++ b/lib/chat_api_web/controllers/company_controller.ex
@@ -6,6 +6,19 @@ defmodule ChatApiWeb.CompanyController do
 
   action_fallback ChatApiWeb.FallbackController
 
+  plug :authorize when action not in [:index, :create]
+
+  defp authorize(conn, _) do
+    id = conn.path_params["id"]
+
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         company = %{account_id: ^account_id} <- Companies.get_company!(id) do
+      assign(conn, :current_company, company)
+    else
+      _ -> ChatApiWeb.FallbackController.call(conn, {:error, :not_found}) |> halt()
+    end
+  end
+
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
@@ -29,25 +42,21 @@ defmodule ChatApiWeb.CompanyController do
   end
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, %{"id" => id}) do
-    company = Companies.get_company!(id)
-    render(conn, "show.json", company: company)
+  def show(conn, %{"id" => _id}) do
+    render(conn, "show.json", company: conn.assigns.current_company)
   end
 
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update(conn, %{"id" => id, "company" => company_params}) do
-    company = Companies.get_company!(id)
-
-    with {:ok, %Company{} = company} <- Companies.update_company(company, company_params) do
+  def update(conn, %{"id" => _id, "company" => company_params}) do
+    with {:ok, %Company{} = company} <-
+           Companies.update_company(conn.assigns.current_company, company_params) do
       render(conn, "show.json", company: company)
     end
   end
 
   @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def delete(conn, %{"id" => id}) do
-    company = Companies.get_company!(id)
-
-    with {:ok, %Company{}} <- Companies.delete_company(company) do
+  def delete(conn, %{"id" => _id}) do
+    with {:ok, %Company{}} <- Companies.delete_company(conn.assigns.current_company) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/chat_api_web/controllers/tag_controller.ex
+++ b/lib/chat_api_web/controllers/tag_controller.ex
@@ -6,7 +6,7 @@ defmodule ChatApiWeb.TagController do
 
   action_fallback ChatApiWeb.FallbackController
 
-  plug :authorize when action in [:show, :update, :delete]
+  plug :authorize when action not in [:index, :create]
 
   defp authorize(conn, _) do
     id = conn.path_params["id"]

--- a/lib/chat_api_web/controllers/tag_controller.ex
+++ b/lib/chat_api_web/controllers/tag_controller.ex
@@ -6,7 +6,7 @@ defmodule ChatApiWeb.TagController do
 
   action_fallback ChatApiWeb.FallbackController
 
-  plug :authorize when action not in [:index, :create]
+  plug :authorize when action in [:show, :update, :delete]
 
   defp authorize(conn, _) do
     id = conn.path_params["id"]

--- a/test/chat_api_web/controllers/company_controller_test.exs
+++ b/test/chat_api_web/controllers/company_controller_test.exs
@@ -46,6 +46,49 @@ defmodule ChatApiWeb.CompanyControllerTest do
     end
   end
 
+  describe "show company" do
+    test "shows company by id", %{
+      account: account,
+      authed_conn: authed_conn
+    } do
+      company =
+        insert(:company, %{
+          name: "Another company name",
+          account: account
+        })
+
+      conn =
+        get(
+          authed_conn,
+          Routes.company_path(authed_conn, :show, company.id)
+        )
+
+      assert json_response(conn, 200)["data"]
+    end
+
+    test "renders 404 when asking for another user's company", %{
+      authed_conn: authed_conn
+    } do
+      # Create a new account and give it a company
+      another_account = insert(:account)
+
+      company =
+        insert(:company, %{
+          name: "Another company name",
+          account: another_account
+        })
+
+      # Using the original session, try to delete the new account's company
+      conn =
+        get(
+          authed_conn,
+          Routes.company_path(authed_conn, :show, company.id)
+        )
+
+      assert json_response(conn, 404)
+    end
+  end
+
   describe "create company" do
     test "renders company when data is valid", %{
       authed_conn: authed_conn,
@@ -113,6 +156,28 @@ defmodule ChatApiWeb.CompanyControllerTest do
 
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "renders 404 when editing another account's company",
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a company
+      another_account = insert(:account)
+
+      company =
+        insert(:company, %{
+          name: "Another company name",
+          account: another_account
+        })
+
+      # Using the original session, try to update the new account's company
+      conn =
+        put(
+          authed_conn,
+          Routes.company_path(authed_conn, :update, company),
+          company: @update_attrs
+        )
+
+      assert json_response(conn, 404)
+    end
   end
 
   describe "delete company" do
@@ -123,6 +188,27 @@ defmodule ChatApiWeb.CompanyControllerTest do
       assert_error_sent 404, fn ->
         get(authed_conn, Routes.company_path(authed_conn, :show, company))
       end
+    end
+
+    test "renders 404 when deleting another account's company",
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a company
+      another_account = insert(:account)
+
+      company =
+        insert(:company, %{
+          name: "Another company name",
+          account: another_account
+        })
+
+      # Using the original session, try to delete the new account's company
+      conn =
+        delete(
+          authed_conn,
+          Routes.company_path(authed_conn, :delete, company)
+        )
+
+      assert json_response(conn, 404)
     end
   end
 end

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -71,7 +71,7 @@ defmodule ChatApiWeb.TagControllerTest do
 
       another_tag =
         insert(:tag, %{
-          name: "Another canned response name",
+          name: "Another tag name",
           account: another_account
         })
 
@@ -113,7 +113,7 @@ defmodule ChatApiWeb.TagControllerTest do
 
       another_tag =
         insert(:tag, %{
-          name: "Another canned response name",
+          name: "Another tag name",
           account: another_account
         })
 
@@ -141,14 +141,14 @@ defmodule ChatApiWeb.TagControllerTest do
       end
     end
 
-    test "renders 404 when deleting another account's canned response",
+    test "renders 404 when deleting another account's tag",
          %{authed_conn: authed_conn} do
       # Create a new account and give it a tag
       another_account = insert(:account)
 
       tag =
         insert(:tag, %{
-          name: "Another canned response name",
+          name: "Another tag name",
           account: another_account
         })
 

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -51,7 +51,6 @@ defmodule ChatApiWeb.TagControllerTest do
     setup [:create_tag]
 
     test "shows tag by id", %{
-      account: account,
       authed_conn: authed_conn,
       tag: tag
     } do


### PR DESCRIPTION
### Description

Adds a plug for authorizing some Tag and Company endpoints by default.

Also has tests for `:show`, `:update`, and `:delete` cases.

Initially I just did the `Tag` controller, but it was straight up a copy+paste job to cover the `Company` controller.

## Issues

https://github.com/papercups-io/papercups/issues/641
https://github.com/papercups-io/papercups/issues/643

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
