### PR TITLE
Support markdown images in chat messages

### DIFF
--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -77,7 +77,8 @@ export const shadows = {
 
 export const TextArea = Input.TextArea;
 
-/* Whitelist node types that we allow when we render markdown.
+/**
+ * Whitelist node types that we allow when we render markdown.
  * Reference https://github.com/rexxars/react-markdown#node-types
  */
 export const allowedNodeTypes: Array<any> = [
@@ -96,6 +97,7 @@ export const allowedNodeTypes: Array<any> = [
   'heading',
   'inlineCode',
   'code',
+  'image',
 ];
 
 export {

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -12,7 +12,7 @@ const renderers = {
     return <Twemoji text={props.children} />;
   },
   image: (props: any) => {
-    return <img {...props} style={{maxWidth: '100%'}} />;
+    return <img {...props} style={{maxWidth: '100%', maxHeight: 400}} />;
   },
 };
 

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -12,6 +12,7 @@ const renderers = {
     return <Twemoji text={props.children} />;
   },
   image: (props: any) => {
+    // TODO: fix scroll behavior after image loads
     return (
       <img
         alt={props.alt || ''}

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -12,7 +12,14 @@ const renderers = {
     return <Twemoji text={props.children} />;
   },
   image: (props: any) => {
-    return <img {...props} style={{maxWidth: '100%', maxHeight: 400}} />;
+    return (
+      <img
+        alt={props.alt || ''}
+        src={props.src}
+        {...props}
+        style={{maxWidth: '100%', maxHeight: 400}}
+      />
+    );
   },
 };
 

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -11,6 +11,9 @@ const renderers = {
   text: (props: any) => {
     return <Twemoji text={props.children} />;
   },
+  image: (props: any) => {
+    return <img {...props} style={{maxWidth: '100%'}} />;
+  },
 };
 
 const ChatMessageAttachment = ({


### PR DESCRIPTION
### Description

Support markdown images in chat messages

### Issue

Related to https://github.com/papercups-io/chat-widget/issues/90

### Screenshots

<img width="723" alt="Screen Shot 2021-04-08 at 3 19 11 PM" src="https://user-images.githubusercontent.com/5264279/114084102-c9dd7580-987d-11eb-967a-13ef8ce2b2ac.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
