### PR TITLE
Reopen email conversations if new message comes in

### DIFF
--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -25,9 +25,9 @@ defmodule ChatApi.Messages.Helpers do
   def get_message_type(_message), do: :unknown
 
   @spec handle_post_creation_conversation_updates(Message.t()) :: Message.t()
-  def handle_post_creation_conversation_updates(%Message{} = message) do
+  def handle_post_creation_conversation_updates(%Message{} = message, updates \\ %{}) do
     message
-    |> build_conversation_updates()
+    |> build_conversation_updates(updates)
     |> update_message_conversation(message)
     |> Conversations.Notification.broadcast_conversation_update_to_admin!()
     |> Conversations.Notification.notify(:webhooks, event: "conversation:updated")
@@ -37,8 +37,8 @@ defmodule ChatApi.Messages.Helpers do
   end
 
   @spec build_conversation_updates(Message.t()) :: map()
-  def build_conversation_updates(%Message{} = message) do
-    %{}
+  def build_conversation_updates(%Message{} = message, updates \\ %{}) do
+    updates
     |> build_first_reply_updates(message)
     |> build_message_type_updates(message)
   end

--- a/lib/workers/sync_gmail_inbox.ex
+++ b/lib/workers/sync_gmail_inbox.ex
@@ -245,13 +245,13 @@ defmodule ChatApi.Workers.SyncGmailInbox do
           _ -> DateTime.utc_now()
         end
     })
-    |> ChatApi.Messages.create_and_fetch!()
-    |> ChatApi.Messages.Notification.broadcast_to_admin!()
-    |> ChatApi.Messages.Notification.notify(:webhooks)
+    |> Messages.create_and_fetch!()
+    |> Messages.Notification.broadcast_to_admin!()
+    |> Messages.Notification.notify(:webhooks)
     # NB: we need to make sure the messages are created in the correct order, so we set async: false
-    |> ChatApi.Messages.Notification.notify(:slack, async: false)
-    |> ChatApi.Messages.Notification.notify(:mattermost, async: false)
-    # TODO: not sure we need to do this on every message
-    |> ChatApi.Messages.Helpers.handle_post_creation_conversation_updates()
+    |> Messages.Notification.notify(:slack, async: false)
+    |> Messages.Notification.notify(:mattermost, async: false)
+    # NB: for email threads, for now we want to reopen the conversation if it was closed
+    |> Messages.Helpers.handle_post_creation_conversation_updates(%{status: "open"})
   end
 end


### PR DESCRIPTION
### Description

Reopen email conversations if new message comes in via Gmail sync

### Issue

Fixes https://github.com/papercups-io/papercups/issues/705

### Screenshots

TODO

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
