### PR TITLE
Fix unique constraint on tag name

### DIFF
--- a/lib/chat_api/tags/tag.ex
+++ b/lib/chat_api/tags/tag.ex
@@ -43,6 +43,6 @@ defmodule ChatApi.Tags.Tag do
     tag
     |> cast(attrs, [:name, :account_id, :description, :color, :creator_id])
     |> validate_required([:name, :account_id])
-    |> unique_constraint(:name)
+    |> unique_constraint([:name, :account_id])
   end
 end

--- a/priv/repo/migrations/20210326132156_fix_tag_name_index.exs
+++ b/priv/repo/migrations/20210326132156_fix_tag_name_index.exs
@@ -2,12 +2,11 @@ defmodule ChatApi.Repo.Migrations.FixTagNameIndex do
   use Ecto.Migration
 
   def up do
-    drop(unique_index(:tags, [:name]))
+    drop_if_exists(unique_index(:tags, [:name]))
     create(unique_index(:tags, [:name, :account_id]))
   end
 
   def down do
     drop(unique_index(:tags, [:name, :account_id]))
-    create(unique_index(:tags, [:name]))
   end
 end

--- a/priv/repo/migrations/20210326132156_fix_tag_name_index.exs
+++ b/priv/repo/migrations/20210326132156_fix_tag_name_index.exs
@@ -1,0 +1,13 @@
+defmodule ChatApi.Repo.Migrations.FixTagNameIndex do
+  use Ecto.Migration
+
+  def up do
+    drop(unique_index(:tags, [:name]))
+    create(unique_index(:tags, [:name, :account_id]))
+  end
+
+  def down do
+    drop(unique_index(:tags, [:name, :account_id]))
+    create(unique_index(:tags, [:name]))
+  end
+end


### PR DESCRIPTION
### Description

Fix unique constraint on tag name to be per account instead of system-wide.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
