### PR TITLE
Auto-enable Gmail inbox sync after integration is connected

### DIFF
--- a/lib/chat_api_web/controllers/google_controller.ex
+++ b/lib/chat_api_web/controllers/google_controller.ex
@@ -36,6 +36,8 @@ defmodule ChatApiWeb.GoogleController do
              client: type
            }) do
         {:ok, _result} ->
+          enqueue_enabling_gmail_sync(account_id)
+
           json(conn, %{data: %{ok: true}})
 
         error ->
@@ -93,5 +95,11 @@ defmodule ChatApiWeb.GoogleController do
     url = Google.Auth.authorize_url!(scope: scope, prompt: "consent", access_type: "offline")
 
     json(conn, %{data: %{url: url}})
+  end
+
+  defp enqueue_enabling_gmail_sync(account_id) do
+    %{account_id: account_id}
+    |> ChatApi.Workers.EnableGmailInboxSync.new()
+    |> Oban.insert()
   end
 end

--- a/lib/mix/tasks/enable_gmail_inbox_sync.ex
+++ b/lib/mix/tasks/enable_gmail_inbox_sync.ex
@@ -51,6 +51,9 @@ defmodule Mix.Tasks.EnableGmailInboxSync do
     end
   end
 
+  @spec enable_gmail_sync(binary(), binary()) ::
+          {:error, binary() | Ecto.Changeset.t()}
+          | {:ok, ChatApi.Google.GoogleAuthorization.t()}
   def enable_gmail_sync(account_id, history_id) do
     case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
       %GoogleAuthorization{} = authorization ->
@@ -63,6 +66,9 @@ defmodule Mix.Tasks.EnableGmailInboxSync do
     end
   end
 
+  @spec enable_gmail_sync(binary()) ::
+          {:error, binary() | Ecto.Changeset.t()}
+          | {:ok, ChatApi.Google.GoogleAuthorization.t()}
   def enable_gmail_sync(account_id) do
     case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
       %GoogleAuthorization{refresh_token: _, metadata: %{"next_history_id" => next_history_id}}

--- a/lib/workers/enable_gmail_inbox_sync.ex
+++ b/lib/workers/enable_gmail_inbox_sync.ex
@@ -1,0 +1,62 @@
+defmodule ChatApi.Workers.EnableGmailInboxSync do
+  use Oban.Worker, queue: :default
+
+  require Logger
+
+  alias ChatApi.Google
+  alias ChatApi.Google.{Gmail, GoogleAuthorization}
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{args: %{"account_id" => account_id}} = job) do
+    Logger.info("Performing job: #{inspect(job)}")
+
+    case enable_gmail_sync(account_id) do
+      {:ok, authorization} ->
+        Logger.info(
+          "Successfully enabled Gmail syncing for account #{inspect(account_id)} with authorization #{
+            inspect(authorization.id)
+          }"
+        )
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to enable Gmail syncing for account #{inspect(account_id)}: #{inspect(reason)}"
+        )
+    end
+
+    :ok
+  end
+
+  @spec enable_gmail_sync(binary()) ::
+          {:error, binary() | Ecto.Changeset.t()}
+          | {:ok, ChatApi.Google.GoogleAuthorization.t()}
+  def enable_gmail_sync(account_id) do
+    case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
+      %GoogleAuthorization{refresh_token: _, metadata: %{"next_history_id" => next_history_id}}
+      when is_binary(next_history_id) ->
+        {:error, "Gmail syncing is already enabled for this account"}
+
+      %GoogleAuthorization{refresh_token: token} = authorization ->
+        history_id =
+          token
+          |> Gmail.list_threads()
+          |> Map.get("threads", [])
+          |> List.first()
+          |> Map.get("historyId")
+
+        case Gmail.list_history(token, start_history_id: history_id) do
+          %{"historyId" => next_history_id} ->
+            Google.update_google_authorization(authorization, %{
+              metadata: %{next_history_id: next_history_id}
+            })
+
+          _ ->
+            {:error, "Unable to find valid history ID"}
+        end
+
+      authorization ->
+        {:error, "Invalid authorization #{inspect(authorization)}"}
+    end
+  end
+end


### PR DESCRIPTION
### Description

Auto-enable Gmail inbox sync after integration is connected

### Issue

When we first launched, we only supported handling this step in a manual onboarding. Now that we know it's working (more or less), we can remove the manual step.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
