### PR TITLE
Adds ability to edit customer details page

### DIFF
--- a/assets/src/components/customers/CustomerDetailsPageV2.tsx
+++ b/assets/src/components/customers/CustomerDetailsPageV2.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link, RouteComponentProps} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Button, Empty, Title} from '../common';
+import {notification, Button, Empty, Title} from '../common';
 import {ArrowLeftOutlined} from '../icons';
 import * as API from '../../api';
 import {BrowserSession, Conversation, Customer} from '../../types';
@@ -13,21 +13,24 @@ import StartConversationButton from '../conversations/StartConversationButton';
 import CustomerDetailsSidebar from './CustomerDetailsSidebar';
 import {sortConversationMessages} from '../../utils';
 import CustomerDetailsCard from './CustomerDetailsCard';
+import EditCustomerDetailsModal from './EditCustomerDetailsModal';
 
 type Props = RouteComponentProps<{id: string}>;
 type State = {
   conversations: Array<Conversation>;
   customer: Customer | null;
-  session: BrowserSession | null;
   loading?: boolean;
+  session: BrowserSession | null;
+  isEditModalVisible: boolean;
 };
 
 class CustomerDetailsPage extends React.Component<Props, State> {
   state: State = {
     conversations: [],
     customer: null,
-    session: null,
     loading: true,
+    session: null,
+    isEditModalVisible: false,
   };
 
   async componentDidMount() {
@@ -98,12 +101,28 @@ class CustomerDetailsPage extends React.Component<Props, State> {
     this.props.history.push(url);
   };
 
-  handleCustomerDeleted = () => {
-    this.props.history.push('/customers');
+  handleCustomerUpdated = async () => {
+    const customer = await this.fetchCustomer();
+    this.setState({customer});
+    this.toggleIsEditModalVisible(false);
+    notification.success({
+      message: `Customer successfully updated!`,
+      duration: 10,
+    });
+  };
+
+  toggleIsEditModalVisible = (isEditModalVisible: boolean) => {
+    this.setState({isEditModalVisible});
   };
 
   render() {
-    const {loading, customer, conversations = [], session} = this.state;
+    const {
+      conversations = [],
+      customer,
+      isEditModalVisible,
+      loading,
+      session,
+    } = this.state;
 
     // TODO: add error handling when customer can't be loaded
     if (loading || !customer) {
@@ -138,54 +157,70 @@ class CustomerDetailsPage extends React.Component<Props, State> {
           </Link>
         </Flex>
 
-        <Flex sx={{height: '100%'}}>
-          <Box mr={3}>
-            <CustomerDetailsSidebar customer={customer} session={session} />
-          </Box>
+        <Box sx={{height: '100%'}}>
+          <Flex sx={{flexDirection: 'row-reverse'}} mb={3}>
+            <Button
+              type="primary"
+              onClick={() => this.toggleIsEditModalVisible(true)}
+            >
+              Edit
+            </Button>
+            <EditCustomerDetailsModal
+              customer={customer}
+              isVisible={isEditModalVisible}
+              onClose={() => this.toggleIsEditModalVisible(false)}
+              onUpdate={this.handleCustomerUpdated}
+            />
+          </Flex>
+          <Flex sx={{height: '100%'}}>
+            <Box mr={3}>
+              <CustomerDetailsSidebar customer={customer} session={session} />
+            </Box>
 
-          <Box sx={{flex: 3}}>
-            <CustomerDetailsCard>
-              <Flex
-                p={3}
-                sx={{
-                  borderBottom: '1px solid rgba(0,0,0,.06)',
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Title level={4}>Conversations</Title>
-                <StartConversationButton
-                  customerId={this.getCustomerId()}
-                  isDisabled={this.hasOpenConversation()}
-                  onInitializeNewConversation={this.refetchConversations}
-                />
-              </Flex>
+            <Box sx={{flex: 3}}>
+              <CustomerDetailsCard>
+                <Flex
+                  p={3}
+                  sx={{
+                    borderBottom: '1px solid rgba(0,0,0,.06)',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <Title level={4}>Conversations</Title>
+                  <StartConversationButton
+                    customerId={this.getCustomerId()}
+                    isDisabled={this.hasOpenConversation()}
+                    onInitializeNewConversation={this.refetchConversations}
+                  />
+                </Flex>
 
-              {conversations.length > 0 ? (
-                conversations.map((conversation) => {
-                  const {
-                    id: conversationId,
-                    customer_id: customerId,
-                    messages = [],
-                  } = conversation;
-                  const color = getColorByUuid(customerId);
-                  const sorted = sortConversationMessages(messages);
+                {conversations.length > 0 ? (
+                  conversations.map((conversation) => {
+                    const {
+                      id: conversationId,
+                      customer_id: customerId,
+                      messages = [],
+                    } = conversation;
+                    const color = getColorByUuid(customerId);
+                    const sorted = sortConversationMessages(messages);
 
-                  return (
-                    <ConversationItem
-                      key={conversationId}
-                      conversation={conversation}
-                      messages={sorted}
-                      color={color}
-                      onSelectConversation={this.handleSelectConversation}
-                    />
-                  );
-                })
-              ) : (
-                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
-              )}
-            </CustomerDetailsCard>
-          </Box>
-        </Flex>
+                    return (
+                      <ConversationItem
+                        key={conversationId}
+                        conversation={conversation}
+                        messages={sorted}
+                        color={color}
+                        onSelectConversation={this.handleSelectConversation}
+                      />
+                    );
+                  })
+                ) : (
+                  <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+                )}
+              </CustomerDetailsCard>
+            </Box>
+          </Flex>
+        </Box>
       </Flex>
     );
   }

--- a/assets/src/components/customers/CustomerDetailsPageV2.tsx
+++ b/assets/src/components/customers/CustomerDetailsPageV2.tsx
@@ -106,9 +106,13 @@ class CustomerDetailsPage extends React.Component<Props, State> {
     this.setState({customer});
     this.toggleIsEditModalVisible(false);
     notification.success({
-      message: `Customer successfully updated!`,
+      message: `Customer successfully updated`,
       duration: 10,
     });
+  };
+
+  handleCustomerDeleted = () => {
+    this.props.history.push('/customers');
   };
 
   toggleIsEditModalVisible = (isEditModalVisible: boolean) => {
@@ -169,6 +173,7 @@ class CustomerDetailsPage extends React.Component<Props, State> {
               customer={customer}
               isVisible={isEditModalVisible}
               onClose={() => this.toggleIsEditModalVisible(false)}
+              onDelete={this.handleCustomerDeleted}
               onUpdate={this.handleCustomerUpdated}
             />
           </Flex>

--- a/assets/src/components/customers/CustomerDetailsSidebar.tsx
+++ b/assets/src/components/customers/CustomerDetailsSidebar.tsx
@@ -23,6 +23,43 @@ import CustomerDetailsCard from './CustomerDetailsCard';
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
 
+const BasicDetailsSection = ({customer}: {customer: Customer}) => {
+  const {
+    email,
+    name,
+    phone,
+    id: customerId,
+    external_id: externalId,
+  } = customer;
+
+  return (
+    <CustomerDetailsSection title="Basic">
+      <CustomerDetailsProperty
+        icon={<UserOutlined style={{color: colors.primary}} />}
+        name="ID"
+        value={
+          <CustomerDetailsPropertyValue value={externalId || customerId} />
+        }
+      />
+      <CustomerDetailsProperty
+        icon={<UserOutlined style={{color: colors.primary}} />}
+        name="Name"
+        value={<CustomerDetailsPropertyValue value={name} />}
+      />
+      <CustomerDetailsProperty
+        icon={<MailOutlined style={{color: colors.primary}} />}
+        name="Email"
+        value={<CustomerDetailsPropertyValue value={email} />}
+      />
+      <CustomerDetailsProperty
+        icon={<PhoneOutlined style={{color: colors.primary}} />}
+        name="Phone"
+        value={<CustomerDetailsPropertyValue value={phone} />}
+      />
+    </CustomerDetailsSection>
+  );
+};
+
 export const CustomerDetailsSidebar = ({
   customer,
   session,
@@ -31,16 +68,12 @@ export const CustomerDetailsSidebar = ({
   session: BrowserSession | null;
 }) => {
   const {
-    email,
-    name,
     browser,
     os,
-    phone,
     pathname,
     title,
     company,
     id: customerId,
-    external_id: externalId,
     created_at: createdAt,
     last_seen_at: lastSeenAt,
     current_url: currentUrl,
@@ -55,30 +88,9 @@ export const CustomerDetailsSidebar = ({
       <Box p={3}>
         <Title level={4}>{title}</Title>
         <Divider dashed />
-        <CustomerDetailsSection title="Basic">
-          <CustomerDetailsProperty
-            icon={<UserOutlined style={{color: colors.primary}} />}
-            name="ID"
-            value={
-              <CustomerDetailsPropertyValue value={externalId || customerId} />
-            }
-          />
-          <CustomerDetailsProperty
-            icon={<UserOutlined style={{color: colors.primary}} />}
-            name="Name"
-            value={<CustomerDetailsPropertyValue value={name} />}
-          />
-          <CustomerDetailsProperty
-            icon={<MailOutlined style={{color: colors.primary}} />}
-            name="Email"
-            value={<CustomerDetailsPropertyValue value={email} />}
-          />
-          <CustomerDetailsProperty
-            icon={<PhoneOutlined style={{color: colors.primary}} />}
-            name="Phone"
-            value={<CustomerDetailsPropertyValue value={phone} />}
-          />
-        </CustomerDetailsSection>
+
+        <BasicDetailsSection customer={customer} />
+
         <Divider dashed />
         <CustomerDetailsSection title="Activity">
           <CustomerDetailsProperty

--- a/assets/src/components/customers/CustomerDetailsSidebar.tsx
+++ b/assets/src/components/customers/CustomerDetailsSidebar.tsx
@@ -23,43 +23,6 @@ import CustomerDetailsCard from './CustomerDetailsCard';
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
 
-const BasicDetailsSection = ({customer}: {customer: Customer}) => {
-  const {
-    email,
-    name,
-    phone,
-    id: customerId,
-    external_id: externalId,
-  } = customer;
-
-  return (
-    <CustomerDetailsSection title="Basic">
-      <CustomerDetailsProperty
-        icon={<UserOutlined style={{color: colors.primary}} />}
-        name="ID"
-        value={
-          <CustomerDetailsPropertyValue value={externalId || customerId} />
-        }
-      />
-      <CustomerDetailsProperty
-        icon={<UserOutlined style={{color: colors.primary}} />}
-        name="Name"
-        value={<CustomerDetailsPropertyValue value={name} />}
-      />
-      <CustomerDetailsProperty
-        icon={<MailOutlined style={{color: colors.primary}} />}
-        name="Email"
-        value={<CustomerDetailsPropertyValue value={email} />}
-      />
-      <CustomerDetailsProperty
-        icon={<PhoneOutlined style={{color: colors.primary}} />}
-        name="Phone"
-        value={<CustomerDetailsPropertyValue value={phone} />}
-      />
-    </CustomerDetailsSection>
-  );
-};
-
 export const CustomerDetailsSidebar = ({
   customer,
   session,
@@ -69,17 +32,21 @@ export const CustomerDetailsSidebar = ({
 }) => {
   const {
     browser,
+    company,
+    created_at: createdAt,
+    current_url: currentUrl,
+    email,
+    external_id: externalId,
+    id: customerId,
+    ip: lastIpAddress,
+    last_seen_at: lastSeenAt,
+    metadata = {},
+    name,
     os,
     pathname,
-    title,
-    company,
-    id: customerId,
-    created_at: createdAt,
-    last_seen_at: lastSeenAt,
-    current_url: currentUrl,
+    phone,
     time_zone: timezone,
-    ip: lastIpAddress,
-    metadata = {},
+    title,
   } = customer;
   const hasMetadata = !!metadata && Object.keys(metadata).length > 0;
 
@@ -89,9 +56,33 @@ export const CustomerDetailsSidebar = ({
         <Title level={4}>{title}</Title>
         <Divider dashed />
 
-        <BasicDetailsSection customer={customer} />
+        <CustomerDetailsSection title="Basic">
+          <CustomerDetailsProperty
+            icon={<UserOutlined style={{color: colors.primary}} />}
+            name="ID"
+            value={
+              <CustomerDetailsPropertyValue value={externalId || customerId} />
+            }
+          />
+          <CustomerDetailsProperty
+            icon={<UserOutlined style={{color: colors.primary}} />}
+            name="Name"
+            value={<CustomerDetailsPropertyValue value={name} />}
+          />
+          <CustomerDetailsProperty
+            icon={<MailOutlined style={{color: colors.primary}} />}
+            name="Email"
+            value={<CustomerDetailsPropertyValue value={email} />}
+          />
+          <CustomerDetailsProperty
+            icon={<PhoneOutlined style={{color: colors.primary}} />}
+            name="Phone"
+            value={<CustomerDetailsPropertyValue value={phone} />}
+          />
+        </CustomerDetailsSection>
 
         <Divider dashed />
+
         <CustomerDetailsSection title="Activity">
           <CustomerDetailsProperty
             icon={<CalendarOutlined style={{color: colors.primary}} />}
@@ -131,7 +122,9 @@ export const CustomerDetailsSidebar = ({
             </Box>
           )}
         </CustomerDetailsSection>
+
         <Divider dashed />
+
         <CustomerDetailsSection title="Device">
           <CustomerDetailsProperty
             icon={<GlobalOutlined style={{color: colors.primary}} />}
@@ -177,6 +170,7 @@ export const CustomerDetailsSidebar = ({
             <Divider dashed />
           </>
         )}
+
         <CustomerDetailsSection title="Tags">
           <SidebarCustomerTags customerId={customerId} />
         </CustomerDetailsSection>

--- a/assets/src/components/customers/EditCustomerDetailsModal.tsx
+++ b/assets/src/components/customers/EditCustomerDetailsModal.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import {Button, Modal, Text, Input} from '../common';
+import * as API from '../../api';
+import {Customer} from '../../types';
+import logger from '../../logger';
+
+// TODO: create date utility methods so we don't have to do this everywhere
+dayjs.extend(utc);
+
+type Props = {
+  customer: Customer;
+  isVisible: boolean;
+  onClose: () => void;
+  onUpdate: () => Promise<void>;
+};
+
+type State = {
+  email?: string;
+  error?: string;
+  isSaving: boolean;
+  name?: string;
+  phone?: string | number;
+};
+
+class EditCustomerDetailsModal extends React.Component<Props, State> {
+  state: State = {
+    email: this.props.customer.email,
+    isSaving: false,
+    name: this.props.customer.name,
+    phone: this.props.customer.phone,
+  };
+
+  handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({name: e.target.value});
+  };
+
+  handleChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({email: e.target.value});
+  };
+
+  handleChangePhone = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({phone: e.target.value});
+  };
+
+  handleSave = async () => {
+    this.setState({error: '', isSaving: true});
+
+    const {customer, onUpdate} = this.props;
+    const {name, email, phone} = this.state;
+
+    try {
+      await API.updateCustomer(customer.id, {
+        name,
+        email,
+        phone,
+      });
+      await onUpdate();
+    } catch (err) {
+      logger.error('Failed to update customer', err);
+      const error =
+        err.response?.body?.error?.message ||
+        'Something went wrong. Please try again later.';
+
+      this.setState({error, isSaving: false});
+    }
+
+    this.setState({isSaving: false});
+  };
+
+  render() {
+    const {isVisible, onClose} = this.props;
+    const {isSaving, name, email, phone, error} = this.state;
+
+    return (
+      <Modal
+        title="Edit customer"
+        visible={isVisible}
+        onCancel={onClose}
+        onOk={onClose}
+        footer={
+          <Flex sx={{justifyContent: 'space-between'}}>
+            <Button onClick={onClose} type="link">
+              Cancel
+            </Button>
+            <Button
+              onClick={this.handleSave}
+              disabled={isSaving}
+              type="primary"
+            >
+              Save
+            </Button>
+          </Flex>
+        }
+      >
+        <Box mb={2} sx={{flex: 1}}>
+          <Box>
+            <Text strong>Name</Text>
+          </Box>
+          <Box pr={2} mb={12}>
+            <Input
+              style={{marginBottom: -8}}
+              id="name"
+              type="text"
+              value={name}
+              onChange={this.handleChangeName}
+            />
+          </Box>
+        </Box>
+
+        <Box mb={2} sx={{flex: 1}}>
+          <Box>
+            <Text strong>Email</Text>
+          </Box>
+          <Box pr={2} mb={12}>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={this.handleChangeEmail}
+            />
+          </Box>
+        </Box>
+
+        <Box mb={2} sx={{flex: 1}}>
+          <Box>
+            <Text strong>Phone</Text>
+          </Box>
+          <Box pr={2} mb={12}>
+            <Input
+              id="phone"
+              type="text"
+              value={phone}
+              onChange={this.handleChangePhone}
+            />
+          </Box>
+
+          {error && (
+            <Box mt={2}>
+              <Text type="danger">{error}</Text>
+            </Box>
+          )}
+        </Box>
+      </Modal>
+    );
+  }
+}
+
+export default EditCustomerDetailsModal;


### PR DESCRIPTION
### Description

As a follow-up to https://github.com/papercups-io/papercups/commit/048caba52c81cd517b5bdf871c427bb28c3f56c8, this commit adds the ability to edit the customer from the customer details page. 

### Screenshots

#### Editing a user
https://user-images.githubusercontent.com/1361509/114769464-3f42bd80-9d38-11eb-99a3-4e1f8917907f.mp4

#### When the server returns an error
<img width="601" alt="CleanShot 2021-04-14 at 15 35 01@2x" src="https://user-images.githubusercontent.com/1361509/114769517-4cf84300-9d38-11eb-8e49-c62e85568713.png">

#### Deletion flow
https://user-images.githubusercontent.com/1361509/114775980-f0008b00-9d3f-11eb-9b99-b6886d6696d0.mp4

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
