### PR TITLE
Set up support for bot messages in dashboard

### DIFF
--- a/assets/src/components/conversations/ChatMessage.tsx
+++ b/assets/src/components/conversations/ChatMessage.tsx
@@ -8,9 +8,9 @@ import {formatRelativeTime} from '../../utils';
 import {Account, Message} from '../../types';
 import {
   getColorByUuid,
-  isBotMessage,
   getSenderIdentifier,
   getSenderProfilePhoto,
+  isAgentMessage,
 } from './support';
 import ChatMessageBox from './ChatMessageBox';
 
@@ -96,14 +96,12 @@ const ChatMessage = ({
     body,
     sent_at,
     created_at,
-    user,
     seen_at,
     customer_id: customerId,
     private: isPrivate,
     attachments = [],
   } = message;
-  const isBot = isBotMessage(message);
-  const isAgent = !isBot && !!user;
+  const isAgent = isAgentMessage(message);
   const sentAt = dayjs.utc(sent_at || created_at);
   const formattedSentAt = formatRelativeTime(sentAt);
   const seenAt = seen_at ? dayjs.utc(seen_at) : null;

--- a/assets/src/components/conversations/ConversationContainer.tsx
+++ b/assets/src/components/conversations/ConversationContainer.tsx
@@ -132,6 +132,7 @@ const ConversationContainer = ({
       >
         <ConversationMessages
           conversationId={selectedConversationId}
+          account={account}
           messages={messages}
           history={history}
           currentUser={currentUser}
@@ -167,8 +168,8 @@ const ConversationContainer = ({
           >
             <ConversationDetailsSidebar
               customer={customer}
-              isOnline={isOnline}
               conversation={conversation}
+              isOnline={isOnline}
             />
           </Box>
         )}

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -491,12 +491,14 @@ const ConversationDetails = ({conversation}: {conversation: Conversation}) => {
 type Props = {
   customer: Customer;
   conversation?: Conversation;
+  account?: Account | null;
   isOnline?: boolean;
 };
 
 const ConversationDetailsSidebar = ({
   customer,
   conversation,
+  account,
   isOnline,
 }: Props) => {
   return (

--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -6,7 +6,6 @@ import {
   colors,
   Button,
   Popconfirm,
-  Drawer,
   Select,
   Text,
   Title,
@@ -19,107 +18,11 @@ import {
   UploadOutlined,
   UserOutlined,
 } from '../icons';
-import {Customer, Conversation, User} from '../../types';
-import ConversationDetailsSidebar from './ConversationDetailsSidebar';
+import {Conversation, User} from '../../types';
 import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
-
-const hasCustomerMetadata = (customer: Customer) => {
-  const {current_url, browser, os} = customer;
-
-  if (!current_url && !browser && !os) {
-    return false;
-  }
-
-  return true;
-};
-
-const CustomerMetadataSubheader = ({
-  customer,
-  conversation,
-}: {
-  customer: Customer;
-  conversation: Conversation;
-}) => {
-  const [isDrawerVisible, setDrawerVisible] = React.useState(false);
-
-  if (!hasCustomerMetadata(customer)) {
-    return null;
-  }
-
-  const {
-    current_url,
-    pathname,
-    browser,
-    os,
-    ip,
-    time_zone: timezone,
-  } = customer;
-  const formattedTimezone =
-    timezone && timezone.length ? timezone.split('_').join(' ') : null;
-
-  return (
-    <>
-      <Flex>
-        <Flex
-          sx={{
-            flex: 1,
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {current_url && (
-            <Box
-              pr={3}
-              mr={3}
-              sx={{
-                maxWidth: 240,
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-                borderRight: '1px solid rgba(0,0,0,.06)',
-              }}
-            >
-              <a href={current_url} target="_blank" rel="noopener noreferrer">
-                {pathname && pathname.length > 1 ? pathname : current_url}
-              </a>
-            </Box>
-          )}
-          {(browser || os) && (
-            <Box mr={3}>
-              <Text type="secondary">
-                {[browser, os, formattedTimezone || ip]
-                  .filter(Boolean)
-                  .join(' · ')}
-              </Text>
-            </Box>
-          )}
-        </Flex>
-        <Box>
-          <Button size="small" onClick={() => setDrawerVisible(true)}>
-            View details
-          </Button>
-        </Box>
-      </Flex>
-
-      <Drawer
-        placement="right"
-        width={240}
-        closable={false}
-        bodyStyle={{padding: 0, display: 'flex'}}
-        visible={isDrawerVisible}
-        onClose={() => setDrawerVisible(false)}
-      >
-        <ConversationDetailsSidebar
-          customer={customer}
-          conversation={conversation}
-        />
-      </Drawer>
-    </>
-  );
-};
 
 const ConversationHeader = ({
   conversation,
@@ -266,24 +169,6 @@ const ConversationHeader = ({
           )}
         </Flex>
       </Flex>
-
-      {/* NB: just hiding this for now */}
-      {false && hasCustomerMetadata(customer) && (
-        <Box
-          py={2}
-          mx={4}
-          sx={{
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            borderTop: '1px solid rgba(0,0,0,.06)',
-          }}
-        >
-          <CustomerMetadataSubheader
-            customer={customer}
-            conversation={conversation as Conversation}
-          />
-        </Box>
-      )}
     </header>
   );
 };

--- a/assets/src/components/conversations/RelatedCustomerConversations.tsx
+++ b/assets/src/components/conversations/RelatedCustomerConversations.tsx
@@ -4,14 +4,14 @@ import utc from 'dayjs/plugin/utc';
 import {Box, Flex} from 'theme-ui';
 import {colors, Text} from '../common';
 import Spinner from '../Spinner';
+import {SenderAvatar} from './ChatMessage';
 import {
+  getColorByUuid,
   getSenderIdentifier,
   getSenderProfilePhoto,
-  SenderAvatar,
-} from './ChatMessage';
-import {getColorByUuid} from './support';
+} from './support';
 import * as API from '../../api';
-import {Conversation} from '../../types';
+import {Account, Conversation} from '../../types';
 import {formatShortRelativeTime} from '../../utils';
 import logger from '../../logger';
 
@@ -20,8 +20,10 @@ dayjs.extend(utc);
 
 const RelatedConversationItem = ({
   conversation,
+  account,
 }: {
   conversation: Conversation;
+  account: Account;
 }) => {
   const {id, status, created_at, messages = []} = conversation;
 
@@ -34,8 +36,8 @@ const RelatedConversationItem = ({
   const created = dayjs.utc(ts);
   const date = formatShortRelativeTime(created);
   const {user, customer} = recent;
-  const name = getSenderIdentifier(customer, user);
-  const profilePhotoUrl = getSenderProfilePhoto(customer, user);
+  const name = getSenderIdentifier(recent, account);
+  const profilePhotoUrl = getSenderProfilePhoto(recent, account);
   const isAgent = !!user;
   const preview = recent.body ? recent.body : '...';
   const customerId = customer && customer.id;
@@ -62,7 +64,7 @@ const RelatedConversationItem = ({
             color={color}
             size={20}
             name={name}
-            profilePhotoUrl={profilePhotoUrl}
+            avatarPhotoUrl={profilePhotoUrl}
           />
           <Text type="secondary" style={{fontSize: 12}}>
             {date}
@@ -89,6 +91,7 @@ const RelatedCustomerConversations = ({
   conversationId: string;
 }) => {
   const [loading, setLoading] = React.useState(false);
+  const [account, setAccount] = React.useState<Account | null>(null);
   const [conversations, setRelatedConversations] = React.useState<
     Array<Conversation>
   >([]);
@@ -96,8 +99,14 @@ const RelatedCustomerConversations = ({
   React.useEffect(() => {
     setLoading(true);
 
-    API.fetchRelatedConversations(conversationId)
-      .then((results) => setRelatedConversations(results))
+    Promise.all([
+      API.fetchAccountInfo(),
+      API.fetchRelatedConversations(conversationId),
+    ])
+      .then(([account, conversations]) => {
+        setAccount(account);
+        setRelatedConversations(conversations);
+      })
       .catch((err) =>
         logger.error('Error retrieving related conversations:', err)
       )
@@ -110,7 +119,7 @@ const RelatedCustomerConversations = ({
     return messages && messages.length > 0;
   });
 
-  if (loading) {
+  if (loading || !account) {
     return <Spinner size={16} />;
   } else if (conversationsWithMessages.length === 0) {
     return (
@@ -126,6 +135,7 @@ const RelatedCustomerConversations = ({
         return (
           <RelatedConversationItem
             key={conversation.id}
+            account={account}
             conversation={conversation}
           />
         );

--- a/assets/src/components/conversations/RelatedCustomerConversations.tsx
+++ b/assets/src/components/conversations/RelatedCustomerConversations.tsx
@@ -9,6 +9,7 @@ import {
   getColorByUuid,
   getSenderIdentifier,
   getSenderProfilePhoto,
+  isAgentMessage,
 } from './support';
 import * as API from '../../api';
 import {Account, Conversation} from '../../types';
@@ -35,12 +36,11 @@ const RelatedConversationItem = ({
   const ts = recent ? recent.created_at : created_at;
   const created = dayjs.utc(ts);
   const date = formatShortRelativeTime(created);
-  const {user, customer} = recent;
+  const {customer_id: customerId} = recent;
   const name = getSenderIdentifier(recent, account);
   const profilePhotoUrl = getSenderProfilePhoto(recent, account);
-  const isAgent = !!user;
+  const isAgent = isAgentMessage(recent);
   const preview = recent.body ? recent.body : '...';
-  const customerId = customer && customer.id;
   const color = customerId ? getColorByUuid(customerId) : colors.gray[0];
   const isOpen = status === 'open';
   const url = isOpen

--- a/assets/src/components/conversations/SharedConversation.tsx
+++ b/assets/src/components/conversations/SharedConversation.tsx
@@ -75,7 +75,9 @@ class SharedConversationContainer extends React.Component<Props, State> {
             sx={{p: 3}}
             loading={loading}
             messages={messages}
-            isAgentMessage={(message: Message) => message && !!message.user_id}
+            isAgentMessage={({user_id: userId, type: messageType}: Message) =>
+              messageType !== 'bot' && !!userId
+            }
             setScrollRef={(el) => (this.scrollToEl = el)}
           />
         </Box>

--- a/assets/src/components/conversations/SharedConversation.tsx
+++ b/assets/src/components/conversations/SharedConversation.tsx
@@ -75,9 +75,6 @@ class SharedConversationContainer extends React.Component<Props, State> {
             sx={{p: 3}}
             loading={loading}
             messages={messages}
-            isAgentMessage={({user_id: userId, type: messageType}: Message) =>
-              messageType !== 'bot' && !!userId
-            }
             setScrollRef={(el) => (this.scrollToEl = el)}
           />
         </Box>

--- a/assets/src/components/conversations/support.ts
+++ b/assets/src/components/conversations/support.ts
@@ -1,4 +1,5 @@
 import {colors} from '../common';
+import {Account, Customer, Message, User} from '../../types';
 
 const {primary, gold, red, green, purple, magenta} = colors;
 
@@ -11,4 +12,50 @@ export const getColorByUuid = (uuid?: string | null) => {
   const color = [gold, red, green, purple, magenta][colorIndex];
 
   return color;
+};
+
+export const isBotMessage = (message: Message) => {
+  return message.type === 'bot';
+};
+
+export const getSenderIdentifier = (
+  message: Message,
+  account?: Account | null
+) => {
+  const {user, customer} = message;
+
+  if (isBotMessage(message)) {
+    return account?.company_name || 'Bot';
+  }
+
+  if (user) {
+    const {display_name, full_name, email} = user;
+
+    return display_name || full_name || email || 'Agent';
+  } else if (customer) {
+    const {name, email} = customer;
+
+    return name || email || 'Anonymous User';
+  } else {
+    return 'Anonymous User';
+  }
+};
+
+export const getSenderProfilePhoto = (
+  message: Message,
+  account?: Account | null
+) => {
+  const {user, customer} = message;
+
+  if (isBotMessage(message)) {
+    return account?.company_logo_url || null;
+  }
+
+  if (user) {
+    return user.profile_photo_url || null;
+  } else if (customer) {
+    return customer.profile_photo_url || null;
+  } else {
+    return null;
+  }
 };

--- a/assets/src/components/conversations/support.ts
+++ b/assets/src/components/conversations/support.ts
@@ -1,5 +1,5 @@
 import {colors} from '../common';
-import {Account, Customer, Message, User} from '../../types';
+import {Account, Message} from '../../types';
 
 const {primary, gold, red, green, purple, magenta} = colors;
 

--- a/assets/src/components/conversations/support.ts
+++ b/assets/src/components/conversations/support.ts
@@ -18,6 +18,10 @@ export const isBotMessage = (message: Message) => {
   return message.type === 'bot';
 };
 
+export const isAgentMessage = (message: Message) => {
+  return !isBotMessage(message) && !!message.user_id;
+};
+
 export const getSenderIdentifier = (
   message: Message,
   account?: Account | null

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -62,7 +62,7 @@ export type MessageType = 'reply' | 'note';
 export type Message = {
   id: string;
   body: string;
-  type?: 'reply' | 'note';
+  type?: 'reply' | 'note' | 'bot';
   private?: boolean;
   created_at: string;
   sent_at?: string;

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -69,7 +69,7 @@ defmodule ChatApi.Messages.Message do
       :metadata
     ])
     |> validate_required([:account_id, :conversation_id])
-    |> validate_inclusion(:type, ["reply", "note"])
+    |> validate_inclusion(:type, ["reply", "note", "bot"])
     |> validate_inclusion(:source, ["chat", "slack", "mattermost", "email", "sms"])
   end
 end


### PR DESCRIPTION
### Description

This PR adds support for "bot" messages. This will make it easier to indicate automated messages from webhooks/API in the UI.

(This PR only handles the dashboard use case, we'll need to update the chat widget UI separately)

### Screenshots

<img width="985" alt="Screen Shot 2021-04-13 at 5 00 18 PM" src="https://user-images.githubusercontent.com/5264279/114620801-f0cee980-9c79-11eb-9333-274d849fb29a.png">

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
