### PR TITLE
Improve how we handle redirect urls in Slack authorization flow

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -828,9 +828,14 @@ export const deleteEventSubscription = async (
     .set('Authorization', token);
 };
 
+type SlackAuthorizationParams = {
+  code: string;
+  type: string;
+  redirect_url?: string;
+};
+
 export const authorizeSlackIntegration = async (
-  code: string,
-  type: string,
+  params: SlackAuthorizationParams,
   token = getAccessToken()
 ) => {
   if (!token) {
@@ -839,7 +844,7 @@ export const authorizeSlackIntegration = async (
 
   return request
     .get(`/api/slack/oauth`)
-    .query({code, type})
+    .query(params)
     .set('Authorization', token)
     .then((res) => res.body.data);
 };

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -8,7 +8,7 @@ import Spinner from '../Spinner';
 import * as API from '../../api';
 import logger from '../../logger';
 import {EventSubscription, PersonalApiKey} from '../../types';
-import {IntegrationType} from './support';
+import {IntegrationType, getSlackRedirectUrl} from './support';
 import IntegrationsTable from './IntegrationsTable';
 import WebhooksTable from './WebhooksTable';
 import NewWebhookModal from './NewWebhookModal';
@@ -213,7 +213,11 @@ class IntegrationsOverview extends React.Component<Props, State> {
       case 'slack':
         const authorizationType = state || 'reply';
 
-        return API.authorizeSlackIntegration(code, authorizationType)
+        return API.authorizeSlackIntegration({
+          code,
+          type: authorizationType,
+          redirect_url: getSlackRedirectUrl(),
+        })
           .then((result) =>
             logger.debug('Successfully authorized Slack:', result)
           )

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -1,52 +1,9 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
-import qs from 'query-string';
 import {colors, Button, Popconfirm, Table, Tag, Text, Tooltip} from '../common';
-import {SLACK_CLIENT_ID, isDev} from '../../config';
-import {IntegrationType} from './support';
+import {IntegrationType, getSlackAuthUrl, getGoogleAuthUrl} from './support';
 import {MattermostAuthorizationButton} from './MattermostAuthorizationModal';
-
-const getSlackAuthUrl = (type = 'reply') => {
-  const origin = window.location.origin;
-  const redirect = `${origin}/integrations/slack`;
-  const scopes = [
-    'incoming-webhook',
-    'chat:write',
-    'channels:history',
-    'channels:manage',
-    'channels:read',
-    'chat:write.public',
-    'chat:write.customize',
-    'users:read',
-    'users:read.email',
-    'groups:history',
-    'groups:read',
-    'reactions:read',
-  ];
-  const userScopes = [
-    'channels:history',
-    'groups:history',
-    'chat:write',
-    'reactions:read',
-  ];
-  const q = {
-    state: type,
-    scope: scopes.join(' '),
-    user_scope: userScopes.join(' '),
-    client_id: SLACK_CLIENT_ID,
-    redirect_uri: redirect,
-  };
-  const query = qs.stringify(q);
-
-  return `https://slack.com/oauth/v2/authorize?${query}`;
-};
-
-const getGoogleAuthUrl = (client: 'gmail' | 'sheets') => {
-  const origin = isDev ? 'http://localhost:4000' : window.location.origin;
-
-  return `${origin}/google/auth?client=${client}`;
-};
 
 const IntegrationsTable = ({
   loading,

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -1,3 +1,6 @@
+import qs from 'query-string';
+import {SLACK_CLIENT_ID, isDev} from '../../config';
+
 export type IntegrationType = {
   key:
     | 'slack'
@@ -14,4 +17,49 @@ export type IntegrationType = {
   authorization_id: string | null;
   icon: string;
   description?: string;
+};
+
+export const getSlackRedirectUrl = () => {
+  const origin = window.location.origin;
+
+  return `${origin}/integrations/slack`;
+};
+
+export const getSlackAuthUrl = (type = 'reply') => {
+  const scopes = [
+    'incoming-webhook',
+    'chat:write',
+    'channels:history',
+    'channels:manage',
+    'channels:read',
+    'chat:write.public',
+    'chat:write.customize',
+    'users:read',
+    'users:read.email',
+    'groups:history',
+    'groups:read',
+    'reactions:read',
+  ];
+  const userScopes = [
+    'channels:history',
+    'groups:history',
+    'chat:write',
+    'reactions:read',
+  ];
+  const q = {
+    state: type,
+    scope: scopes.join(' '),
+    user_scope: userScopes.join(' '),
+    client_id: SLACK_CLIENT_ID,
+    redirect_uri: getSlackRedirectUrl(),
+  };
+  const query = qs.stringify(q);
+
+  return `https://slack.com/oauth/v2/authorize?${query}`;
+};
+
+export const getGoogleAuthUrl = (client: 'gmail' | 'sheets') => {
+  const origin = isDev ? 'http://localhost:4000' : window.location.origin;
+
+  return `${origin}/google/auth?client=${client}`;
 };

--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -26,6 +26,28 @@ defmodule ChatApi.Slack.Client do
     )
   end
 
+  @spec get_access_token(binary(), binary() | nil) :: Tesla.Env.result()
+  def get_access_token(code, nil) do
+    case System.get_env("PAPERCUPS_SLACK_REDIRECT_URI") do
+      nil -> get_access_token(code)
+      redirect_uri -> get_access_token(code, redirect_uri)
+    end
+  end
+
+  def get_access_token(code, redirect_uri) do
+    client_id = System.get_env("PAPERCUPS_SLACK_CLIENT_ID")
+    client_secret = System.get_env("PAPERCUPS_SLACK_CLIENT_SECRET")
+
+    get("/oauth.v2.access",
+      query: [
+        code: code,
+        redirect_uri: redirect_uri,
+        client_id: client_id,
+        client_secret: client_secret
+      ]
+    )
+  end
+
   @spec send_message(map(), binary()) :: Tesla.Env.result() | {:ok, nil}
   @doc """
   `message` looks like:

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -14,7 +14,8 @@ defmodule ChatApiWeb.SlackController do
 
     # TODO: improve error handling?
     with %{account_id: account_id, email: email} <- conn.assigns.current_user,
-         {:ok, response} <- Slack.Client.get_access_token(code),
+         redirect_uri <- Map.get(params, "redirect_url"),
+         {:ok, response} <- Slack.Client.get_access_token(code, redirect_uri),
          :ok <- Logger.info("Slack OAuth response: #{inspect(response)}"),
          %{body: body} <- response,
          %{


### PR DESCRIPTION
### Description

Improve how we handle redirect urls in Slack authorization flow.

### Issue

Makes it possible to support multiple redirect urls, which is necessary for having our Slack app work in our EU edition.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
