### PR TITLE
Adds ability to send user invitation emails from Account Overview

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -626,6 +626,21 @@ export const generateUserInvitation = async (token = getAccessToken()) => {
     .then((res) => res.body.data);
 };
 
+export const sendUserInvitationEmail = async (
+  to_address: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/user_invitation_emails`)
+    .send({to_address})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const fetchSlackAuthorization = async (
   type = 'reply',
   token = getAccessToken()

--- a/assets/src/components/account/AccountOverview.tsx
+++ b/assets/src/components/account/AccountOverview.tsx
@@ -433,18 +433,12 @@ class AccountOverview extends React.Component<Props, State> {
                   </Flex>
                 </form>
               ) : (
-                <a onClick={this.handleClickOnInviteMoreLink}>
-                  <span
-                    style={{
-                      marginRight: '5px',
-                      display: 'inline-block',
-                      transform: 'translate(0, -1px)',
-                    }}
-                  >
-                    +
-                  </span>
-                  <span>Invite More</span>
-                </a>
+                <Button
+                  type="primary"
+                  onClick={this.handleClickOnInviteMoreLink}
+                >
+                  Invite teammate
+                </Button>
               )}
             </Box>
           )}

--- a/lib/chat_api/emails.ex
+++ b/lib/chat_api/emails.ex
@@ -58,6 +58,18 @@ defmodule ChatApi.Emails do
     |> deliver()
   end
 
+  @spec send_user_invitation_email(User.t(), Account.t(), binary(), binary()) :: deliver_result()
+  def send_user_invitation_email(user, account, to_address, invitation_token) do
+    Email.user_invitation(%{
+      company: account.company_name,
+      from_address: user.email,
+      from_name: format_sender_name(user, account),
+      invitation_token: invitation_token,
+      to_address: to_address
+    })
+    |> deliver()
+  end
+
   @spec send_via_gmail(binary(), map()) :: deliver_result()
   def send_via_gmail(
         access_token,

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -220,6 +220,89 @@ defmodule ChatApi.Emails.Email do
     """
   end
 
+  def user_invitation(
+        %{
+          company: company,
+          from_address: from_address,
+          from_name: from_name,
+          invitation_token: invitation_token,
+          to_address: to_address
+        } = _params
+      ) do
+    subject =
+      if from_name == company,
+        do: "You've been invited to join #{company} on Papercups!",
+        else: "#{from_name} has invited you to join #{company} on Papercups!"
+
+    intro_line =
+      if from_name == company,
+        do: "#{from_address} has invited you to join #{company} on Papercups!",
+        else: "#{from_name} (#{from_address}) has invited you to join #{company} on Papercups!"
+
+    invitation_url = "#{get_app_domain()}/registration/#{invitation_token}"
+
+    new()
+    |> to(to_address)
+    |> from({"Alex", @from_address})
+    |> reply_to("alex@papercups.io")
+    |> subject(subject)
+    |> html_body(
+      user_invitation_email_html(%{
+        intro_line: intro_line,
+        invitation_url: invitation_url
+      })
+    )
+    |> text_body(
+      user_invitation_email_text(%{
+        intro_line: intro_line,
+        invitation_url: invitation_url
+      })
+    )
+  end
+
+  defp user_invitation_email_text(
+         %{
+           invitation_url: invitation_url,
+           intro_line: intro_line
+         } = _params
+       ) do
+    """
+    Hi there!
+
+    #{intro_line}
+
+    Click the link below to sign up:
+
+    #{invitation_url}
+
+    Best,
+    Alex & Kam @ Papercups
+    """
+  end
+
+  # TODO: figure out a better way to create templates for these
+  defp user_invitation_email_html(
+         %{
+           invitation_url: invitation_url,
+           intro_line: intro_line
+         } = _params
+       ) do
+    """
+    <p>Hi there!</p>
+
+    <p>#{intro_line}</p>
+
+    <p>Click the link below to sign up:</p>
+
+    <a href="#{invitation_url}">#{invitation_url}</a>
+
+    <p>
+    Best,<br />
+    Alex & Kam @ Papercups
+    </p>
+    """
+  end
+
   def password_reset(%ChatApi.Users.User{email: email, password_reset_token: token} = _user) do
     new()
     |> to(email)

--- a/lib/chat_api_web/controllers/user_invitation_email_controller.ex
+++ b/lib/chat_api_web/controllers/user_invitation_email_controller.ex
@@ -1,0 +1,54 @@
+defmodule ChatApiWeb.UserInvitationEmailController do
+  use ChatApiWeb, :controller
+
+  alias ChatApi.{Accounts, UserInvitations}
+  alias ChatApi.UserInvitations.UserInvitation
+
+  plug ChatApiWeb.EnsureRolePlug, :admin when action in [:create]
+
+  action_fallback ChatApiWeb.FallbackController
+
+  @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def create(conn, %{"to_address" => to_address}) do
+    current_user = Pow.Plug.current_user(conn)
+
+    # TODO: consolidate logic related to checking user capacity in controllers.
+    if Accounts.has_reached_user_capacity?(current_user.account_id) do
+      conn
+      |> put_status(403)
+      |> json(%{
+        error: %{
+          status: 403,
+          message:
+            "You've hit the user limit for our free tier. " <>
+              "Try the premium plan free for 14 days to invite more users to your account!"
+        }
+      })
+    else
+      {:ok, %UserInvitation{} = user_invitation} =
+        UserInvitations.create_user_invitation(%{account_id: current_user.account_id})
+
+      enqueue_user_invitation_email(
+        current_user.id,
+        current_user.account_id,
+        to_address,
+        user_invitation.id
+      )
+
+      conn
+      |> put_status(:created)
+      |> json(%{})
+    end
+  end
+
+  def enqueue_user_invitation_email(user_id, account_id, to_address, invitation_token) do
+    %{
+      user_id: user_id,
+      account_id: account_id,
+      to_address: to_address,
+      invitation_token: invitation_token
+    }
+    |> ChatApi.Workers.SendUserInvitationEmail.new()
+    |> Oban.insert()
+  end
+end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -116,6 +116,7 @@ defmodule ChatApiWeb.Router do
     get("/browser_sessions/count", BrowserSessionController, :count)
 
     resources("/user_invitations", UserInvitationController, except: [:new, :edit])
+    resources("/user_invitation_emails", UserInvitationEmailController, only: [:create])
     resources("/accounts", AccountController, only: [:update, :delete])
     resources("/messages", MessageController, except: [:new, :edit])
     resources("/conversations", ConversationController, except: [:new, :edit, :create])

--- a/lib/workers/send_user_invitation_email.ex
+++ b/lib/workers/send_user_invitation_email.ex
@@ -23,12 +23,24 @@ defmodule ChatApi.Workers.SendUserInvitationEmail do
       account = Accounts.get_account!(account_id)
       Logger.info("Sending user invitation email to #{to_address}")
 
-      ChatApi.Emails.send_user_invitation_email(
-        user,
-        account,
-        to_address,
-        invitation_token
-      )
+      deliver_result =
+        ChatApi.Emails.send_user_invitation_email(
+          user,
+          account,
+          to_address,
+          invitation_token
+        )
+
+      case deliver_result do
+        {:ok, result} ->
+          Logger.info("Successfully sent user invitation email: #{result}")
+
+        {:warning, reason} ->
+          Logger.warn("Warning when sending user invitation email: #{inspect(reason)}")
+
+        {:error, reason} ->
+          Logger.error("Error when sending user invitation email: #{inspect(reason)}")
+      end
     else
       Logger.info("Skipping user invitation email to #{to_address}")
     end

--- a/lib/workers/send_user_invitation_email.ex
+++ b/lib/workers/send_user_invitation_email.ex
@@ -1,0 +1,46 @@
+defmodule ChatApi.Workers.SendUserInvitationEmail do
+  @moduledoc false
+
+  use Oban.Worker, queue: :mailers
+
+  alias ChatApi.{Accounts, Users}
+  alias ChatApi.Repo
+
+  require Logger
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{
+        args: %{
+          "user_id" => user_id,
+          "account_id" => account_id,
+          "to_address" => to_address,
+          "invitation_token" => invitation_token
+        }
+      }) do
+    if send_user_invitation_email_enabled?() do
+      user = Users.find_by_id!(user_id) |> Repo.preload([:profile])
+      account = Accounts.get_account!(account_id)
+      Logger.info("Sending user invitation email to #{to_address}")
+
+      ChatApi.Emails.send_user_invitation_email(
+        user,
+        account,
+        to_address,
+        invitation_token
+      )
+    else
+      Logger.info("Skipping user invitation email to #{to_address}")
+    end
+
+    :ok
+  end
+
+  @spec send_user_invitation_email_enabled? :: boolean()
+  def send_user_invitation_email_enabled?() do
+    case System.get_env("USER_INVITATION_EMAIL_ENABLED") do
+      x when x == "1" or x == "true" -> true
+      _ -> false
+    end
+  end
+end


### PR DESCRIPTION
### Description

Currently, the only way to invite a user to an account is to generate a an invite url from the Account Overview page, copy that url, and send it directly to the user. We can make this process a lot easier by allowing for account admins to input the user's email and letting us send the invitation url to provided user. 

**Note:** there's a lot of duplicated logic, so I've added some todos. I'm going to address them as a follow-up to this diff, but I wanted to keep them separate to keep the size of this diff smaller.

### Issue

https://github.com/papercups-io/papercups/issues/591

### Screenshots

**Video of invite flow**

https://user-images.githubusercontent.com/1361509/113453069-45997700-93d3-11eb-95d6-c03c56d379bf.mp4

**Email when the sender has a name**
<img width="626" alt="CleanShot 2021-04-02 at 16 32 10@2x" src="https://user-images.githubusercontent.com/1361509/113452499-1c2c1b80-93d2-11eb-8c29-e964b54e3054.png">

**Email when the sender doesn't have a name**
<img width="708" alt="CleanShot 2021-04-02 at 16 25 19@2x" src="https://user-images.githubusercontent.com/1361509/113452503-1df5df00-93d2-11eb-818b-f9d235284a31.png">


## Checklist

- [✓] Everything passes when running `mix test`
- [✓] Ran `mix format`
- [✓] No frontend compilation warnings
