### PR TITLE
Refactors customer details page conversation into a separate component

### DIFF
--- a/assets/src/components/customers/CustomerDetailsConversations.tsx
+++ b/assets/src/components/customers/CustomerDetailsConversations.tsx
@@ -1,0 +1,113 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {useHistory} from 'react-router-dom';
+import {Flex} from 'theme-ui';
+import {Empty} from '../common';
+import Spinner from '../Spinner';
+import * as API from '../../api';
+import {Conversation} from '../../types';
+import {getColorByUuid} from '../conversations/support';
+import ConversationItem from '../conversations/ConversationItem';
+import StartConversationButton from '../conversations/StartConversationButton';
+import {sortConversationMessages} from '../../utils';
+
+type Props = {customerId: string};
+
+const CustomerDetailsConversations = ({customerId}: Props) => {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const history = useHistory();
+
+  const hasOpenConversation = useMemo(() => {
+    const openConversation = conversations.find(
+      (conversation) => conversation.status === 'open'
+    );
+
+    return !!openConversation;
+  }, [conversations]);
+
+  const fetchConversations = () => {
+    (async () => {
+      setIsLoading(true);
+
+      const {data: conversations} = await API.fetchConversations({
+        customer_id: customerId,
+      });
+
+      setConversations(conversations);
+      setIsLoading(false);
+    })();
+  };
+
+  const handleSelectConversation = (conversationId: string) => {
+    const conversation = conversations.find(
+      (conversation) => conversation.id === conversationId
+    );
+    const isClosed = conversation && conversation.status === 'closed';
+    const url = isClosed
+      ? `/conversations/closed?cid=${conversationId}`
+      : `/conversations/all?cid=${conversationId}`;
+
+    history.push(url);
+  };
+
+  useEffect(fetchConversations, [customerId]);
+
+  if (isLoading) {
+    return (
+      <Flex
+        p={4}
+        sx={{
+          flex: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100%',
+        }}
+      >
+        <Spinner size={40} />
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <Flex
+        p={3}
+        sx={{
+          flexDirection: 'row-reverse',
+        }}
+      >
+        <StartConversationButton
+          customerId={customerId}
+          isDisabled={hasOpenConversation}
+          onInitializeNewConversation={fetchConversations}
+        />
+      </Flex>
+
+      {conversations.length > 0 ? (
+        conversations.map((conversation) => {
+          const {
+            id: conversationId,
+            customer_id: customerId,
+            messages = [],
+          } = conversation;
+          const color = getColorByUuid(customerId);
+          const sorted = sortConversationMessages(messages);
+
+          return (
+            <ConversationItem
+              key={conversationId}
+              conversation={conversation}
+              messages={sorted}
+              color={color}
+              onSelectConversation={handleSelectConversation}
+            />
+          );
+        })
+      ) : (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+      )}
+    </>
+  );
+};
+
+export default CustomerDetailsConversations;

--- a/assets/src/components/customers/CustomerDetailsPrimarySection.tsx
+++ b/assets/src/components/customers/CustomerDetailsPrimarySection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {Box} from 'theme-ui';
+import {Tabs} from '../common';
+import CustomerDetailsCard from './CustomerDetailsCard';
+import CustomerDetailsConversations from './CustomerDetailsConversations';
+
+const {TabPane} = Tabs;
+
+enum TAB_KEYS {
+  Conversations = 'Conversations',
+  Notes = 'Notes',
+}
+
+type Props = {customerId: string};
+type State = {};
+
+class CustomerDetailsPrimarySection extends React.Component<Props, State> {
+  render() {
+    return (
+      <CustomerDetailsCard>
+        <Box>
+          <Tabs
+            defaultActiveKey={TAB_KEYS.Conversations}
+            size="large"
+            tabBarStyle={{paddingLeft: '16px', marginBottom: '0'}}
+          >
+            <TabPane tab={TAB_KEYS.Conversations} key={TAB_KEYS.Conversations}>
+              <CustomerDetailsConversations
+                customerId={this.props.customerId}
+              />
+            </TabPane>
+            <TabPane tab={TAB_KEYS.Notes} key={TAB_KEYS.Notes}>
+              Notes
+            </TabPane>
+          </Tabs>
+        </Box>
+      </CustomerDetailsCard>
+    );
+  }
+}
+
+export default CustomerDetailsPrimarySection;


### PR DESCRIPTION
### Description

As part of the redesign of the customer details page, we want to move conversation and notes into the bigger unit. This commit refactors the conversation into its own component and nests it under a sub-menu. 

Work for the notes section will come in a follow-up commit.

### Screenshots

https://user-images.githubusercontent.com/1361509/115076945-46e69b80-9ecb-11eb-80ce-21a1fcddb672.mp4

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [x] No frontend compilation warnings
