### PR TITLE
Add Bodyguard library to canned responses

### DIFF
--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -1,4 +1,6 @@
 defmodule ChatApi.CannedResponses do
+  defdelegate authorize(action, user, params), to: ChatApi.CannedResponses.Policy
+
   @moduledoc """
   The CannedResponses context.
   """
@@ -46,4 +48,25 @@ defmodule ChatApi.CannedResponses do
   def change_canned_response(%CannedResponse{} = canned_response, attrs \\ %{}) do
     CannedResponse.changeset(canned_response, attrs)
   end
+end
+
+defmodule ChatApi.CannedResponses.Policy do
+  @behaviour Bodyguard.Policy
+
+  # Require account_id check for getting, updating, deleting
+  def authorize(
+        action,
+        %{account_id: account_id} = _user,
+        %{account_id: account_id} = _canned_response
+      )
+      when action in [:get_canned_response!, :update_canned_response, :delete_canned_response],
+      do: :ok
+
+  # Don't require authorization check when listing or creating
+  def authorize(action, _, _)
+      when action in [:list_canned_responses, :create_canned_response],
+      do: :ok
+
+  # Catch-all: deny everything else
+  def authorize(_, _, _), do: {:error, :not_found}
 end

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -6,9 +6,10 @@ defmodule ChatApiWeb.CannedResponseController do
 
   action_fallback ChatApiWeb.FallbackController
 
-  plug :get_canned_response when action in [:show, :update, :delete]
+  @unauthorized_actions [:index, :create]
 
-  # Do the check
+  plug :get_canned_response when action not in @unauthorized_actions
+
   plug Bodyguard.Plug.Authorize,
        [
          policy: CannedResponses.Policy,
@@ -17,7 +18,7 @@ defmodule ChatApiWeb.CannedResponseController do
          params: {__MODULE__, :extract_canned_response},
          fallback: ChatApiWeb.FallbackController
        ]
-       when action in [:show, :update, :delete]
+       when action not in @unauthorized_actions
 
   # Helper for the Authorize plug
   def current_user(conn), do: conn.assigns.current_user

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -6,19 +6,6 @@ defmodule ChatApiWeb.CannedResponseController do
 
   action_fallback ChatApiWeb.FallbackController
 
-  plug :authorize when action in [:show, :update, :delete]
-
-  defp authorize(conn, _) do
-    id = conn.path_params["id"]
-
-    with %{account_id: account_id} <- conn.assigns.current_user,
-         canned_response = %{account_id: ^account_id} <- CannedResponses.get_canned_response!(id) do
-      assign(conn, :current_canned_response, canned_response)
-    else
-      _ -> ChatApiWeb.FallbackController.call(conn, {:error, :not_found}) |> halt()
-    end
-  end
-
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     with %{account_id: account_id} <- conn.assigns.current_user do
@@ -42,25 +29,34 @@ defmodule ChatApiWeb.CannedResponseController do
   end
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def show(conn, _params) do
-    render(conn, "show.json", canned_response: conn.assigns.current_canned_response)
+  def show(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with :ok <- Bodyguard.permit(CannedResponses, :get_canned_response!, user, canned_response) do
+      render(conn, "show.json", canned_response: canned_response)
+    end
   end
 
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def update(conn, %{"canned_response" => canned_response_params}) do
-    with {:ok, %CannedResponse{} = updated_canned_response} <-
-           CannedResponses.update_canned_response(
-             conn.assigns.current_canned_response,
-             canned_response_params
-           ) do
-      render(conn, "show.json", canned_response: updated_canned_response)
+  def update(conn, %{"id" => id, "canned_response" => canned_response_params}) do
+    user = conn.assigns.current_user
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with :ok <- Bodyguard.permit(CannedResponses, :update_canned_response, user, canned_response),
+         {:ok, %CannedResponse{} = canned_response} <-
+           CannedResponses.update_canned_response(canned_response, canned_response_params) do
+      render(conn, "show.json", canned_response: canned_response)
     end
   end
 
   @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def delete(conn, _params) do
-    with {:ok, %CannedResponse{}} <-
-           CannedResponses.delete_canned_response(conn.assigns.current_canned_response) do
+  def delete(conn, %{"id" => id}) do
+    user = conn.assigns.current_user
+    canned_response = CannedResponses.get_canned_response!(id)
+
+    with :ok <- Bodyguard.permit(CannedResponses, :delete_canned_response, user, canned_response),
+         {:ok, %CannedResponse{}} <- CannedResponses.delete_canned_response(canned_response) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,8 @@ defmodule ChatApi.MixProject do
       {:tzdata, "~> 1.0.5"},
       {:scrivener_ecto, "~> 2.0"},
       {:floki, "~> 0.30.0"},
-      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false}
+      {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
+      {:bodyguard, "~> 2.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "bodyguard": {:hex, :bodyguard, "2.4.1", "223df8fa7ac6bd9acd959054aebc386738d3d458fbc02703dd3df341467e3ff6", [:mix], [{:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "8f570352941d4e43c0f795e4a27c58cb252ee9acdfae6ea16fcd17d12df995f7"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "certifi": {:hex, :certifi, "2.5.2", "b7cfeae9d2ed395695dd8201c57a2d019c0c43ecaf8b8bcb9320b40d6662f340", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "3b3b5f36493004ac3455966991eaf6e768ce9884693d9968055aeeeb1e575040"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},


### PR DESCRIPTION
### Description

Switches hand-rolled auth in controller to [Bodyguard](https://hexdocs.pm/bodyguard/readme.html) auth, with auth policy defined in context. 

### Issue

As discussed in https://github.com/papercups-io/papercups/issues/641


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
