### PR TITLE
Fix update event subscriptions route

### DIFF
--- a/lib/chat_api/event_subscriptions.ex
+++ b/lib/chat_api/event_subscriptions.ex
@@ -151,7 +151,9 @@ defmodule ChatApi.EventSubscriptions do
 
   def should_handle_event?(_event_subscription, _event), do: false
 
-  @spec is_valid_uri?(binary() | URI.t()) :: boolean()
+  @spec is_valid_uri?(binary() | URI.t() | nil) :: boolean()
+  def is_valid_uri?(nil), do: false
+
   def is_valid_uri?(str) do
     case URI.parse(str) do
       %URI{scheme: nil} -> false

--- a/lib/chat_api_web/controllers/event_subscription_controller.ex
+++ b/lib/chat_api_web/controllers/event_subscription_controller.ex
@@ -48,12 +48,16 @@ defmodule ChatApiWeb.EventSubscriptionController do
   @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def update(conn, %{"id" => id, "event_subscription" => event_subscription_params}) do
     event_subscription = EventSubscriptions.get_event_subscription!(id)
+    # Not sure the most appropriate place to handle this verification :shrug:
+    verified =
+      event_subscription_params
+      |> Map.get("webhook_url")
+      |> EventSubscriptions.is_valid_webhook_url?()
+
+    params = Map.merge(event_subscription_params, %{"verified" => verified})
 
     with {:ok, %EventSubscription{} = event_subscription} <-
-           EventSubscriptions.update_event_subscription(
-             event_subscription,
-             event_subscription_params
-           ) do
+           EventSubscriptions.update_event_subscription(event_subscription, params) do
       render(conn, "show.json", event_subscription: event_subscription)
     end
   end


### PR DESCRIPTION
### Description

Fixes update event subscriptions route.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/721

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
