### PR TITLE
Extracts markdown rendering out of ChatMessageBox.tsx

### DIFF
--- a/assets/src/components/MarkdownRenderer.tsx
+++ b/assets/src/components/MarkdownRenderer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import breaks from 'remark-breaks';
+import {Twemoji} from 'react-emoji-render';
+import {allowedNodeTypes} from './common';
+
+const renderers = {
+  text: (props: any) => {
+    return <Twemoji text={props.children} />;
+  },
+  image: (props: any) => {
+    // TODO: fix scroll behavior after image loads
+    return (
+      <img
+        alt={props.alt || ''}
+        src={props.src}
+        {...props}
+        style={{maxWidth: '100%', maxHeight: 400}}
+      />
+    );
+  },
+};
+
+type Props = {
+  className?: string;
+  source: string;
+};
+
+const MarkdownRenderer = ({className, source}: Props) => {
+  return (
+    <ReactMarkdown
+      className={`Text--markdown ${className}`}
+      source={source}
+      allowedTypes={allowedNodeTypes}
+      renderers={renderers}
+      plugins={[breaks]}
+    />
+  );
+};
+
+export default MarkdownRenderer;

--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -39,6 +39,7 @@ import {
 } from '@ant-design/colors';
 
 import DatePicker from './DatePicker';
+import MarkdownRenderer from './MarkdownRenderer';
 
 export type {UploadChangeParam} from 'antd/lib/upload';
 export type {UploadFile} from 'antd/lib/upload/interface';
@@ -122,6 +123,7 @@ export {
   Dropdown,
   Empty,
   Input,
+  MarkdownRenderer,
   Menu,
   Modal,
   notification,

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -1,28 +1,8 @@
 import React from 'react';
-import ReactMarkdown from 'react-markdown';
-import breaks from 'remark-breaks';
-import {Twemoji} from 'react-emoji-render';
 import {Box} from 'theme-ui';
-import {allowedNodeTypes} from '../common';
+import {MarkdownRenderer} from '../common';
 import {Attachment} from '../../types';
 import {PaperClipOutlined} from '../icons';
-
-const renderers = {
-  text: (props: any) => {
-    return <Twemoji text={props.children} />;
-  },
-  image: (props: any) => {
-    // TODO: fix scroll behavior after image loads
-    return (
-      <img
-        alt={props.alt || ''}
-        src={props.src}
-        {...props}
-        style={{maxWidth: '100%', maxHeight: 400}}
-      />
-    );
-  },
-};
 
 const ChatMessageAttachment = ({
   attachment,
@@ -78,13 +58,7 @@ const ChatMessageBox = ({
 
   return (
     <Box sx={parsedSx}>
-      <ReactMarkdown
-        className={`Text--markdown ${className}`}
-        source={content}
-        allowedTypes={allowedNodeTypes}
-        renderers={renderers}
-        plugins={[breaks]}
-      />
+      <MarkdownRenderer className={className} source={content} />
 
       {attachments && attachments.length > 0 && (
         <Box mt={2} className={className}>


### PR DESCRIPTION
### Description

We want to be able to re-use the markdown rendering logic in ChatMessageBox.tsx on the customer details page.

### Issue

https://github.com/papercups-io/papercups/issues/750

### Screenshots

![image](https://user-images.githubusercontent.com/1361509/115438823-db0e7680-a1db-11eb-9cc0-a4de562fd533.png)

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [x] No frontend compilation warnings
