### PR TITLE
Support specifying customer in `POST /api/v1/messages` endpoint

### DIFF
--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -45,7 +45,7 @@ defmodule ChatApi.Customers do
     |> Repo.paginate(pagination_params)
   end
 
-  @spec get_customer!(binary(), atom() | list(atom()) | keyword()) :: Customer.t() | nil
+  @spec get_customer!(binary(), atom() | list(atom()) | keyword()) :: Customer.t()
   def get_customer!(id, preloads \\ [:company, :tags]) do
     Customer
     |> Repo.get!(id)

--- a/lib/chat_api_web/controllers/fallback_controller.ex
+++ b/lib/chat_api_web/controllers/fallback_controller.ex
@@ -46,4 +46,15 @@ defmodule ChatApiWeb.FallbackController do
       }
     })
   end
+
+  def call(conn, {:error, :forbidden, message}) do
+    conn
+    |> put_status(403)
+    |> json(%{
+      error: %{
+        status: 403,
+        message: message
+      }
+    })
+  end
 end

--- a/lib/chat_api_web/controllers/fallback_controller.ex
+++ b/lib/chat_api_web/controllers/fallback_controller.ex
@@ -35,4 +35,15 @@ defmodule ChatApiWeb.FallbackController do
       }
     })
   end
+
+  def call(conn, {:error, :unprocessable_entity, message}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: %{
+        status: 422,
+        message: message
+      }
+    })
+  end
 end

--- a/lib/chat_api_web/controllers/message_controller.ex
+++ b/lib/chat_api_web/controllers/message_controller.ex
@@ -164,11 +164,7 @@ defmodule ChatApiWeb.MessageController do
         {:ok, Map.merge(params, %{"account_id" => account_id})}
 
       _ ->
-        {:ok,
-         Map.merge(params, %{
-           "account_id" => account_id,
-           "user_id" => conn.assigns.current_user.id
-         })}
+        {:error, :forbidden, "Forbidden: invalid `customer_id`"}
     end
   end
 

--- a/test/chat_api_web/controllers/message_controller_test.exs
+++ b/test/chat_api_web/controllers/message_controller_test.exs
@@ -129,6 +129,24 @@ defmodule ChatApiWeb.MessageControllerTest do
              } = json_response(conn, 200)["data"]
     end
 
+    test "returns error when customer ID is not associated with the authenticated account",
+         %{
+           authed_conn: authed_conn,
+           conversation: conversation
+         } do
+      some_other_account = insert(:account)
+      customer = insert(:customer, account: some_other_account)
+
+      message = %{
+        body: "some body",
+        customer_id: customer.id,
+        conversation_id: conversation.id
+      }
+
+      conn = post(authed_conn, Routes.message_path(authed_conn, :create), message: message)
+      assert json_response(conn, 403)["error"]["message"]
+    end
+
     test "returns error when both a user ID and customer ID are specified",
          %{
            authed_conn: authed_conn,


### PR DESCRIPTION
### Description

Adds support for specifying the customer on the `POST /api/v1/messages` endpoint.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/706

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
