### PR TITLE
Improve error logging with `Sentry.LoggerBackend`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,14 @@ config :logger, :console,
   metadata: [:request_id],
   backends: [:console, Sentry.LoggerBackend]
 
+config :logger, Sentry.LoggerBackend,
+  # Also send warn messages
+  level: :warn,
+  # Send messages from Plug/Cowboy
+  excluded_domains: [],
+  # Send messages like `Logger.error("error")` to Sentry
+  capture_log_messages: true
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,8 @@ config :chat_api, ChatApiWeb.Endpoint,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  metadata: [:request_id],
+  backends: [:console, Sentry.LoggerBackend]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,11 +21,13 @@ config :chat_api, ChatApiWeb.Endpoint,
   pubsub_server: ChatApi.PubSub,
   live_view: [signing_salt: "pRVXwt3k"]
 
+config :logger,
+  backends: [:console, Sentry.LoggerBackend]
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id],
-  backends: [:console, Sentry.LoggerBackend]
+  metadata: [:request_id]
 
 config :logger, Sentry.LoggerBackend,
   # Also send warn messages


### PR DESCRIPTION
### Description

Ideally all logs from `Logger.error` would go to Sentry as well... let's see if this works 🤞 

### Issue

Better insights into errors.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
