### PR TITLE
Change Datetime calls to specify milliseconds

### DIFF
--- a/test/chat_api/conversations/helpers_test.exs
+++ b/test/chat_api/conversations/helpers_test.exs
@@ -39,7 +39,7 @@ defmodule ChatApi.Conversations.HelpersTest do
 
     test "send_multiple_archived_updates/2 sends archived updates to multiple conversations",
          %{account: account, customer: customer} do
-      past = DateTime.add(DateTime.utc_now(), -:timer.hours(336))
+      past = DateTime.add(DateTime.utc_now(), -:timer.hours(336), :millisecond)
 
       insert_list(3, :conversation, %{
         account: account,

--- a/test/chat_api/conversations_test.exs
+++ b/test/chat_api/conversations_test.exs
@@ -309,7 +309,7 @@ defmodule ChatApi.ConversationsTest do
 
   describe "archive_conversations/1" do
     test "archives conversations which have been closed for more than 14 days" do
-      past = DateTime.add(DateTime.utc_now(), -:timer.hours(336))
+      past = DateTime.add(DateTime.utc_now(), -:timer.hours(336), :millisecond)
 
       closed_conversation = insert(:conversation, status: "closed")
 


### PR DESCRIPTION
### Description

Up to you if you think this is important, but I was bothered while writing some other tests based on the ones here. 

`:timer.hours/1` uses ms, but `DateTime.add/3` uses seconds by default unless you specify. The tests that I borrowed from didn't specify, so it led me to write incorrect tests. This should prevent that slight confusion in future.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
