### PR TITLE
Reduce the number of clicks to get to the customer details page

### DIFF
--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -369,7 +369,9 @@ export const CustomerDetailsSection = ({
   return (
     <Box px={2} py={3}>
       <Box px={2} mb={3}>
-        <Text strong>Customer details</Text>
+        <Link to={`/customers/${customer.id}`}>
+          <Text strong>Customer details</Text>
+        </Link>
       </Box>
 
       <CustomerDetails customer={customer} isOnline={isOnline} />

--- a/assets/src/components/customers/CustomersPage.tsx
+++ b/assets/src/components/customers/CustomersPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Alert, Input, Paragraph, Text, Title} from '../common';
+import {Alert, Button, Input, Paragraph, Text, Title} from '../common';
 import {useConversations} from '../conversations/ConversationsProvider';
 import * as API from '../../api';
 import Spinner from '../Spinner';
@@ -169,6 +170,11 @@ class CustomersPage extends React.Component<Props, State> {
             customers={filteredCustomers}
             currentlyOnline={currentlyOnline}
             onUpdate={this.handleRefreshCustomers}
+            action={(customer: Customer) => (
+              <Link to={`/customers/${customer.id}`}>
+                <Button>View profile</Button>
+              </Link>
+            )}
           />
         </Box>
       </Box>

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Box} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import {Customer} from '../../types';
 import {Badge, Button, Table, Text, Tooltip} from '../common';
 import CustomerDetailsModal from './CustomerDetailsModal';
 
@@ -13,17 +14,21 @@ const CustomersTable = ({
   customers,
   currentlyOnline = {},
   shouldIncludeAnonymous,
+  action,
   onUpdate,
 }: {
   loading?: boolean;
-  customers: Array<any>;
-  currentlyOnline?: any;
+  customers: Array<Customer>;
+  currentlyOnline?: Record<string, any>;
   shouldIncludeAnonymous?: boolean;
+  action?: (customer: Customer) => React.ReactElement;
   onUpdate: () => Promise<void>;
 }) => {
-  const [selectedCustomerId, setSelectedCustomerId] = React.useState(null);
+  const [selectedCustomerId, setSelectedCustomerId] = React.useState<
+    string | null
+  >(null);
 
-  const isCustomerOnline = (customer: any) => {
+  const isCustomerOnline = (customer: Customer) => {
     const {id: customerId} = customer;
 
     return currentlyOnline[customerId];
@@ -35,6 +40,7 @@ const CustomersTable = ({
     .map((customer) => {
       return {key: customer.id, ...customer};
     })
+    // TODO: make sorting configurable from the UI
     .sort((a, b) => {
       if (isCustomerOnline(a)) {
         return -1;
@@ -67,7 +73,7 @@ const CustomersTable = ({
       title: 'Last seen',
       dataIndex: 'last_seen',
       key: 'last_seen',
-      render: (value: string, record: any) => {
+      render: (value: string, record: Customer) => {
         const {id, pathname, current_url} = record;
         const formatted = dayjs.utc(value).format('MMMM DD, YYYY');
         const isOnline = currentlyOnline[id];
@@ -98,7 +104,7 @@ const CustomersTable = ({
       title: 'Device info',
       dataIndex: 'info',
       key: 'info',
-      render: (value: string, record: any) => {
+      render: (value: string, record: Customer) => {
         const {browser, os} = record;
 
         return (
@@ -114,7 +120,11 @@ const CustomersTable = ({
       title: '',
       dataIndex: 'action',
       key: 'action',
-      render: (value: string, record: any) => {
+      render: (value: string, record: Customer) => {
+        if (action && typeof action === 'function') {
+          return action(record);
+        }
+
         const {id: customerId} = record;
 
         return (

--- a/assets/src/components/tags/TagDetailsPage.tsx
+++ b/assets/src/components/tags/TagDetailsPage.tsx
@@ -269,6 +269,11 @@ class TagDetailsPage extends React.Component<Props, State> {
                 customers={customers}
                 shouldIncludeAnonymous
                 onUpdate={this.handleRefreshCustomers}
+                action={(customer: T.Customer) => (
+                  <Link to={`/customers/${customer.id}`}>
+                    <Button>View profile</Button>
+                  </Link>
+                )}
               />
             </DetailsSectionCard>
 

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -32,7 +32,7 @@ export type Customer = {
   first_seen?: any;
   host?: string;
   ip?: string;
-  last_seen?: string;
+  last_seen: string;
   metadata?: any;
   os?: string;
   pathname?: string;


### PR DESCRIPTION
### Description

Reduce the number of clicks to get to the customer details page. Now, instead of opening the customer details modal, we just take the user directly to the customer profile.

### Issue

It can be annoying clicking so many times to be able to see the customer details page.

### Screenshots

![view-customer-profile](https://user-images.githubusercontent.com/5264279/113715185-322e2a80-96b7-11eb-90bd-6798903cfa35.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
