### PR TITLE
Remove Google Analytics from dashboard

### DIFF
--- a/assets/public/index.html
+++ b/assets/public/index.html
@@ -30,21 +30,6 @@
         window.__ENV__ = __SERVER_ENV_DATA__;
       </script>
     <% } %>
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <!-- TODO: move Google Analytics id to environment variable -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_ANALYTICS_ID%"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', '%REACT_APP_GOOGLE_ANALYTICS_ID%');
-    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
### Description

This should make our dashboard cookie free.

(We can set up Plausible to replace it eventually if we need more analytics, but PostHog might be enough for now 🤷 )

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
