### PR TITLE
Don't flash html title when dashboard tab is active

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -141,8 +141,6 @@ const DashboardHtmlHead = ({totalNumUnread}: {totalNumUnread: number}) => {
   const [htmlTitle, setHtmlTitle] = useState('Papercups');
   const [isHidden, setHidden] = useState(isWindowHidden(doc));
 
-  const onVisibilityChange = () => setHidden(isWindowHidden(doc));
-
   const toggleNotificationMessage = () => {
     if (totalNumUnread > 0 && htmlTitle.startsWith('Papercups') && isHidden) {
       setHtmlTitle(
@@ -154,15 +152,16 @@ const DashboardHtmlHead = ({totalNumUnread}: {totalNumUnread: number}) => {
   };
 
   useEffect(() => {
-    const {event} = getBrowserVisibilityInfo(document);
+    const {event} = getBrowserVisibilityInfo(doc);
+    const handler = () => setHidden(isWindowHidden(doc));
 
     if (!event) {
       return;
     }
 
-    doc.addEventListener(event, onVisibilityChange, false);
+    doc.addEventListener(event, handler, false);
 
-    return () => doc.removeEventListener(event, onVisibilityChange);
+    return () => doc.removeEventListener(event, handler);
   }, [doc]);
 
   useEffect(() => {


### PR DESCRIPTION
### Description

When the dashboard tab is active, it can be distracting to flash the title (e.g. for new messages)

### Issue

Reported in Slack

### Screenshots

**When active:**
![active-tab-no-flash](https://user-images.githubusercontent.com/5264279/113149841-71fd9980-9201-11eb-8cbc-7bedf1a2ec85.gif)

**When inactive/hidden:**
![inactive-tab-flash](https://user-images.githubusercontent.com/5264279/113149843-71fd9980-9201-11eb-8974-316137883e35.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
