### PR TITLE
Allow users to delete Gmail authenication

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -805,6 +805,19 @@ export const fetchGoogleAuthorization = async (
     .then((res) => res.body.data);
 };
 
+export const deleteGoogleAuthorization = async (
+  authorizationId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/google/authorization/${authorizationId}`)
+    .set('Authorization', token);
+};
+
 export type EmailParams = {
   recipient: string;
   subject: string;

--- a/assets/src/components/integrations/GoogleAuthorizationButton.tsx
+++ b/assets/src/components/integrations/GoogleAuthorizationButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Button, Popconfirm} from '../common';
+import {getGoogleAuthUrl} from './support';
+import Tooltip from 'antd/lib/tooltip';
+
+export const GoogleAuthorizationButton = ({
+  isConnected,
+  authorizationId,
+  onDisconnectGmail,
+}: {
+  isConnected: boolean;
+  authorizationId: string | null;
+  onDisconnectGmail: (id: string) => void;
+}) => {
+  if (isConnected && authorizationId) {
+    return (
+      <Flex mx={-1}>
+        <Box mx={1}>
+          <a href={getGoogleAuthUrl('gmail')}>
+            <Button>Reconnect</Button>
+          </a>
+        </Box>
+        <Box mx={1}>
+          <Popconfirm
+            title="Are you sure you want to disconnect from Gmail?"
+            okText="Yes"
+            cancelText="No"
+            placement="topLeft"
+            onConfirm={() => onDisconnectGmail(authorizationId)}
+          >
+            <Button danger>Disconnect</Button>
+          </Popconfirm>
+        </Box>
+      </Flex>
+    );
+  }
+  return (
+    <Tooltip
+      title={
+        <Box>
+          Our verification with the Google API is pending, but you can still
+          link your Gmail account to opt into new features.
+        </Box>
+      }
+    >
+      <a href={getGoogleAuthUrl('gmail')}>
+        <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
+      </a>
+    </Tooltip>
+  );
+};

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -272,6 +272,14 @@ class IntegrationsOverview extends React.Component<Props, State> {
       );
   };
 
+  handleDisconnectGmail = async (authorizationId: string) => {
+    return API.deleteGoogleAuthorization(authorizationId)
+      .then(() => this.refreshAllIntegrations())
+      .catch((err) =>
+        logger.error('Failed to remove Gmail authorization:', err)
+      );
+  };
+
   handleAddWebhook = () => {
     this.setState({isWebhookModalOpen: true});
   };
@@ -394,6 +402,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
               loading={refreshing}
               integrations={integrations}
               onDisconnectSlack={this.handleDisconnectSlack}
+              onDisconnectGmail={this.handleDisconnectGmail}
               onUpdateIntegration={this.refreshAllIntegrations}
             />
           </Box>

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -5,16 +5,19 @@ import {colors, Button, Popconfirm, Table, Tag, Text, Tooltip} from '../common';
 import {IntegrationType, getSlackAuthUrl, getGoogleAuthUrl} from './support';
 import {MattermostAuthorizationButton} from './MattermostAuthorizationModal';
 import {TwilioAuthorizationButton} from './TwilioAuthorizationModal';
+import {GoogleAuthorizationButton} from './GoogleAuthorizationButton';
 
 const IntegrationsTable = ({
   loading,
   integrations,
   onDisconnectSlack,
+  onDisconnectGmail,
   onUpdateIntegration,
 }: {
   loading?: boolean;
   integrations: Array<IntegrationType>;
   onDisconnectSlack: (id: string) => void;
+  onDisconnectGmail: (id: string) => void;
   onUpdateIntegration: (data?: any) => void;
 }) => {
   const columns = [
@@ -113,18 +116,11 @@ const IntegrationsTable = ({
             );
           case 'gmail':
             return (
-              <Tooltip
-                title={
-                  <Box>
-                    Our verification with the Google API is pending, but you can
-                    still link your Gmail account to opt into new features.
-                  </Box>
-                }
-              >
-                <a href={getGoogleAuthUrl('gmail')}>
-                  <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
-                </a>
-              </Tooltip>
+              <GoogleAuthorizationButton
+                isConnected={isConnected}
+                authorizationId={authorizationId}
+                onDisconnectGmail={onDisconnectGmail}
+              />
             );
           case 'sheets':
             return (

--- a/lib/chat_api_web/controllers/google_controller.ex
+++ b/lib/chat_api_web/controllers/google_controller.ex
@@ -4,6 +4,7 @@ defmodule ChatApiWeb.GoogleController do
   require Logger
 
   alias ChatApi.Google
+  alias ChatApi.Google.GoogleAuthorization
 
   @spec callback(Plug.Conn.t(), map()) :: Plug.Conn.t()
   @doc """
@@ -58,6 +59,7 @@ defmodule ChatApiWeb.GoogleController do
         auth ->
           json(conn, %{
             data: %{
+              id: auth.id,
               created_at: auth.inserted_at,
               account_id: auth.account_id,
               user_id: auth.user_id,
@@ -97,6 +99,18 @@ defmodule ChatApiWeb.GoogleController do
     json(conn, %{data: %{url: url}})
   end
 
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def delete(conn, %{"id" => id}) do
+    with %{account_id: _account_id} <- conn.assigns.current_user,
+         %GoogleAuthorization{} = auth <-
+           Google.get_google_authorization!(id),
+         {:ok, %GoogleAuthorization{}} <- Google.delete_google_authorization(auth) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  @spec enqueue_enabling_gmail_sync(binary()) ::
+          {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
   defp enqueue_enabling_gmail_sync(account_id) do
     %{account_id: account_id}
     |> ChatApi.Workers.EnableGmailInboxSync.new()

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -102,6 +102,7 @@ defmodule ChatApiWeb.Router do
     get("/google/auth", GoogleController, :auth)
     get("/google/oauth", GoogleController, :callback)
     get("/google/authorization", GoogleController, :authorization)
+    delete("/google/authorization/:id", GoogleController, :delete)
     post("/gmail/send", GmailController, :send)
     put("/widget_settings", WidgetSettingsController, :update)
     get("/profile", UserProfileController, :show)


### PR DESCRIPTION
### Description
Adds a route to delete gmail auth. Adds UI to show disconnect button in integrations tab

Missing tests. Will add tomorrow



### Issue

Closes #707 

### Screenshots


https://user-images.githubusercontent.com/7440689/113665951-646e6680-967c-11eb-87ec-c8df840bcc71.mov



## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
