### PR TITLE
Set frontend env variables from server

### DIFF
--- a/assets/public/index.html
+++ b/assets/public/index.html
@@ -25,6 +25,10 @@
     -->
     <title>Papercups</title>
 
+    <script>
+      window.__ENV__ = __SERVER_ENV_DATA__;
+    </script>
+
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <!-- TODO: move Google Analytics id to environment variable -->
     <script

--- a/assets/src/analytics.ts
+++ b/assets/src/analytics.ts
@@ -1,14 +1,14 @@
 import * as Sentry from '@sentry/react';
 import LogRocket from 'logrocket';
 import posthog from 'posthog-js';
-import {isDev} from './config';
+import {isDev, env} from './config';
 
 const {
   REACT_APP_SENTRY_DSN,
   REACT_APP_LOGROCKET_ID,
   REACT_APP_POSTHOG_TOKEN = 'cQo4wipp5ipWWXhTN8kTacBItgqo457yDRtzCMOr-Tw',
   REACT_APP_POSTHOG_API_HOST = 'https://app.posthog.com',
-} = process.env;
+} = env;
 
 export const isSentryEnabled = REACT_APP_SENTRY_DSN && !isDev;
 export const isLogRocketEnabled = REACT_APP_LOGROCKET_ID && !isDev;

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -24,7 +24,7 @@ import {
   TeamOutlined,
   VideoCameraOutlined,
 } from './icons';
-import {BASE_URL, isDev, isEuEdition, isHostedProd} from '../config';
+import {BASE_URL, env, isDev, isEuEdition, isHostedProd} from '../config';
 import analytics from '../analytics';
 import {hasValidStripeKey} from '../utils';
 import {Account, User} from '../types';
@@ -57,7 +57,7 @@ import TagDetailsPage from './tags/TagDetailsPage';
 const {
   REACT_APP_STORYTIME_ENABLED,
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
-} = process.env;
+} = env;
 
 const TITLE_FLASH_INTERVAL = 2000;
 

--- a/assets/src/components/billing/BillingOverview.tsx
+++ b/assets/src/components/billing/BillingOverview.tsx
@@ -34,11 +34,10 @@ import {
 } from './support';
 import logger from '../../logger';
 import {LITE_PRICE, STARTER_PRICE, TEAM_PRICE} from '../../constants';
+import {env} from '../../config';
 import './Billing.css';
 
