### PR TITLE
Add tag searching

### DIFF
--- a/assets/src/components/tags/TagsOverview.tsx
+++ b/assets/src/components/tags/TagsOverview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Alert, Button, Paragraph, Table, Tag, Text, Title} from '../common';
+import {Alert, Button, Input, Paragraph, Table, Tag, Text, Title} from '../common';
 import {PlusOutlined} from '../icons';
 import * as API from '../../api';
 import * as T from '../../types';
@@ -61,17 +61,49 @@ const TagsTable = ({
 
 type Props = {};
 type State = {
-  loading: boolean;
-  refreshing: boolean;
+  filterQuery: string;
+  filteredTags: Array<T.Tag>;
   isNewTagModalVisible: boolean;
-  tags: Array<any>;
+  loading: boolean;
+  tags: Array<T.Tag>;
+};
+
+const filterTagsByQuery = (
+  tags: Array<T.Tag>,
+  query?: string
+): Array<T.Tag> => {
+  if (!query || !query.length) {
+    return tags;
+  }
+
+  return tags.filter((tag) => {
+    const {
+      id,
+      name,
+      description,
+    } = tag;
+
+    const words = [id, name, description]
+      .filter((str) => str && String(str).trim().length > 0)
+      .join(' ')
+      .replace('_', ' ')
+      .split(' ')
+      .map((str) => str.toLowerCase());
+
+    const queries = query.split(' ').map((str) => str.toLowerCase());
+
+    return words.some((word) => {
+      return queries.every((q) => word.indexOf(q) !== -1);
+    });
+  });
 };
 
 class TagsOverview extends React.Component<Props, State> {
   state: State = {
-    loading: true,
-    refreshing: false,
+    filteredTags: [],
+    filterQuery: '',
     isNewTagModalVisible: false,
+    loading: true,
     tags: [],
   };
 
@@ -79,11 +111,29 @@ class TagsOverview extends React.Component<Props, State> {
     await this.handleRefreshTags();
   }
 
+  handleSearchTags = (filterQuery: string) => {
+    const {tags = []} = this.state;
+
+    if (!filterQuery?.length) {
+      this.setState({filterQuery: '', filteredTags: tags});
+    }
+
+    this.setState({
+      filterQuery,
+      filteredTags: filterTagsByQuery(tags, filterQuery),
+    });
+  };
+
   handleRefreshTags = async () => {
     try {
+      const { filterQuery } = this.state;
       const tags = await API.fetchAllTags();
 
-      this.setState({tags, loading: false});
+      this.setState({
+        filteredTags: filterTagsByQuery(tags, filterQuery),
+        loading: false,
+        tags,
+      });
     } catch (err) {
       logger.error('Error loading tags!', err);
 
@@ -105,7 +155,7 @@ class TagsOverview extends React.Component<Props, State> {
   };
 
   render() {
-    const {loading, isNewTagModalVisible, tags = []} = this.state;
+    const {loading, isNewTagModalVisible, filteredTags = []} = this.state;
 
     return (
       <Box p={4} sx={{maxWidth: 1080}}>
@@ -145,8 +195,17 @@ class TagsOverview extends React.Component<Props, State> {
           />
         </Box>
 
+        <Box mb={3}>
+          <Input.Search
+            placeholder="Search tags..."
+            allowClear
+            onSearch={this.handleSearchTags}
+            style={{width: 400}}
+          />
+        </Box>
+
         <Box my={4}>
-          <TagsTable loading={loading} tags={tags} />
+          <TagsTable loading={loading} tags={filteredTags} />
         </Box>
       </Box>
     );

--- a/assets/src/components/tags/TagsOverview.tsx
+++ b/assets/src/components/tags/TagsOverview.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Alert, Button, Input, Paragraph, Table, Tag, Text, Title} from '../common';
+import {
+  Alert,
+  Button,
+  Input,
+  Paragraph,
+  Table,
+  Tag,
+  Text,
+  Title,
+} from '../common';
 import {PlusOutlined} from '../icons';
 import * as API from '../../api';
 import * as T from '../../types';
@@ -77,11 +86,7 @@ const filterTagsByQuery = (
   }
 
   return tags.filter((tag) => {
-    const {
-      id,
-      name,
-      description,
-    } = tag;
+    const {id, name, description} = tag;
 
     const words = [id, name, description]
       .filter((str) => str && String(str).trim().length > 0)
@@ -126,7 +131,7 @@ class TagsOverview extends React.Component<Props, State> {
 
   handleRefreshTags = async () => {
     try {
-      const { filterQuery } = this.state;
+      const {filterQuery} = this.state;
       const tags = await API.fetchAllTags();
 
       this.setState({


### PR DESCRIPTION
### Description

- Provides clientside filtering in the style of @reichert621's [additions to the customers page](https://github.com/papercups-io/papercups/blob/master/assets/src/components/customers/CustomersPage.tsx#L158-L165).
- Removes `state.refreshing` as it wasn't being used

### Issue

https://github.com/papercups-io/papercups/issues/571

### Screenshots
![image](https://p91.f3.n0.cdn.getcloudapp.com/items/llu5RxNy/3d24de8e-05e7-436d-81ca-4e52dc34ea35.gif?v=a35cb82e8c5f8f861d29e506c5d0372e)
![image](https://user-images.githubusercontent.com/525011/112250841-85709980-8c30-11eb-897b-70e75f6d3a3d.png)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
