### PR TITLE
Adds button to start a new conversation from the customer details page

### DIFF
--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import {Button, Modal, TextArea, Tooltip} from '../common';
+import {SendOutlined} from '../icons';
+import * as API from '../../api';
+import logger from '../../logger';
+import {Conversation} from '../../types';
+import {TooltipPlacement} from 'antd/lib/tooltip';
+
+export type Props = {
+  customerId: string;
+  disabled: boolean;
+  disabledTooltipPlacement: TooltipPlacement;
+  disabledTooltipTitle: string;
+  onInitializeNewConversation?: (conservation: Conversation) => void;
+};
+
+export type State = {
+  isConversationModalOpen: boolean;
+  isSendingMessage: boolean;
+  message: string;
+};
+
+export class StartConversationButton extends React.Component<Props, State> {
+  static defaultProps = {
+    disabled: false,
+    disabledTooltipPlacement: 'right',
+    disabledTooltipTitle: 'This customer already has an open conversation',
+  };
+
+  state: State = {
+    isConversationModalOpen: false,
+    isSendingMessage: false,
+    message: '',
+  };
+
+  handleOpenNewConversationModal = () => {
+    this.setState({isConversationModalOpen: true});
+  };
+
+  handleCloseNewConversationModal = () => {
+    this.setState({isConversationModalOpen: false});
+  };
+
+  initializeNewConversation = async () => {
+    const {customerId, onInitializeNewConversation} = this.props;
+    const {message} = this.state;
+
+    this.setState({isSendingMessage: true});
+
+    try {
+      const conversation = await API.createNewConversation(customerId, {
+        message: {
+          body: message,
+          sent_at: new Date().toISOString(),
+        },
+      });
+
+      if (onInitializeNewConversation) {
+        onInitializeNewConversation(conversation);
+      }
+    } catch (err) {
+      logger.error('Failed to initialize conversation!', err);
+    }
+
+    this.setState({isConversationModalOpen: false, isSendingMessage: false});
+  };
+
+  getButton = () => {
+    const {
+      disabled,
+      disabledTooltipPlacement,
+      disabledTooltipTitle,
+    } = this.props;
+
+    const button = (
+      <Button
+        type="primary"
+        onClick={this.handleOpenNewConversationModal}
+        disabled={disabled}
+      >
+        Start conversation
+      </Button>
+    );
+
+    if (disabled) {
+      return (
+        <Tooltip
+          title={disabledTooltipTitle}
+          placement={disabledTooltipPlacement}
+        >
+          {button}
+        </Tooltip>
+      );
+    } else {
+      return button;
+    }
+  };
+
+  render() {
+    const {isConversationModalOpen, isSendingMessage, message} = this.state;
+
+    return (
+      <React.Fragment>
+        {this.getButton()}
+        <Modal
+          title="Initialize a conversation"
+          visible={isConversationModalOpen}
+          onCancel={this.handleCloseNewConversationModal}
+          footer={[
+            <Button key="cancel" onClick={this.handleCloseNewConversationModal}>
+              Cancel
+            </Button>,
+            <Button
+              key="submit"
+              type="primary"
+              icon={<SendOutlined />}
+              loading={isSendingMessage}
+              onClick={this.initializeNewConversation}
+            >
+              Send
+            </Button>,
+          ]}
+        >
+          <TextArea
+            className="TextArea--transparent"
+            placeholder="Enter a message..."
+            autoSize={{maxRows: 4}}
+            autoFocus
+            value={message}
+            onChange={(e) => this.setState({message: e.target.value})}
+          />
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+
+export default StartConversationButton;

--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -7,11 +7,42 @@ import logger from '../../logger';
 import {Conversation} from '../../types';
 import {TooltipPlacement} from 'antd/lib/tooltip';
 
+const ButtonWrapper = ({
+  isDisabled = false,
+  disabledTooltipPlacement = 'left',
+  disabledTooltipTitle = 'This customer already has an open conversation',
+  onClick,
+}: {
+  isDisabled: boolean;
+  disabledTooltipPlacement?: TooltipPlacement;
+  disabledTooltipTitle?: string;
+  onClick: () => void;
+}) => {
+  const button = (
+    <Button type="primary" onClick={onClick} disabled={isDisabled}>
+      Start conversation
+    </Button>
+  );
+
+  if (isDisabled) {
+    return (
+      <Tooltip
+        title={disabledTooltipTitle}
+        placement={disabledTooltipPlacement}
+      >
+        {button}
+      </Tooltip>
+    );
+  } else {
+    return button;
+  }
+};
+
 export type Props = {
   customerId: string;
-  disabled: boolean;
-  disabledTooltipPlacement: TooltipPlacement;
-  disabledTooltipTitle: string;
+  isDisabled: boolean;
+  disabledTooltipPlacement?: TooltipPlacement;
+  disabledTooltipTitle?: string;
   onInitializeNewConversation?: (conservation: Conversation) => void;
 };
 
@@ -22,12 +53,6 @@ export type State = {
 };
 
 export class StartConversationButton extends React.Component<Props, State> {
-  static defaultProps = {
-    disabled: false,
-    disabledTooltipPlacement: 'right',
-    disabledTooltipTitle: 'This customer already has an open conversation',
-  };
-
   state: State = {
     isConversationModalOpen: false,
     isSendingMessage: false,
@@ -66,43 +91,23 @@ export class StartConversationButton extends React.Component<Props, State> {
     this.setState({isConversationModalOpen: false, isSendingMessage: false});
   };
 
-  getButton = () => {
+  render() {
     const {
-      disabled,
+      isDisabled,
       disabledTooltipPlacement,
       disabledTooltipTitle,
     } = this.props;
-
-    const button = (
-      <Button
-        type="primary"
-        onClick={this.handleOpenNewConversationModal}
-        disabled={disabled}
-      >
-        Start conversation
-      </Button>
-    );
-
-    if (disabled) {
-      return (
-        <Tooltip
-          title={disabledTooltipTitle}
-          placement={disabledTooltipPlacement}
-        >
-          {button}
-        </Tooltip>
-      );
-    } else {
-      return button;
-    }
-  };
-
-  render() {
     const {isConversationModalOpen, isSendingMessage, message} = this.state;
 
     return (
       <React.Fragment>
-        {this.getButton()}
+        <ButtonWrapper
+          isDisabled={isDisabled}
+          disabledTooltipPlacement={disabledTooltipPlacement}
+          disabledTooltipTitle={disabledTooltipTitle}
+          onClick={this.handleOpenNewConversationModal}
+        />
+
         <Modal
           title="Initialize a conversation"
           visible={isConversationModalOpen}

--- a/assets/src/components/customers/CustomerDetailsPage.tsx
+++ b/assets/src/components/customers/CustomerDetailsPage.tsx
@@ -202,7 +202,7 @@ class CustomerDetailsPage extends React.Component<Props, State> {
                 <Title level={4}>Conversations</Title>
                 <StartConversationButton
                   customerId={this.getCustomerId()}
-                  disabled={this.hasOpenConversation()}
+                  isDisabled={this.hasOpenConversation()}
                   onInitializeNewConversation={this.fetchConversations}
                 />
               </Flex>

--- a/assets/src/components/sessions/LiveSessionViewer.tsx
+++ b/assets/src/components/sessions/LiveSessionViewer.tsx
@@ -300,10 +300,10 @@ class LiveSessionViewer extends React.Component<Props, State> {
                   {!loading && customer && (
                     <StartConversationButton
                       customerId={customer.id}
+                      isDisabled={!!conversation}
                       onInitializeNewConversation={(conversation) =>
                         this.setState({conversation})
                       }
-                      disabled={!!conversation}
                     />
                   )}
                 </Flex>

--- a/assets/src/components/sessions/LiveSessionViewer.tsx
+++ b/assets/src/components/sessions/LiveSessionViewer.tsx
@@ -4,13 +4,14 @@ import {throttle} from 'lodash';
 import {Channel, Presence, Socket} from 'phoenix';
 import {Box, Flex} from 'theme-ui';
 import {Replayer, ReplayerEvents} from 'rrweb';
-import {Alert, Button, Modal, Paragraph, Text, TextArea} from '../common';
-import {ArrowLeftOutlined, SendOutlined} from '../icons';
+import {Alert, Button, Paragraph, Text} from '../common';
+import {ArrowLeftOutlined} from '../icons';
 import {SOCKET_URL} from '../../socket';
 import * as API from '../../api';
 import logger from '../../logger';
 import Spinner from '../Spinner';
 import ConversationDetailsSidebar from '../conversations/ConversationDetailsSidebar';
+import StartConversationButton from '../conversations/StartConversationButton';
 import ConversationSidebar from './ConversationSidebar';
 import {Conversation, Customer} from '../../types';
 import 'rrweb/dist/replay/rrweb-replay.min.css';
@@ -22,11 +23,8 @@ type State = {
   customer: Customer | null;
   conversation: Conversation | null;
   scale: number;
-  isConversationModalOpen: boolean;
-  isSendingMessage: boolean;
   isCustomerActive: boolean;
   isCustomerConnected: boolean;
-  message: string;
 };
 
 class LiveSessionViewer extends React.Component<Props, State> {
@@ -41,11 +39,8 @@ class LiveSessionViewer extends React.Component<Props, State> {
     customer: null,
     conversation: null,
     scale: 1,
-    isConversationModalOpen: false,
-    isSendingMessage: false,
     isCustomerActive: true,
     isCustomerConnected: true,
-    message: '',
   };
 
   // TODO: move a bunch of logic from here into separate functions
@@ -178,38 +173,6 @@ class LiveSessionViewer extends React.Component<Props, State> {
     this.channels.push(channel);
   };
 
-  initializeNewConversation = async () => {
-    const {customer, message} = this.state;
-
-    if (!customer) {
-      return null;
-    }
-
-    this.setState({isSendingMessage: true});
-
-    try {
-      const {id: customerId} = customer;
-      const conversation = await API.createNewConversation(customerId, {
-        message: {
-          body: message,
-          sent_at: new Date().toISOString(),
-        },
-      });
-
-      this.setState({conversation});
-    } catch (err) {
-      logger.error('Failed to initialize conversation!', err);
-    }
-
-    this.setState({isConversationModalOpen: false, isSendingMessage: false});
-  };
-
-  handleOpenNewConversationModal = () =>
-    this.setState({isConversationModalOpen: true});
-
-  handleCloseNewConversationModal = () =>
-    this.setState({isConversationModalOpen: false});
-
   findExistingConversation = async (
     accountId: string,
     customerId?: string | null
@@ -312,11 +275,8 @@ class LiveSessionViewer extends React.Component<Props, State> {
       scale = 1,
       conversation,
       customer,
-      isConversationModalOpen,
-      isSendingMessage,
       isCustomerActive,
       isCustomerConnected,
-      message,
     } = this.state;
     const hasAdditionalDetails = !!(conversation || customer);
 
@@ -337,45 +297,15 @@ class LiveSessionViewer extends React.Component<Props, State> {
                     </Button>
                   </Link>
 
-                  {!loading && !conversation && (
-                    <Button
-                      type="primary"
-                      onClick={this.handleOpenNewConversationModal}
-                    >
-                      Start conversation
-                    </Button>
-                  )}
-                  <Modal
-                    title="Initialize a conversation"
-                    visible={isConversationModalOpen}
-                    onCancel={this.handleCloseNewConversationModal}
-                    footer={[
-                      <Button
-                        key="cancel"
-                        onClick={this.handleCloseNewConversationModal}
-                      >
-                        Cancel
-                      </Button>,
-                      <Button
-                        key="submit"
-                        type="primary"
-                        icon={<SendOutlined />}
-                        loading={isSendingMessage}
-                        onClick={this.initializeNewConversation}
-                      >
-                        Send
-                      </Button>,
-                    ]}
-                  >
-                    <TextArea
-                      className="TextArea--transparent"
-                      placeholder="Enter a message..."
-                      autoSize={{maxRows: 4}}
-                      autoFocus
-                      value={message}
-                      onChange={(e) => this.setState({message: e.target.value})}
+                  {!loading && customer && (
+                    <StartConversationButton
+                      customerId={customer.id}
+                      onInitializeNewConversation={(conversation) =>
+                        this.setState({conversation})
+                      }
+                      disabled={!!conversation}
                     />
-                  </Modal>
+                  )}
                 </Flex>
               </Paragraph>
 


### PR DESCRIPTION
### Description
The high level goal for this pull request is to add the ability for users to proactively send messages to customers from the customer details page. 

In order to do that, I refactored the button and modal that existed to start new conversations from the live session viewer page into a separate component (4eacc9b). With just the customer id, we're not able to start new conversations anywhere in the app.

4b5537a uses the new component to add the ability to start a new conversation on the customer details page.

Notice that on the live session viewer page, I also made the design decision to always show the button, but disable it with a tooltip when a conversation is already in progress. This teaches our users to reference existing conversations before creating new ones. Hiding buttons based on certain states isn't always clear for our users and can lead to a confusing experience.

### Issue
https://github.com/papercups-io/papercups/issues/688

### Screenshots
**Starting a new conversation from the live session page**
https://user-images.githubusercontent.com/1361509/113760331-168d4900-96e4-11eb-9041-c80e01aa61db.mp4

**Starting a new conversation from the customer details page**
https://user-images.githubusercontent.com/1361509/113760340-18efa300-96e4-11eb-8fec-d2a0b5cbaf3a.mp4

## Checklist

- [✔] Everything passes when running `mix test`
- [✔] Ran `mix format`
- [✔] No frontend compilation warnings
