### PR TITLE
Fix auto-assignment and auto-reopening conversations

### DIFF
--- a/lib/chat_api/accounts.ex
+++ b/lib/chat_api/accounts.ex
@@ -181,6 +181,16 @@ defmodule ChatApi.Accounts do
     |> Repo.one()
   end
 
+  @spec get_primary_user(binary()) :: User.t()
+  def get_primary_user(account_id) do
+    User
+    |> where(account_id: ^account_id, role: "admin")
+    |> where([u], is_nil(u.disabled_at) and is_nil(u.archived_at))
+    |> order_by(asc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
   @spec is_outside_working_hours?(Account.t(), DateTime.t()) :: boolean()
   def is_outside_working_hours?(%Account{working_hours: working_hours}, datetime)
       when is_list(working_hours) do

--- a/lib/workers/sync_gmail_inbox.ex
+++ b/lib/workers/sync_gmail_inbox.ex
@@ -252,6 +252,6 @@ defmodule ChatApi.Workers.SyncGmailInbox do
     |> Messages.Notification.notify(:slack, async: false)
     |> Messages.Notification.notify(:mattermost, async: false)
     # NB: for email threads, for now we want to reopen the conversation if it was closed
-    |> Messages.Helpers.handle_post_creation_conversation_updates(%{status: "open"})
+    |> Messages.Helpers.handle_post_creation_conversation_updates()
   end
 end

--- a/test/chat_api_web/controllers/slack_controller_test.exs
+++ b/test/chat_api_web/controllers/slack_controller_test.exs
@@ -12,7 +12,7 @@ defmodule ChatApiWeb.SlackControllerTest do
 
   setup %{conn: conn} do
     account = insert(:account)
-    user = insert(:user, account: account)
+    user = insert(:user, account: account, role: "admin")
     customer = insert(:customer, account: account, email: @email)
     conversation = insert(:conversation, account: account, customer: customer)
     auth = insert(:slack_authorization, account: account, channel: @slack_channel)


### PR DESCRIPTION
### Description

- [x] Fixes auto-assignment (we were auto-assigning the last person to join the account)
- [x] Fixes auto-reopening conversations when a customer replies to a closed conversation (happens in slack sync)
- [x] Fixes double sending in Slack

### Issue

Fixes https://github.com/papercups-io/papercups/issues/727
Potential fix for https://github.com/papercups-io/papercups/issues/738 (need to test more)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
