### PR TITLE
Implement Slack reminders (wip)

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -96,7 +96,9 @@ defmodule ChatApi.Conversations do
         on: not is_nil(most_recent_message.customer_id)
       )
 
-    Repo.all(query)
+    query
+    |> preload([:customer, messages: ^most_recent_message_query])
+    |> Repo.all()
   end
 
   @spec list_other_recent_conversations(Conversation.t(), integer(), map()) :: [Conversation.t()]

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -28,6 +28,18 @@ defmodule ChatApi.Users do
     |> Repo.preload([:profile, :settings])
   end
 
+  @spec list_slackable_users_from_ids(binary()) :: [User.t()]
+  def list_slackable_users_from_ids(user_ids) do
+    user_query =
+      from u in User,
+        where: u.id in ^user_ids,
+        join: p in assoc(u, :profile),
+        where: not is_nil(p.slack_user_id)
+
+    Repo.all(user_query)
+    |> Repo.preload([:profile, :settings])
+  end
+
   @spec find_by_id!(integer() | binary()) :: User.t()
   def find_by_id!(user_id) do
     Repo.get!(User, user_id)

--- a/lib/workers/send_slack_reminders.ex
+++ b/lib/workers/send_slack_reminders.ex
@@ -13,4 +13,21 @@ defmodule ChatApi.Workers.SendSlackReminders do
     |> Enum.reject(&is_nil/1)
     |> Users.list_slackable_users_from_ids()
   end
+
+  @spec group_conversations_by_slackable_user([Conversation.t()]) :: [
+          {binary(), [Conversation.t()]}
+        ]
+  def group_conversations_by_slackable_user(conversations) do
+    slackable_users = find_slackable_users(conversations)
+    slackable_user_ids = slackable_users |> Enum.map(& &1.id)
+
+    conversations
+    |> Enum.filter(&(&1.assignee_id in slackable_user_ids))
+    |> Enum.group_by(& &1.assignee_id)
+    |> Map.to_list()
+    |> Enum.map(fn {user_id, conversations} ->
+      user = slackable_users |> Enum.find(&(&1.id == user_id))
+      {user, conversations}
+    end)
+  end
 end

--- a/lib/workers/send_slack_reminders.ex
+++ b/lib/workers/send_slack_reminders.ex
@@ -30,4 +30,20 @@ defmodule ChatApi.Workers.SendSlackReminders do
       {user, conversations}
     end)
   end
+
+  def format_slack_reminder({user, conversations}) do
+    header =
+      "Hey #{user.profile.display_name}! Here are some conversations you haven't gotten back to in over 24 hours:"
+
+    conversation_summaries = Enum.map(conversations, &format_conversation_line/1)
+
+    ([header] ++ conversation_summaries)
+    |> Enum.join("\n\n")
+  end
+
+  def format_conversation_line(conversation) do
+    customer = conversation.customer_id |> Customers.get_customer!()
+    last_customer_message = conversation.messages |> hd()
+    "**#{customer.name}** (#{last_customer_message.inserted_at}): '#{last_customer_message.body}'"
+  end
 end

--- a/lib/workers/send_slack_reminders.ex
+++ b/lib/workers/send_slack_reminders.ex
@@ -1,0 +1,8 @@
+defmodule ChatApi.Workers.SendSlackReminders do
+  alias ChatApi.Conversations
+
+  @spec list_forgotten_conversations :: [ChatApi.Conversations.Conversation.t()]
+  def list_forgotten_conversations() do
+    Conversations.list_forgotten_conversations(24)
+  end
+end

--- a/lib/workers/send_slack_reminders.ex
+++ b/lib/workers/send_slack_reminders.ex
@@ -1,8 +1,16 @@
 defmodule ChatApi.Workers.SendSlackReminders do
-  alias ChatApi.Conversations
+  alias ChatApi.{Conversations, Conversations.Conversation, Users, Users.User}
 
   @spec list_forgotten_conversations :: [ChatApi.Conversations.Conversation.t()]
   def list_forgotten_conversations() do
     Conversations.list_forgotten_conversations(24)
+  end
+
+  @spec find_slackable_users([Conversation.t()]) :: [User.t()]
+  def find_slackable_users(conversations) do
+    conversations
+    |> Enum.map(& &1.assignee_id)
+    |> Enum.reject(&is_nil/1)
+    |> Users.list_slackable_users_from_ids()
   end
 end

--- a/test/workers/send_slack_reminders_test.ex
+++ b/test/workers/send_slack_reminders_test.ex
@@ -1,0 +1,67 @@
+defmodule ChatApi.SendConversationReplyEmailTest do
+  use ChatApi.DataCase, async: true
+
+  import ChatApi.Factory
+
+  setup do
+    account = insert(:account)
+    user = insert(:user, account: account)
+    customer = insert(:customer, account: account)
+
+    {:ok, account: account, customer: customer, user: user}
+  end
+
+  describe "list_forgotten_conversations/0" do
+    test "finds no conversations if no messages", %{
+      account: account,
+      customer: customer
+    } do
+      insert(:conversation, account: account, customer: customer, source: "chat")
+
+      assert [] = ChatApi.Workers.SendSlackReminders.list_forgotten_conversations()
+    end
+
+    test "finds conversation only if last message was from customer, sent more than 24 hours ago",
+         %{
+           account: account,
+           customer: customer,
+           user: user
+         } do
+      conversation = insert(:conversation, account: account, customer: customer, source: "chat")
+
+      insert(:message,
+        body: "I am a customer",
+        account: account,
+        conversation: conversation,
+        customer: customer,
+        user: nil,
+        sent_at: DateTime.add(DateTime.utc_now(), -:timer.hours(26), :millisecond)
+      )
+
+      assert [conversation] = ChatApi.Workers.SendSlackReminders.list_forgotten_conversations()
+
+      insert(:message,
+        body: "Hello customer, I am a user",
+        account: account,
+        conversation: conversation,
+        customer: nil,
+        user: user,
+        sent_at: DateTime.add(DateTime.utc_now(), -:timer.hours(25), :millisecond)
+      )
+
+      assert [] = ChatApi.Workers.SendSlackReminders.list_forgotten_conversations()
+
+      insert(:message,
+        body: "Hello user, customer here. goodbye now",
+        account: account,
+        conversation: conversation,
+        customer: customer,
+        user: nil,
+        seen_at: nil,
+        sent_at: DateTime.add(DateTime.utc_now(), -:timer.hours(3), :millisecond)
+      )
+
+      assert [] = ChatApi.Workers.SendSlackReminders.list_forgotten_conversations()
+    end
+  end
+end


### PR DESCRIPTION
### Description

Totally open to changes like naming nitpicks, code organization, logic, etc. 

WIP:
- [x] Adds query for forgotten conversations
- [x] Finds slackable users from forgotten conversations
- [x] Formats users, conversations, etc into a slack message
- [ ] Sends slackable users said slack message
- [ ] does this every day

### Issue

https://github.com/papercups-io/papercups/issues/536

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
