### PR TITLE
Filter conversations by tag

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -18,6 +18,7 @@ defmodule ChatApi.Conversations do
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
+    |> filter_by_tag(filters)
     |> order_by_most_recent_message()
     |> preload([:customer, messages: [:attachments, :customer, user: :profile]])
     |> Repo.all()
@@ -48,6 +49,7 @@ defmodule ChatApi.Conversations do
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
     |> where([c], is_nil(c.archived_at))
+    |> filter_by_tag(filters)
     |> order_by_most_recent_message()
     |> preload([:customer, messages: ^messages_query])
     |> Repo.all()
@@ -454,6 +456,15 @@ defmodule ChatApi.Conversations do
     |> get_tag(tag_id)
     |> Repo.delete()
   end
+
+  @spec filter_by_tag(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  def filter_by_tag(query, %{"tag_id" => tag_id}) when not is_nil(tag_id) do
+    query
+    |> join(:left, [c], t in assoc(c, :tags))
+    |> where([_c, t], t.id == ^tag_id)
+  end
+
+  def filter_by_tag(query, _filters), do: query
 
   @spec mark_activity(String.t()) ::
           {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -61,6 +61,25 @@ defmodule ChatApi.ConversationsTest do
 
       assert result_ids == [not_archived_conversation.id]
     end
+
+    test "filters conversations for an account by tag", %{
+      account: account,
+      conversation: conversation
+    } do
+      tag = insert(:tag)
+      Conversations.add_tag(conversation, tag.id)
+
+      result_ids =
+        account.id
+        |> Conversations.list_conversations_by_account(%{"tag_id" => tag.id})
+        |> Enum.map(& &1.id)
+
+      assert result_ids == [conversation.id]
+
+      Conversations.remove_tag(conversation, tag.id)
+
+      assert [] = Conversations.list_conversations_by_account(account.id, %{"tag_id" => tag.id})
+    end
   end
 
   describe "find_by_customer/2" do


### PR DESCRIPTION
### Description

Make it possible to filter conversations by tag in `ChatApi.Conversations.list_conversations_by_account/2`

### Issue

Required for https://github.com/papercups-io/papercups/issues/635

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