-const stripe = loadStripe(
-  process.env.REACT_APP_STRIPE_PUBLIC_KEY || 'pk_test_xxxxx'
-);
+const stripe = loadStripe(env.REACT_APP_STRIPE_PUBLIC_KEY);
 
 const BillingBreakdownTable = ({
   loading,

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -11,8 +11,9 @@ import {
 } from '../common';
 import {Message, MessageType, User} from '../../types';
 import {PaperClipOutlined} from '../icons';
+import {env} from '../../config';
 
-const {REACT_APP_FILE_UPLOADS_ENABLED} = process.env;
+const {REACT_APP_FILE_UPLOADS_ENABLED} = env;
 
 const fileUploadsEnabled = (accountId?: string) => {
   const enabled = REACT_APP_FILE_UPLOADS_ENABLED || '';

--- a/assets/src/components/demo/BotDemo.tsx
+++ b/assets/src/components/demo/BotDemo.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
 } from '../common';
 import {DeleteOutlined, RightCircleOutlined} from '../icons';
-import {BASE_URL} from '../../config';
+import {BASE_URL, env} from '../../config';
 import * as API from '../../api';
 import logger from '../../logger';
 import {getBotDemoFaqs, setBotDemoFaqs} from '../../storage';
@@ -24,7 +24,7 @@ import ChatWidget from '@papercups-io/chat-widget';
 
 const {
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
-} = process.env;
+} = env;
 
 type FAQ = {
   q: string;

--- a/assets/src/components/demo/Demo.tsx
+++ b/assets/src/components/demo/Demo.tsx
@@ -13,7 +13,7 @@ import {
   Title,
 } from '../common';
 import {RightCircleOutlined} from '../icons';
-import {BASE_URL, isDev} from '../../config';
+import {BASE_URL, env, isDev} from '../../config';
 import * as API from '../../api';
 import logger from '../../logger';
 // Testing widget in separate package
@@ -24,7 +24,7 @@ import ChatWidget from '@papercups-io/chat-widget';
 const {
   REACT_APP_STORYTIME_ENABLED,
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
-} = process.env;
+} = env;
 
 type Props = RouteComponentProps & {};
 type State = {

--- a/assets/src/config.ts
+++ b/assets/src/config.ts
@@ -15,8 +15,6 @@ export const env = {
   ...serverEnvData,
 };
 
-console.log('!!!', env);
-
 const hostname = window.location.hostname;
 
 export const isHostedProd =

--- a/assets/src/config.ts
+++ b/assets/src/config.ts
@@ -8,16 +8,24 @@ export const isDev = Boolean(
     )
 );
 
+const serverEnvData = (window as any).__ENV__ || {};
+
+export const env = {
+  ...process.env,
+  ...serverEnvData,
+};
+
+console.log('!!!', env);
+
 const hostname = window.location.hostname;
 
 export const isHostedProd =
   hostname === 'app.papercups.io' || hostname === 'app.papercups-eu.io';
 
 export const isEuEdition =
-  process.env.REACT_APP_EU_EDITION === 'true' ||
-  process.env.REACT_APP_EU_EDITION === '1';
+  env.REACT_APP_EU_EDITION === 'true' || env.REACT_APP_EU_EDITION === '1';
 
-export const REACT_URL = process.env.REACT_APP_URL || 'app.papercups.io';
+export const REACT_URL = env.REACT_APP_URL || 'app.papercups.io';
 
 export const BASE_URL = isDev
   ? 'http://localhost:4000'
@@ -28,4 +36,4 @@ export const FRONTEND_BASE_URL = isDev ? 'http://localhost:3000' : BASE_URL;
 
 // Defaults to Papercups client ID (it's ok for this value to be public)
 export const SLACK_CLIENT_ID =
-  process.env.REACT_APP_SLACK_CLIENT_ID || '1192316529232.1250363411891';
+  env.REACT_APP_SLACK_CLIENT_ID || '1192316529232.1250363411891';

--- a/assets/src/logger.tsx
+++ b/assets/src/logger.tsx
@@ -4,7 +4,7 @@ import qs from 'query-string';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import {atomOneLight} from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import {notification, Divider} from './components/common';
-import {isHostedProd} from './config';
+import {env, isHostedProd} from './config';
 
 const noop = () => {};
 
@@ -104,7 +104,7 @@ const stringify = (data: any) => {
 
 const {debug = 0} = qs.parse(window?.location?.search || '');
 const forceDebugModeEnabled =
-  !!Number(debug) || !!Number(process.env.REACT_APP_DEBUG_MODE_ENABLED);
+  !!Number(debug) || !!Number(env.REACT_APP_DEBUG_MODE_ENABLED);
 
 const callback = (type: Level, ...args: any) => {
   const description = args.map((arg: any, idx: number) => {

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -1,11 +1,12 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import qs from 'query-string';
+import {env} from './config';
 import {Message} from './types';
 
 dayjs.extend(utc);
 
-const {REACT_APP_STRIPE_PUBLIC_KEY} = process.env;
+const {REACT_APP_STRIPE_PUBLIC_KEY} = env;
 
 export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 

--- a/lib/chat_api_web/controllers/page_controller.ex
+++ b/lib/chat_api_web/controllers/page_controller.ex
@@ -3,6 +3,35 @@ defmodule ChatApiWeb.PageController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
-    html(conn, File.read!("./priv/static/index.html"))
+    file =
+      "./priv/static/index.html"
+      |> File.read!()
+      |> String.replace(
+        "__SERVER_ENV_DATA__",
+        Jason.encode!(server_env_data(), escape: :html_safe)
+      )
+
+    html(conn, file)
+  end
+
+  defp server_env_data() do
+    %{
+      REACT_APP_SENTRY_DSN: System.get_env("REACT_APP_SENTRY_DSN"),
+      REACT_APP_LOGROCKET_ID: System.get_env("REACT_APP_LOGROCKET_ID"),
+      REACT_APP_POSTHOG_TOKEN:
+        System.get_env("REACT_APP_POSTHOG_TOKEN", "cQo4wipp5ipWWXhTN8kTacBItgqo457yDRtzCMOr-Tw"),
+      REACT_APP_POSTHOG_API_HOST:
+        System.get_env("REACT_APP_POSTHOG_API_HOST", "https://app.posthog.com"),
+      REACT_APP_DEBUG_MODE_ENABLED: System.get_env("REACT_APP_DEBUG_MODE_ENABLED"),
+      REACT_APP_EU_EDITION: System.get_env("REACT_APP_EU_EDITION"),
+      REACT_APP_URL: System.get_env("REACT_APP_URL", "app.papercups.io"),
+      REACT_APP_SLACK_CLIENT_ID:
+        System.get_env("REACT_APP_SLACK_CLIENT_ID", "1192316529232.1250363411891"),
+      REACT_APP_STRIPE_PUBLIC_KEY: System.get_env("REACT_APP_STRIPE_PUBLIC_KEY"),
+      REACT_APP_FILE_UPLOADS_ENABLED: System.get_env("REACT_APP_FILE_UPLOADS_ENABLED"),
+      REACT_APP_STORYTIME_ENABLED: System.get_env("REACT_APP_STORYTIME_ENABLED"),
+      REACT_APP_ADMIN_ACCOUNT_ID:
+        System.get_env("REACT_APP_ADMIN_ACCOUNT_ID", "eb504736-0f20-4978-98ff-1a82ae60b266")
+    }
   end
 end


### PR DESCRIPTION
### Description

Sets `window.__ENV__` on server so we don't require a complete redeploy whenever we need to update these env variables on the frontend.

### Issue

https://create-react-app.dev/docs/title-and-meta-tags/#injecting-data-from-the-server-into-the-page

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
