### PR TITLE
Set up Twilio authorization flow

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -690,6 +690,45 @@ export const deleteMattermostAuthorization = async (
     .set('Authorization', token);
 };
 
+export const createTwilioAuthorization = async (
+  authorization = {},
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/twilio/auth`)
+    .send({authorization})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const fetchTwilioAuthorization = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/twilio/authorization`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const deleteTwilioAuthorization = async (
+  authorizationId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/twilio/authorizations/${authorizationId}`)
+    .set('Authorization', token);
+};
+
 export const fetchGmailAuthorization = async (token = getAccessToken()) => {
   if (!token) {
     throw new Error('Invalid token!');

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -192,12 +192,14 @@ class IntegrationsOverview extends React.Component<Props, State> {
   };
 
   fetchTwilioIntegration = async (): Promise<IntegrationType> => {
+    const auth = await API.fetchTwilioAuthorization();
+
     return {
       key: 'twilio',
       integration: 'Twilio',
-      status: 'not_connected',
-      created_at: null,
-      authorization_id: null,
+      status: auth ? 'connected' : 'not_connected',
+      created_at: auth ? auth.created_at : null,
+      authorization_id: auth ? auth.id : null,
       icon: '/twilio.svg',
     };
   };

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -4,6 +4,7 @@ import {Box, Flex} from 'theme-ui';
 import {colors, Button, Popconfirm, Table, Tag, Text, Tooltip} from '../common';
 import {IntegrationType, getSlackAuthUrl, getGoogleAuthUrl} from './support';
 import {MattermostAuthorizationButton} from './MattermostAuthorizationModal';
+import {TwilioAuthorizationButton} from './TwilioAuthorizationModal';
 
 const IntegrationsTable = ({
   loading,
@@ -140,6 +141,13 @@ const IntegrationsTable = ({
                   <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
                 </a>
               </Tooltip>
+            );
+          case 'twilio':
+            return (
+              <TwilioAuthorizationButton
+                integration={record}
+                onUpdate={onUpdateIntegration}
+              />
             );
           // TODO: deprecate
           case 'slack:sync':

--- a/assets/src/components/integrations/TwilioAuthorizationModal.tsx
+++ b/assets/src/components/integrations/TwilioAuthorizationModal.tsx
@@ -21,6 +21,7 @@ const TwilioAuthorizationModal = ({
     {}
   );
   const [isSaving, setSaving] = React.useState(false);
+  const [error, setErrorMessage] = React.useState<string | null>(null);
 
   const handleSetAuthorization = async () => {
     setSaving(true);
@@ -31,7 +32,15 @@ const TwilioAuthorizationModal = ({
         : authorization;
       const result = await API.createTwilioAuthorization(params);
 
-      return onSuccess(result);
+      if (result.ok) {
+        setErrorMessage(null);
+
+        return onSuccess(result);
+      } else {
+        setErrorMessage(
+          'Invalid Twilio authorization details. Please check the inputs above and try again.'
+        );
+      }
     } catch (err) {
       logger.error('Error creating Twilio authorization!', err);
     } finally {
@@ -130,6 +139,10 @@ const TwilioAuthorizationModal = ({
             placeholder="+16501235555"
             onChange={handleChangePhoneNumber}
           />
+        </Box>
+
+        <Box>
+          <Text type="danger">{error}</Text>
         </Box>
       </Box>
     </Modal>

--- a/assets/src/components/integrations/TwilioAuthorizationModal.tsx
+++ b/assets/src/components/integrations/TwilioAuthorizationModal.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Button, Divider, Input, Modal, Paragraph, Text} from '../common';
+import * as API from '../../api';
+import {TwilioAuthorization} from '../../types';
+import logger from '../../logger';
+import {IntegrationType} from './support';
+
+const TwilioAuthorizationModal = ({
+  visible,
+  authorizationId,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  authorizationId?: string | null;
+  onSuccess: (authorization: TwilioAuthorization) => void;
+  onCancel: () => void;
+}) => {
+  const [authorization, setAuthorization] = React.useState<TwilioAuthorization>(
+    {}
+  );
+  const [isSaving, setSaving] = React.useState(false);
+
+  const handleSetAuthorization = async () => {
+    setSaving(true);
+
+    try {
+      const params = authorizationId
+        ? {...authorization, id: authorizationId}
+        : authorization;
+      const result = await API.createTwilioAuthorization(params);
+
+      return onSuccess(result);
+    } catch (err) {
+      logger.error('Error creating Twilio authorization!', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChangeAccountSid = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setAuthorization({...authorization, twilio_account_sid: e.target.value});
+
+  const handleChangeAuthToken = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setAuthorization({...authorization, twilio_auth_token: e.target.value});
+
+  const handleChangePhoneNumber = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setAuthorization({...authorization, from_phone_number: e.target.value});
+
+  const handleCancel = () => {
+    onCancel();
+    setAuthorization({});
+  };
+
+  const {
+    twilio_auth_token: authToken,
+    twilio_account_sid: accountSid,
+    from_phone_number: phoneNumber,
+  } = authorization;
+
+  return (
+    <Modal
+      title="Connect to Twilio"
+      visible={visible}
+      onOk={handleSetAuthorization}
+      onCancel={handleCancel}
+      footer={[
+        <Button key="cancel" onClick={handleCancel}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleSetAuthorization}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Paragraph>
+          <Text type="secondary">
+            Please provide your Twilio API credentials to get started. (TODO:
+            link to docs with walkthrough)
+          </Text>
+        </Paragraph>
+
+        <Divider />
+
+        <Box mb={3}>
+          <label htmlFor="twilio_account_sid">
+            <Text strong>Twilio account SID</Text>
+          </label>
+
+          <Input
+            id="twilio_account_sid"
+            type="text"
+            value={accountSid}
+            autoFocus
+            placeholder="AC1xxxxxa2b"
+            onChange={handleChangeAccountSid}
+          />
+        </Box>
+
+        <Box mb={3}>
+          <label htmlFor="twilio_auth_token">
+            <Text strong>Twilio auth token</Text>
+          </label>
+
+          <Input
+            id="twilio_auth_token"
+            type="text"
+            value={authToken}
+            placeholder="ab12cd34"
+            onChange={handleChangeAuthToken}
+          />
+        </Box>
+
+        <Box mb={3}>
+          <label htmlFor="from_phone_number">
+            <Text strong>Twilio phone number</Text>
+          </label>
+
+          <Input
+            id="from_phone_number"
+            type="text"
+            value={phoneNumber}
+            placeholder="+16501235555"
+            onChange={handleChangePhoneNumber}
+          />
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export const TwilioAuthorizationButton = ({
+  integration,
+  onUpdate,
+}: {
+  integration: IntegrationType;
+  onUpdate: () => void;
+}) => {
+  const [isOpen, setOpen] = React.useState(false);
+
+  const {status, authorization_id: authorizationId} = integration;
+  const isConnected = status === 'connected' && !!authorizationId;
+
+  const handleOpenModal = () => setOpen(true);
+  const handlCloseModal = () => setOpen(false);
+  const handleSuccess = () => {
+    onUpdate();
+    handlCloseModal();
+  };
+
+  const handleDisconnect = async () => {
+    if (!authorizationId) {
+      return;
+    }
+
+    return API.deleteTwilioAuthorization(authorizationId)
+      .then(() => onUpdate())
+      .catch((err) =>
+        logger.error('Error deleting Twilio authorization!', err)
+      );
+  };
+
+  return (
+    <>
+      {isConnected ? (
+        <Flex mx={-1}>
+          <Box mx={1}>
+            <Button onClick={handleOpenModal}>Update</Button>
+          </Box>
+          <Box mx={1}>
+            <Button danger onClick={handleDisconnect}>
+              Disconnect
+            </Button>
+          </Box>
+        </Flex>
+      ) : (
+        <Button onClick={handleOpenModal}>Connect</Button>
+      )}
+      <TwilioAuthorizationModal
+        visible={isOpen}
+        authorizationId={authorizationId}
+        onSuccess={handleSuccess}
+        onCancel={handlCloseModal}
+      />
+    </>
+  );
+};
+
+export default TwilioAuthorizationModal;

--- a/assets/src/components/integrations/TwilioAuthorizationModal.tsx
+++ b/assets/src/components/integrations/TwilioAuthorizationModal.tsx
@@ -91,8 +91,8 @@ const TwilioAuthorizationModal = ({
       <Box>
         <Paragraph>
           <Text type="secondary">
-            Please provide your Twilio API credentials to get started. (TODO:
-            link to docs with walkthrough)
+            Please provide your Twilio API credentials to get started.
+            {/* TODO: add link to docs once https://github.com/papercups-io/papercups/issues/677 is completed */}
           </Text>
         </Paragraph>
 

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -161,6 +161,13 @@ export type MattermostChannel = {
   team_name: string;
 };
 
+export type TwilioAuthorization = {
+  id?: string;
+  twilio_auth_token?: string;
+  twilio_account_sid?: string;
+  from_phone_number?: string;
+};
+
 export type WidgetIconVariant = 'outlined' | 'filled';
 
 export type WidgetSettings = {

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -54,6 +54,22 @@ defmodule ChatApi.Messages.Notification do
     message
   end
 
+  def notify(%Message{private: false} = message, :sms, _opts) do
+    Logger.info("Sending message notification: :sms")
+
+    Task.start(fn ->
+      # TODO: implement me!
+      #
+      # First, check if message parent conversation has `source: "sms"`
+      # Also check that the conversation customer has a valid phone number
+      # If true, use the message account ID to check for a twilio_authorization record
+      # If one exists, use it to send a message to the customer's phone number
+      nil
+    end)
+
+    message
+  end
+
   def notify(%Message{account_id: account_id} = message, :webhooks, _opts) do
     Logger.info("Sending message notification: :webhooks")
     # TODO: how should we handle errors/retry logic?

--- a/lib/chat_api/slack/event.ex
+++ b/lib/chat_api/slack/event.ex
@@ -81,6 +81,7 @@ defmodule ChatApi.Slack.Event do
         |> Messages.Notification.notify(:slack_support_channel)
         |> Messages.Notification.notify(:slack_company_channel)
         |> Messages.Notification.notify(:conversation_reply_email)
+        |> Messages.Notification.notify(:sms)
         |> Messages.Notification.notify(:mattermost)
         |> Messages.Helpers.handle_post_creation_conversation_updates()
       else

--- a/lib/chat_api/twilio.ex
+++ b/lib/chat_api/twilio.ex
@@ -38,6 +38,7 @@ defmodule ChatApi.Twilio do
   @spec create_or_update_authorization!(map()) ::
           {:ok, TwilioAuthorization.t()} | {:error, Ecto.Changeset.t()}
   def create_or_update_authorization!(attrs \\ %{}) do
+    # TODO: should we take the "account_id" into account as well?
     case attrs do
       %{"id" => id} when is_binary(id) ->
         id

--- a/lib/chat_api/twilio.ex
+++ b/lib/chat_api/twilio.ex
@@ -1,0 +1,5 @@
+defmodule ChatApi.Twilio do
+  @moduledoc """
+  The Twilio context.
+  """
+end

--- a/lib/chat_api/twilio.ex
+++ b/lib/chat_api/twilio.ex
@@ -2,4 +2,99 @@ defmodule ChatApi.Twilio do
   @moduledoc """
   The Twilio context.
   """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.Twilio.TwilioAuthorization
+
+  @spec list_twilio_authorizations() :: [TwilioAuthorization.t()]
+  def list_twilio_authorizations() do
+    Repo.all(TwilioAuthorization)
+  end
+
+  @spec get_twilio_authorization!(binary()) :: TwilioAuthorization.t()
+  def get_twilio_authorization!(id), do: Repo.get!(TwilioAuthorization, id)
+
+  @spec create_twilio_authorization(map()) ::
+          {:ok, TwilioAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def create_twilio_authorization(attrs \\ %{}) do
+    %TwilioAuthorization{}
+    |> TwilioAuthorization.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_twilio_authorization(TwilioAuthorization.t(), map()) ::
+          {:ok, TwilioAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def update_twilio_authorization(
+        %TwilioAuthorization{} = twilio_authorization,
+        attrs
+      ) do
+    twilio_authorization
+    |> TwilioAuthorization.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec create_or_update_authorization!(map()) ::
+          {:ok, TwilioAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def create_or_update_authorization!(attrs \\ %{}) do
+    case attrs do
+      %{"id" => id} when is_binary(id) ->
+        id
+        |> get_twilio_authorization!()
+        |> update_twilio_authorization(attrs)
+
+      params ->
+        create_twilio_authorization(params)
+    end
+  end
+
+  @spec delete_twilio_authorization(TwilioAuthorization.t()) ::
+          {:ok, TwilioAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def delete_twilio_authorization(%TwilioAuthorization{} = twilio_authorization) do
+    Repo.delete(twilio_authorization)
+  end
+
+  @spec change_twilio_authorization(TwilioAuthorization.t(), map()) :: Ecto.Changeset.t()
+  def change_twilio_authorization(
+        %TwilioAuthorization{} = twilio_authorization,
+        attrs \\ %{}
+      ) do
+    TwilioAuthorization.changeset(twilio_authorization, attrs)
+  end
+
+  @spec get_authorization_by_account(binary(), map()) :: TwilioAuthorization.t() | nil
+  def get_authorization_by_account(account_id, _filters \\ %{}) do
+    TwilioAuthorization
+    |> where(account_id: ^account_id)
+    |> order_by(desc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
+  @spec find_twilio_authorization(map()) :: TwilioAuthorization.t() | nil
+  def find_twilio_authorization(filters \\ %{}) do
+    TwilioAuthorization
+    |> where(^filter_authorizations_where(filters))
+    |> order_by(desc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
+  defp filter_authorizations_where(params) do
+    Enum.reduce(params, dynamic(true), fn
+      {:account_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.account_id == ^value)
+
+      {:twilio_account_sid, value}, dynamic ->
+        dynamic([r], ^dynamic and r.twilio_account_sid == ^value)
+
+      {:from_phone_number, value}, dynamic ->
+        dynamic([r], ^dynamic and r.from_phone_number == ^value)
+
+      {_, _}, dynamic ->
+        # Not a where parameter
+        dynamic
+    end)
+  end
 end

--- a/lib/chat_api/twilio/client.ex
+++ b/lib/chat_api/twilio/client.ex
@@ -1,0 +1,29 @@
+defmodule ChatApi.Twilio.Client do
+  @moduledoc """
+  A module for interacting with the Twilio API.
+  """
+
+  require Logger
+
+  @spec client(map() | map()) :: Tesla.Client.t()
+  def client(%{auth_token: token, account_sid: account_sid}) do
+    middleware = [
+      {Tesla.Middleware.BaseUrl, "https://api.twilio.com/2010-04-01"},
+      {Tesla.Middleware.Headers,
+       [{"Authorization", Plug.BasicAuth.encode_basic_auth(account_sid, token)}]},
+      Tesla.Middleware.FormUrlencoded,
+      Tesla.Middleware.Logger
+    ]
+
+    Tesla.client(middleware)
+  end
+
+  @spec send_message(map(), map()) :: Tesla.Env.result()
+  def send_message(params, %{account_sid: account_sid} = authorization) do
+    message = Map.new(params, fn {k, v} -> {k |> to_string() |> Macro.camelize(), v} end)
+
+    authorization
+    |> client()
+    |> Tesla.post("/Accounts/#{account_sid}/Messages.json", message)
+  end
+end

--- a/lib/chat_api/twilio/twilio_authorization.ex
+++ b/lib/chat_api/twilio/twilio_authorization.ex
@@ -1,0 +1,54 @@
+defmodule ChatApi.Twilio.TwilioAuthorization do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Users.User
+
+  @type t :: %__MODULE__{
+          twilio_auth_token: String.t(),
+          twilio_account_sid: String.t(),
+          from_phone_number: String.t(),
+          metadata: any(),
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          user_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "twilio_authorizations" do
+    field(:twilio_auth_token, :string, null: false)
+    field(:twilio_account_sid, :string, null: false)
+    field(:from_phone_number, :string, null: false)
+    field(:metadata, :map)
+
+    belongs_to(:account, Account)
+    belongs_to(:user, User, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(twilio_authorization, attrs) do
+    twilio_authorization
+    |> cast(attrs, [
+      :twilio_auth_token,
+      :twilio_account_sid,
+      :from_phone_number,
+      :metadata,
+      :user_id,
+      :account_id
+    ])
+    |> validate_required([
+      :twilio_auth_token,
+      :twilio_account_sid,
+      :from_phone_number,
+      :user_id,
+      :account_id
+    ])
+  end
+end

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -117,6 +117,7 @@ defmodule ChatApiWeb.NotificationChannel do
     |> Messages.Notification.notify(:mattermost)
     |> Messages.Notification.notify(:webhooks)
     |> Messages.Notification.notify(:conversation_reply_email)
+    |> Messages.Notification.notify(:sms)
   end
 
   @spec authorized?(any(), binary()) :: boolean()

--- a/lib/chat_api_web/controllers/mattermost_controller.ex
+++ b/lib/chat_api_web/controllers/mattermost_controller.ex
@@ -12,6 +12,7 @@ defmodule ChatApiWeb.MattermostController do
   def auth(conn, %{"authorization" => authorization}) do
     Logger.info("Params from Mattermost auth: #{inspect(authorization)}")
 
+    # TODO: verify that auth info works with Mattermost API before creating?
     with %{account_id: account_id, id: user_id} <- conn.assigns.current_user,
          params <- Map.merge(authorization, %{"account_id" => account_id, "user_id" => user_id}),
          {:ok, result} <- Mattermost.create_or_update_authorization!(params) do
@@ -124,6 +125,7 @@ defmodule ChatApiWeb.MattermostController do
       |> Messages.Notification.notify(:webhooks)
       |> Messages.Notification.notify(:slack)
       |> Messages.Notification.notify(:conversation_reply_email)
+      |> Messages.Notification.notify(:sms)
       |> Messages.Helpers.handle_post_creation_conversation_updates()
     end
   end

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -155,5 +155,7 @@ defmodule ChatApiWeb.MessageController do
     |> Messages.Notification.notify(:slack_company_channel)
     |> Messages.Notification.notify(:mattermost)
     |> Messages.Notification.notify(:webhooks)
+    |> Messages.Notification.notify(:conversation_reply_email)
+    |> Messages.Notification.notify(:sms)
   end
 end

--- a/lib/chat_api_web/controllers/twilio_controller.ex
+++ b/lib/chat_api_web/controllers/twilio_controller.ex
@@ -1,0 +1,64 @@
+defmodule ChatApiWeb.TwilioController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.Twilio
+  alias ChatApi.Twilio.TwilioAuthorization
+
+  require Logger
+
+  action_fallback(ChatApiWeb.FallbackController)
+
+  @spec auth(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def auth(conn, %{"authorization" => authorization}) do
+    Logger.info("Params from Twilio auth: #{inspect(authorization)}")
+
+    # TODO: verify that auth info works with Twilio API before creating?
+    with %{account_id: account_id, id: user_id} <- conn.assigns.current_user,
+         params <- Map.merge(authorization, %{"account_id" => account_id, "user_id" => user_id}),
+         {:ok, result} <- Twilio.create_or_update_authorization!(params) do
+      json(conn, %{data: %{ok: true, id: result.id}})
+    else
+      _ -> json(conn, %{data: %{ok: false}})
+    end
+  end
+
+  @spec authorization(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def authorization(conn, _payload) do
+    authorization =
+      conn
+      |> Pow.Plug.current_user()
+      |> Map.get(:account_id)
+      |> Twilio.get_authorization_by_account()
+
+    case authorization do
+      nil ->
+        json(conn, %{data: nil})
+
+      auth ->
+        json(conn, %{
+          data: %{
+            id: auth.id,
+            created_at: auth.inserted_at,
+            from_phone_number: auth.from_phone_number
+          }
+        })
+    end
+  end
+
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def delete(conn, %{"id" => id}) do
+    with %{account_id: _account_id} <- conn.assigns.current_user,
+         %TwilioAuthorization{} = auth <-
+           Twilio.get_twilio_authorization!(id),
+         {:ok, %TwilioAuthorization{}} <- Twilio.delete_twilio_authorization(auth) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  @spec webhook(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def webhook(conn, payload) do
+    Logger.debug("Payload from Twilio webhook: #{inspect(payload)}")
+    # TODO: implement me!
+    send_resp(conn, 200, "")
+  end
+end

--- a/lib/chat_api_web/controllers/twilio_controller.ex
+++ b/lib/chat_api_web/controllers/twilio_controller.ex
@@ -21,7 +21,7 @@ defmodule ChatApiWeb.TwilioController do
       {:error, :invalid_twilio_authorization, _} ->
         json(conn, %{data: %{ok: false, error: "Invalid Twilio authorization details."}})
 
-      error ->
+      _error ->
         json(conn, %{data: %{ok: false}})
     end
   end
@@ -63,6 +63,16 @@ defmodule ChatApiWeb.TwilioController do
   def webhook(conn, payload) do
     Logger.debug("Payload from Twilio webhook: #{inspect(payload)}")
     # TODO: implement me!
+    #
+    # When new SMS message comes in...
+    #   - Check if the receiving number matches one of our `twilio_authorizations`
+    #   - If it does, use that to determine the `account_id` (from the `twilio_authorizations` table)
+    # Next, find or create a conversation for the account (with `source: "sms"`)
+    #   - First, find customer by phone number (implement `Customers.find_by_phone/2`)
+    #   - If no customer exists, create new customer record and new conversation (with `source: "sms"`)
+    #   - If customer exists, fetch latest open conversation (with `source: "sms"`)
+    #   - If open conversation exists, add message to conversation
+    #   - Otherwise, create new conversation (with `source: "sms"`)
     send_resp(conn, 200, "")
   end
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -69,6 +69,7 @@ defmodule ChatApiWeb.Router do
     post("/slack/webhook", SlackController, :webhook)
     post("/slack/actions", SlackController, :actions)
     post("/mattermost/webhook", MattermostController, :webhook)
+    post("/twilio/webhook", TwilioController, :webhook)
     # TODO: move to protected route after testing?
     get("/hubspot/oauth", HubspotController, :oauth)
 
@@ -95,6 +96,9 @@ defmodule ChatApiWeb.Router do
     get("/mattermost/channels", MattermostController, :channels)
     get("/mattermost/authorization", MattermostController, :authorization)
     delete("/mattermost/authorizations/:id", MattermostController, :delete)
+    post("/twilio/auth", TwilioController, :auth)
+    get("/twilio/authorization", TwilioController, :authorization)
+    delete("/twilio/authorizations/:id", TwilioController, :delete)
     get("/google/auth", GoogleController, :auth)
     get("/google/oauth", GoogleController, :callback)
     get("/google/authorization", GoogleController, :authorization)

--- a/priv/repo/migrations/20210322230210_create_twilio_authorizations.exs
+++ b/priv/repo/migrations/20210322230210_create_twilio_authorizations.exs
@@ -1,0 +1,21 @@
+defmodule ChatApi.Repo.Migrations.CreateTwilioAuthorizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:twilio_authorizations, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:twilio_auth_token, :string, null: false)
+      add(:twilio_account_sid, :string, null: false)
+      add(:from_phone_number, :string, null: false)
+      add(:metadata, :map)
+
+      add(:account_id, references(:accounts, type: :uuid, on_delete: :delete_all), null: false)
+      add(:user_id, references(:users), null: false)
+
+      timestamps()
+    end
+
+    create(index(:twilio_authorizations, [:account_id]))
+    create(index(:twilio_authorizations, [:user_id]))
+  end
+end


### PR DESCRIPTION
### Description

This PR will set up the boilerplate logic for storing Twilio authorizations:
- [x] Add the `twilio_authorizations` table with `auth_token`, `account_sid`, `from_phone_number`, `account_id`, etc
- [x] Add CRUD methods for managing these authorizations
- [x] Set up the placeholder webhook URL to receive incoming SMS messages

_**In separate PR:**_
- When new SMS message comes in...
  - It hits our webhook URL, and we check if the receiving number matches one of our `twilio_authorizations`
  - If it does, use that to determine the `account_id` (should just exist on the `twilio_authorizations` table)
- Next, find or create a conversation for the account (with `source: "sms"` or something like that)
  - First, find customer by phone number
  - If no customer exists, create new customer record and new conversation (with `source: "sms"`)
  - If customer exists, fetch latest open conversation (with `source: "sms"`)
  - If open conversation exists, add message to conversation
  - Otherwise, create new conversation (with `source: "sms"`)
- When agent replies from dashboard/Slack/etc AND conversation `source: "sms"` AND customer has valid phone number, send SMS message to customer via Twilio API using account's `twilio_authorization` info

### Issue

Handles https://github.com/papercups-io/papercups/issues/674

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
