### PR TITLE
Set up `Issue` boilerplate

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -6,6 +6,7 @@ import {
   BrowserSession,
   Conversation,
   Customer,
+  Issue,
   Tag,
   User,
   WidgetSettings,
@@ -1286,6 +1287,70 @@ export const removeCustomerTag = async (
     .delete(`/api/customers/${customerId}/tags/${tagId}`)
     .set('Authorization', token)
     .then((res) => res.body.data);
+};
+
+export const fetchAllIssues = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/issues`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const fetchIssueById = async (id: string, token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/issues/${id}`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const createIssue = async (
+  issue: Partial<Issue>,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/issues`)
+    .send({issue})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const updateIssue = async (
+  id: string,
+  issue: Partial<Issue>,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .put(`/api/issues/${id}`)
+    .send({issue})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const deleteIssue = async (id: string, token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/issues/${id}`)
+    .set('Authorization', token)
+    .then((res) => res.body);
 };
 
 type BrowserSessionFilters = {

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -66,6 +66,7 @@ import UpdateCompanyPage from './companies/UpdateCompanyPage';
 import CompanyDetailsPage from './companies/CompanyDetailsPage';
 import TagsOverview from './tags/TagsOverview';
 import TagDetailsPage from './tags/TagDetailsPage';
+import IssuesOverview from './issues/IssuesOverview';
 
 const {
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
@@ -459,6 +460,7 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/sessions*" component={SessionsOverview} />
           <Route path="/tags/:id" component={TagDetailsPage} />
           <Route path="/tags" component={TagsOverview} />
+          <Route path="/issues" component={IssuesOverview} />
           <Route path="*" render={() => <Redirect to="/conversations/all" />} />
         </Switch>
       </Layout>

--- a/assets/src/components/issues/IssuesOverview.tsx
+++ b/assets/src/components/issues/IssuesOverview.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import {
   Alert,
@@ -43,6 +42,8 @@ const IssuesTable = ({
             return <Tag>unstarted</Tag>;
           case 'in_progress':
             return <Tag color="orange">in progress</Tag>;
+          case 'in_review':
+            return <Tag color="blue">in review</Tag>;
           case 'done':
             return <Tag color="green">done</Tag>;
           case 'closed':

--- a/assets/src/components/issues/IssuesOverview.tsx
+++ b/assets/src/components/issues/IssuesOverview.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {Box, Flex} from 'theme-ui';
+import {
+  Alert,
+  Button,
+  Input,
+  Paragraph,
+  Table,
+  Tag,
+  Text,
+  Title,
+} from '../common';
+import {PlusOutlined} from '../icons';
+import * as API from '../../api';
+import * as T from '../../types';
+import logger from '../../logger';
+import NewIssueModal from './NewIssueModal';
+
+const IssuesTable = ({
+  loading,
+  issues,
+}: {
+  loading?: boolean;
+  issues: Array<T.Issue>;
+}) => {
+  const data = issues
+    .map((issue) => {
+      return {key: issue.id, ...issue};
+    })
+    .sort((a, b) => {
+      return +new Date(b.updated_at) - +new Date(a.updated_at);
+    });
+
+  const columns = [
+    {
+      title: 'Status',
+      dataIndex: 'state',
+      key: 'state',
+      render: (value: string) => {
+        switch (value) {
+          case 'unstarted':
+            return <Tag>unstarted</Tag>;
+          case 'in_progress':
+            return <Tag color="orange">in progress</Tag>;
+          case 'done':
+            return <Tag color="green">done</Tag>;
+          case 'closed':
+            return <Tag color="red">closed</Tag>;
+          default:
+            return <Tag>{value.split('_').join(' ')}</Tag>;
+        }
+      },
+    },
+    {
+      title: 'Title',
+      dataIndex: 'title',
+      key: 'title',
+      render: (value: string, record: T.Issue) => {
+        const {github_issue_url: githubIssueUrl} = record;
+
+        if (githubIssueUrl) {
+          return (
+            <a href={githubIssueUrl} target="_blank" rel="noopener noreferrer">
+              {value}
+            </a>
+          );
+        }
+
+        return <Text>{value}</Text>;
+      },
+    },
+    {
+      title: 'Description',
+      dataIndex: 'body',
+      key: 'body',
+      render: (value: string) => {
+        return value || '--';
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (value: string, record: any) => {
+        // TODO: add after implementing IssueDetailsPage
+        return null;
+      },
+    },
+  ];
+
+  return <Table loading={loading} dataSource={data} columns={columns} />;
+};
+
+type Props = {};
+type State = {
+  filterQuery: string;
+  filteredIssues: Array<T.Issue>;
+  isNewIssueModalVisible: boolean;
+  loading: boolean;
+  issues: Array<T.Issue>;
+};
+
+const filterIssuesByQuery = (
+  issues: Array<T.Issue>,
+  query?: string
+): Array<T.Issue> => {
+  if (!query || !query.length) {
+    return issues;
+  }
+
+  return issues.filter((issue) => {
+    const {id, title, body} = issue;
+
+    const words = [id, title, body]
+      .filter((str) => str && String(str).trim().length > 0)
+      .join(' ')
+      .replace('_', ' ')
+      .split(' ')
+      .map((str) => str.toLowerCase());
+
+    const queries = query.split(' ').map((str) => str.toLowerCase());
+
+    return words.some((word) => {
+      return queries.every((q) => word.indexOf(q) !== -1);
+    });
+  });
+};
+
+class IssuesOverview extends React.Component<Props, State> {
+  state: State = {
+    filteredIssues: [],
+    filterQuery: '',
+    isNewIssueModalVisible: false,
+    loading: true,
+    issues: [],
+  };
+
+  async componentDidMount() {
+    await this.handleRefreshIssues();
+  }
+
+  handleSearchIssues = (filterQuery: string) => {
+    const {issues = []} = this.state;
+
+    if (!filterQuery?.length) {
+      this.setState({filterQuery: '', filteredIssues: issues});
+    }
+
+    this.setState({
+      filterQuery,
+      filteredIssues: filterIssuesByQuery(issues, filterQuery),
+    });
+  };
+
+  handleRefreshIssues = async () => {
+    try {
+      const {filterQuery} = this.state;
+      const issues = await API.fetchAllIssues();
+
+      this.setState({
+        filteredIssues: filterIssuesByQuery(issues, filterQuery),
+        loading: false,
+        issues,
+      });
+    } catch (err) {
+      logger.error('Error loading issues!', err);
+
+      this.setState({loading: false});
+    }
+  };
+
+  handleOpenNewIssueModal = () => {
+    this.setState({isNewIssueModalVisible: true});
+  };
+
+  handleNewIssueModalClosed = () => {
+    this.setState({isNewIssueModalVisible: false});
+  };
+
+  handleNewIssueCreated = () => {
+    this.handleNewIssueModalClosed();
+    this.handleRefreshIssues();
+  };
+
+  render() {
+    const {loading, isNewIssueModalVisible, filteredIssues = []} = this.state;
+
+    return (
+      <Box p={4} sx={{maxWidth: 1080}}>
+        <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
+          <Title level={3}>Issues (beta)</Title>
+
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={this.handleOpenNewIssueModal}
+          >
+            New issue
+          </Button>
+        </Flex>
+
+        <NewIssueModal
+          visible={isNewIssueModalVisible}
+          onSuccess={this.handleNewIssueCreated}
+          onCancel={this.handleNewIssueModalClosed}
+        />
+
+        <Box mb={4}>
+          <Paragraph>
+            Use issues to track and manage feedback from your customers.
+          </Paragraph>
+
+          <Alert
+            message={
+              <Text>
+                This page is still a work in progress &mdash; more features
+                coming soon!
+              </Text>
+            }
+            type="info"
+            showIcon
+          />
+        </Box>
+
+        <Box mb={3}>
+          <Input.Search
+            placeholder="Search issues..."
+            allowClear
+            onSearch={this.handleSearchIssues}
+            style={{width: 400}}
+          />
+        </Box>
+
+        <Box my={4}>
+          <IssuesTable loading={loading} issues={filteredIssues} />
+        </Box>
+      </Box>
+    );
+  }
+}
+
+export default IssuesOverview;

--- a/assets/src/components/issues/NewIssueModal.tsx
+++ b/assets/src/components/issues/NewIssueModal.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import {capitalize} from 'lodash';
+import {Button, Input, Modal, Select, Text, TextArea} from '../common';
+import * as API from '../../api';
+import logger from '../../logger';
+import {formatServerError} from '../../utils';
+
+const NewIssueModal = ({
+  visible,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  onSuccess: (params: any) => void;
+  onCancel: () => void;
+}) => {
+  const [title, setTitle] = React.useState('');
+  const [body, setBody] = React.useState('');
+  const [githubIssueUrl, setGithubIssueUrl] = React.useState('');
+  const [status, setStatus] = React.useState('unstarted');
+  const [error, setErrorMessage] = React.useState<string | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const handleChangeTitle = (e: any) => setTitle(e.target.value);
+  const handleChangeBody = (e: any) => setBody(e.target.value);
+  const handleChangeGithubIssueUrl = (e: any) =>
+    setGithubIssueUrl(e.target.value);
+
+  const resetInputFields = () => {
+    setTitle('');
+    setBody('');
+    setGithubIssueUrl('');
+    setStatus('');
+    setErrorMessage(null);
+  };
+
+  const handleCancelIssue = () => {
+    onCancel();
+    resetInputFields();
+  };
+
+  const handleCreateIssue = async () => {
+    setIsSaving(true);
+
+    return API.createIssue({
+      title,
+      body,
+      github_issue_url: githubIssueUrl,
+      state: status,
+    })
+      .then((result) => {
+        onSuccess(result);
+        resetInputFields();
+      })
+      .catch((err) => {
+        logger.error('Error creating issue:', err);
+        const errorMessage = formatServerError(err);
+        setErrorMessage(errorMessage);
+      })
+      .finally(() => setIsSaving(false));
+  };
+
+  return (
+    <Modal
+      title="Create new issue"
+      visible={visible}
+      width={400}
+      onOk={handleCreateIssue}
+      onCancel={handleCancelIssue}
+      footer={[
+        <Button key="cancel" onClick={handleCancelIssue}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleCreateIssue}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Box mb={3}>
+          <label htmlFor="title">Title</label>
+          <Input
+            id="title"
+            type="text"
+            value={title}
+            onChange={handleChangeTitle}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="body">Description</label>
+          <TextArea
+            id="body"
+            placeholder="Optional"
+            value={body}
+            onChange={handleChangeBody}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="github_issue_url">GitHub Issue URL</label>
+          <Input
+            id="github_issue_url"
+            type="text"
+            placeholder="https://github.com/my/repo/issues/123"
+            value={githubIssueUrl}
+            onChange={handleChangeGithubIssueUrl}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="state">Status</label>
+          <Box>
+            <Select
+              style={{width: '100%'}}
+              value={status}
+              onChange={setStatus}
+              options={['unstarted', 'in_progress', 'done', 'closed'].map(
+                (value: string) => {
+                  const formatted = value.split('_').join(' ');
+
+                  return {value, label: capitalize(formatted)};
+                }
+              )}
+            />
+          </Box>
+        </Box>
+
+        {error && (
+          <Box mb={-3}>
+            <Text type="danger">{error}</Text>
+          </Box>
+        )}
+      </Box>
+    </Modal>
+  );
+};
+
+export default NewIssueModal;

--- a/assets/src/components/issues/NewIssueModal.tsx
+++ b/assets/src/components/issues/NewIssueModal.tsx
@@ -3,6 +3,7 @@ import {Box} from 'theme-ui';
 import {capitalize} from 'lodash';
 import {Button, Input, Modal, Select, Text, TextArea} from '../common';
 import * as API from '../../api';
+import {IssueState} from '../../types';
 import logger from '../../logger';
 import {formatServerError} from '../../utils';
 
@@ -15,10 +16,11 @@ const NewIssueModal = ({
   onSuccess: (params: any) => void;
   onCancel: () => void;
 }) => {
+  const DEFAULT_ISSUE_STATE: IssueState = 'unstarted';
   const [title, setTitle] = React.useState('');
   const [body, setBody] = React.useState('');
   const [githubIssueUrl, setGithubIssueUrl] = React.useState('');
-  const [status, setStatus] = React.useState('unstarted');
+  const [status, setStatus] = React.useState<IssueState>(DEFAULT_ISSUE_STATE);
   const [error, setErrorMessage] = React.useState<string | null>(null);
   const [isSaving, setIsSaving] = React.useState(false);
 
@@ -31,7 +33,7 @@ const NewIssueModal = ({
     setTitle('');
     setBody('');
     setGithubIssueUrl('');
-    setStatus('');
+    setStatus(DEFAULT_ISSUE_STATE);
     setErrorMessage(null);
   };
 
@@ -118,13 +120,17 @@ const NewIssueModal = ({
               style={{width: '100%'}}
               value={status}
               onChange={setStatus}
-              options={['unstarted', 'in_progress', 'done', 'closed'].map(
-                (value: string) => {
-                  const formatted = value.split('_').join(' ');
+              options={[
+                'unstarted',
+                'in_progress',
+                'in_review',
+                'done',
+                'closed',
+              ].map((value: string) => {
+                const formatted = value.split('_').join(' ');
 
-                  return {value, label: capitalize(formatted)};
-                }
-              )}
+                return {value, label: capitalize(formatted)};
+              })}
             />
           </Box>
         </Box>

--- a/assets/src/components/tags/TagsOverview.tsx
+++ b/assets/src/components/tags/TagsOverview.tsx
@@ -54,10 +54,10 @@ const TagsTable = ({
       dataIndex: 'action',
       key: 'action',
       render: (value: string, record: any) => {
-        const {id: companyId} = record;
+        const {id: tagId} = record;
 
         return (
-          <Link to={`/tags/${companyId}`}>
+          <Link to={`/tags/${tagId}`}>
             <Button>View</Button>
           </Link>
         );
@@ -167,7 +167,6 @@ class TagsOverview extends React.Component<Props, State> {
         <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
           <Title level={3}>Tags (beta)</Title>
 
-          {/* TODO: implement me! */}
           <Button
             type="primary"
             icon={<PlusOutlined />}

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -123,11 +123,18 @@ export type Tag = {
   updated_at: string;
 };
 
+export type IssueState =
+  | 'unstarted'
+  | 'in_progress'
+  | 'in_review'
+  | 'done'
+  | 'closed';
+
 export type Issue = {
   id: string;
   title: string;
   body?: string;
-  state: string;
+  state: IssueState;
   github_issue_url?: string;
   created_at: string;
   updated_at: string;

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -123,6 +123,16 @@ export type Tag = {
   updated_at: string;
 };
 
+export type Issue = {
+  id: string;
+  title: string;
+  body?: string;
+  state: string;
+  github_issue_url?: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export type BrowserSession = {
   id: string;
   started_at: string;

--- a/lib/chat_api/issues.ex
+++ b/lib/chat_api/issues.ex
@@ -1,0 +1,61 @@
+defmodule ChatApi.Issues do
+  @moduledoc """
+  The Issues context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+  alias ChatApi.Issues.Issue
+  alias ChatApi.Conversations.Conversation
+  alias ChatApi.Customers.Customer
+
+  @spec list_issues(binary()) :: [Issue.t()]
+  def list_issues(account_id) do
+    Issue |> where(account_id: ^account_id) |> Repo.all()
+  end
+
+  @spec get_issue!(binary()) :: Issue.t()
+  def get_issue!(id) do
+    Issue |> Repo.get!(id)
+  end
+
+  @spec create_issue(map()) :: {:ok, Issue.t()} | {:error, Ecto.Changeset.t()}
+  def create_issue(attrs \\ %{}) do
+    %Issue{}
+    |> Issue.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_issue(Issue.t(), map()) :: {:ok, Issue.t()} | {:error, Ecto.Changeset.t()}
+  def update_issue(%Issue{} = issue, attrs) do
+    issue
+    |> Issue.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_issue(Issue.t()) :: {:ok, Issue.t()} | {:error, Ecto.Changeset.t()}
+  def delete_issue(%Issue{} = issue) do
+    Repo.delete(issue)
+  end
+
+  @spec change_issue(Issue.t(), map()) :: Ecto.Changeset.t()
+  def change_issue(%Issue{} = issue, attrs \\ %{}) do
+    Issue.changeset(issue, attrs)
+  end
+
+  @spec list_customers_by_issue(binary()) :: [Customer.t()]
+  def list_customers_by_issue(issue_id) do
+    Issue
+    |> preload(:customers)
+    |> Repo.get!(issue_id)
+    |> Map.get(:customers)
+  end
+
+  @spec list_conversations_by_issue(binary()) :: [Conversation.t()]
+  def list_conversations_by_issue(issue_id) do
+    Issue
+    |> preload(:conversations)
+    |> Repo.get!(issue_id)
+    |> Map.get(:conversations)
+  end
+end

--- a/lib/chat_api/issues/conversation_issue.ex
+++ b/lib/chat_api/issues/conversation_issue.ex
@@ -1,0 +1,35 @@
+defmodule ChatApi.Issues.ConversationIssue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.{Accounts.Account, Conversations.Conversation, Issues.Issue, Users.User}
+
+  @type t :: %__MODULE__{
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          conversation_id: Ecto.UUID.t(),
+          issue_id: Ecto.UUID.t(),
+          creator_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "conversation_issues" do
+    belongs_to(:account, Account)
+    belongs_to(:conversation, Conversation)
+    belongs_to(:issue, Issue)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:account_id, :conversation_id, :issue_id, :creator_id])
+    |> validate_required([:account_id, :conversation_id, :issue_id])
+  end
+end

--- a/lib/chat_api/issues/customer_issue.ex
+++ b/lib/chat_api/issues/customer_issue.ex
@@ -1,0 +1,35 @@
+defmodule ChatApi.Issues.CustomerIssue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.{Accounts.Account, Customers.Customer, Issues.Issue, Users.User}
+
+  @type t :: %__MODULE__{
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          customer_id: Ecto.UUID.t(),
+          issue_id: Ecto.UUID.t(),
+          creator_id: integer() | nil,
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "customer_issues" do
+    belongs_to(:account, Account)
+    belongs_to(:customer, Customer)
+    belongs_to(:issue, Issue)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:account_id, :customer_id, :issue_id, :creator_id])
+    |> validate_required([:account_id, :customer_id, :issue_id])
+  end
+end

--- a/lib/chat_api/issues/issue.ex
+++ b/lib/chat_api/issues/issue.ex
@@ -1,0 +1,65 @@
+defmodule ChatApi.Issues.Issue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Users.User
+  alias ChatApi.Issues.{ConversationIssue, CustomerIssue}
+
+  @type t :: %__MODULE__{
+          title: String.t(),
+          body: String.t() | nil,
+          state: String.t(),
+          github_issue_url: String.t() | nil,
+          closed_at: DateTime.t() | nil,
+          metadata: map() | nil,
+          # Relations
+          account_id: any(),
+          account: any(),
+          creator_id: any(),
+          creator: any(),
+          assignee_id: any(),
+          assignee: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "issues" do
+    field(:title, :string)
+    field(:body, :string)
+    field(:state, :string, default: "unstarted")
+    field(:closed_at, :utc_datetime)
+    field(:github_issue_url, :string)
+    field(:metadata, :map)
+
+    belongs_to(:account, Account)
+    belongs_to(:creator, User, foreign_key: :creator_id, references: :id, type: :integer)
+    belongs_to(:assignee, User, foreign_key: :assignee_id, references: :id, type: :integer)
+
+    has_many(:conversation_issues, ConversationIssue)
+    has_many(:conversations, through: [:conversation_issues, :conversation])
+    has_many(:customer_issues, CustomerIssue)
+    has_many(:customers, through: [:customer_issues, :customer])
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(issue, attrs) do
+    issue
+    |> cast(attrs, [
+      :title,
+      :body,
+      :state,
+      :github_issue_url,
+      :closed_at,
+      :account_id,
+      :creator_id,
+      :assignee_id
+    ])
+    |> validate_required([:title, :state, :account_id])
+  end
+end

--- a/lib/chat_api/issues/issue.ex
+++ b/lib/chat_api/issues/issue.ex
@@ -61,5 +61,12 @@ defmodule ChatApi.Issues.Issue do
       :assignee_id
     ])
     |> validate_required([:title, :state, :account_id])
+    |> validate_inclusion(:state, [
+      "unstarted",
+      "in_progress",
+      "in_review",
+      "done",
+      "closed"
+    ])
   end
 end

--- a/lib/chat_api/tags.ex
+++ b/lib/chat_api/tags.ex
@@ -10,11 +10,6 @@ defmodule ChatApi.Tags do
   alias ChatApi.Customers.Customer
   alias ChatApi.Tags.Tag
 
-  @spec list_tags() :: [Tag.t()]
-  def list_tags do
-    Repo.all(Tag)
-  end
-
   @spec list_tags(binary()) :: [Tag.t()]
   def list_tags(account_id) do
     Tag |> where(account_id: ^account_id) |> Repo.all()

--- a/lib/chat_api_web/controllers/issue_controller.ex
+++ b/lib/chat_api_web/controllers/issue_controller.ex
@@ -1,8 +1,8 @@
-defmodule ChatApiWeb.TagController do
+defmodule ChatApiWeb.IssueController do
   use ChatApiWeb, :controller
 
-  alias ChatApi.Tags
-  alias ChatApi.Tags.Tag
+  alias ChatApi.Issues
+  alias ChatApi.Issues.Issue
 
   action_fallback(ChatApiWeb.FallbackController)
 
@@ -12,8 +12,8 @@ defmodule ChatApiWeb.TagController do
     id = conn.path_params["id"]
 
     with %{account_id: account_id} <- conn.assigns.current_user,
-         tag = %{account_id: ^account_id} <- Tags.get_tag!(id) do
-      assign(conn, :current_tag, tag)
+         issue = %{account_id: ^account_id} <- Issues.get_issue!(id) do
+      assign(conn, :current_issue, issue)
     else
       _ -> ChatApiWeb.FallbackController.call(conn, {:error, :not_found}) |> halt()
     end
@@ -21,38 +21,38 @@ defmodule ChatApiWeb.TagController do
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(%{assigns: %{current_user: %{account_id: account_id}}} = conn, _params) do
-    tags = Tags.list_tags(account_id)
+    issues = Issues.list_issues(account_id)
 
-    render(conn, "index.json", tags: tags)
+    render(conn, "index.json", issues: issues)
   end
 
   @spec create(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def create(%{assigns: %{current_user: %{account_id: account_id, id: creator_id}}} = conn, %{
-        "tag" => tag_params
+        "issue" => issue_params
       }) do
-    with {:ok, %Tag{} = tag} <-
-           tag_params
+    with {:ok, %Issue{} = issue} <-
+           issue_params
            |> Map.merge(%{"creator_id" => creator_id, "account_id" => account_id})
-           |> Tags.create_tag() do
+           |> Issues.create_issue() do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", Routes.tag_path(conn, :show, tag))
-      |> render("show.json", tag: tag)
+      |> put_resp_header("location", Routes.issue_path(conn, :show, issue))
+      |> render("show.json", issue: issue)
     end
   end
 
   def show(conn, _params) do
-    render(conn, "show.json", tag: conn.assigns.current_tag)
+    render(conn, "show.json", issue: conn.assigns.current_issue)
   end
 
-  def update(conn, %{"tag" => tag_params}) do
-    with {:ok, %Tag{} = tag} <- Tags.update_tag(conn.assigns.current_tag, tag_params) do
-      render(conn, "show.json", tag: tag)
+  def update(conn, %{"issue" => issue_params}) do
+    with {:ok, %Issue{} = issue} <- Issues.update_issue(conn.assigns.current_issue, issue_params) do
+      render(conn, "show.json", issue: issue)
     end
   end
 
   def delete(conn, _params) do
-    with {:ok, %Tag{}} <- Tags.delete_tag(conn.assigns.current_tag) do
+    with {:ok, %Issue{}} <- Issues.delete_issue(conn.assigns.current_issue) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -130,6 +130,7 @@ defmodule ChatApiWeb.Router do
     resources("/notes", NoteController, except: [:new, :edit])
     resources("/event_subscriptions", EventSubscriptionController, except: [:new, :edit])
     resources("/tags", TagController, except: [:new, :edit])
+    resources("/issues", IssueController, except: [:new, :edit])
     resources("/browser_sessions", BrowserSessionController, except: [:create, :new, :edit])
     resources("/personal_api_keys", PersonalApiKeyController, except: [:new, :edit, :update])
     resources("/canned_responses", CannedResponseController, except: [:new, :edit])

--- a/lib/chat_api_web/views/github_authorization_view.ex
+++ b/lib/chat_api_web/views/github_authorization_view.ex
@@ -18,6 +18,8 @@ defmodule ChatApiWeb.GithubAuthorizationView do
   def render("github_authorization.json", %{github_authorization: github_authorization}) do
     %{
       id: github_authorization.id,
+      created_at: github_authorization.inserted_at,
+      updated_at: github_authorization.updated_at,
       token_type: github_authorization.token_type,
       scope: github_authorization.scope,
       github_installation_id: github_authorization.github_installation_id,

--- a/lib/chat_api_web/views/issue_view.ex
+++ b/lib/chat_api_web/views/issue_view.ex
@@ -1,0 +1,27 @@
+defmodule ChatApiWeb.IssueView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.IssueView
+
+  def render("index.json", %{issues: issues}) do
+    %{data: render_many(issues, IssueView, "issue.json")}
+  end
+
+  def render("show.json", %{issue: issue}) do
+    %{data: render_one(issue, IssueView, "issue.json")}
+  end
+
+  def render("issue.json", %{issue: issue}) do
+    %{
+      id: issue.id,
+      object: "issue",
+      title: issue.title,
+      body: issue.body,
+      state: issue.state,
+      github_issue_url: issue.github_issue_url,
+      closed_at: issue.closed_at,
+      account_id: issue.account_id,
+      creator_id: issue.creator_id,
+      assignee_id: issue.assignee_id
+    }
+  end
+end

--- a/priv/repo/migrations/20210420181716_create_issues.exs
+++ b/priv/repo/migrations/20210420181716_create_issues.exs
@@ -1,0 +1,59 @@
+defmodule ChatApi.Repo.Migrations.CreateIssues do
+  use Ecto.Migration
+
+  def change do
+    create table(:issues, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:title, :string, null: false)
+      add(:body, :text)
+      add(:state, :string, null: false, default: "unstarted")
+      add(:github_issue_url, :string)
+      add(:closed_at, :utc_datetime)
+      add(:metadata, :map)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+      add(:assignee_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(index(:issues, [:account_id]))
+    create(index(:issues, [:creator_id]))
+    create(index(:issues, [:assignee_id]))
+
+    create table(:conversation_issues, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:conversation_id, references(:conversations, type: :uuid, on_delete: :delete_all))
+      add(:issue_id, references(:issues, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(unique_index(:conversation_issues, [:account_id, :conversation_id, :issue_id]))
+    create(index(:conversation_issues, [:account_id]))
+    create(index(:conversation_issues, [:creator_id]))
+    create(index(:conversation_issues, [:conversation_id]))
+    create(index(:conversation_issues, [:issue_id]))
+
+    create table(:customer_issues, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:customer_id, references(:customers, type: :uuid, on_delete: :delete_all))
+      add(:issue_id, references(:issues, type: :uuid, on_delete: :delete_all))
+      add(:creator_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create(unique_index(:customer_issues, [:account_id, :customer_id, :issue_id]))
+    create(index(:customer_issues, [:account_id]))
+    create(index(:customer_issues, [:creator_id]))
+    create(index(:customer_issues, [:customer_id]))
+    create(index(:customer_issues, [:issue_id]))
+  end
+end

--- a/test/chat_api/issues_test.exs
+++ b/test/chat_api/issues_test.exs
@@ -1,0 +1,75 @@
+defmodule ChatApi.IssuesTest do
+  use ChatApi.DataCase
+
+  import ChatApi.Factory
+  alias ChatApi.Issues
+
+  describe "issues" do
+    alias ChatApi.Issues.Issue
+
+    @update_attrs %{title: "some updated title"}
+    @invalid_attrs %{title: nil}
+
+    setup do
+      account = insert(:account)
+      issue = insert(:issue, account: account)
+
+      {:ok, account: account, issue: issue}
+    end
+
+    test "list_issues/1 returns all issues for the given account", %{
+      account: account,
+      issue: issue
+    } do
+      issue_ids = Issues.list_issues(account.id) |> Enum.map(& &1.id)
+
+      assert issue_ids == [issue.id]
+    end
+
+    test "get_issue!/1 returns the issue with given id", %{issue: issue} do
+      result = Issues.get_issue!(issue.id)
+
+      assert issue.id == result.id
+      assert issue.title == result.title
+      assert issue.body == result.body
+      assert issue.state == result.state
+    end
+
+    test "create_issue/1 with valid data creates a issue" do
+      assert {:ok, %Issue{} = issue} =
+               Issues.create_issue(params_with_assocs(:issue, title: "new issue"))
+
+      assert issue.title == "new issue"
+    end
+
+    test "create_issue/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Issues.create_issue(@invalid_attrs)
+    end
+
+    test "update_issue/2 with valid data updates the issue", %{issue: issue} do
+      assert {:ok, %Issue{} = issue} = Issues.update_issue(issue, @update_attrs)
+      assert issue.title == "some updated title"
+    end
+
+    test "update_issue/2 with invalid data returns error changeset",
+         %{issue: issue} do
+      assert {:error, %Ecto.Changeset{}} = Issues.update_issue(issue, @invalid_attrs)
+
+      current = Issues.get_issue!(issue.id)
+
+      assert issue.id == current.id
+      assert issue.title == current.title
+      assert issue.body == current.body
+      assert issue.state == current.state
+    end
+
+    test "delete_issue/1 deletes the issue", %{issue: issue} do
+      assert {:ok, %Issue{}} = Issues.delete_issue(issue)
+      assert_raise Ecto.NoResultsError, fn -> Issues.get_issue!(issue.id) end
+    end
+
+    test "change_issue/1 returns a issue changeset", %{issue: issue} do
+      assert %Ecto.Changeset{} = Issues.change_issue(issue)
+    end
+  end
+end

--- a/test/chat_api/tags_test.exs
+++ b/test/chat_api/tags_test.exs
@@ -17,7 +17,7 @@ defmodule ChatApi.TagsTest do
       {:ok, account: account, tag: tag}
     end
 
-    test "list_tags/0 returns all tags", %{account: account, tag: tag} do
+    test "list_tags/1 returns all tags for the given account", %{account: account, tag: tag} do
       tag_ids = Tags.list_tags(account.id) |> Enum.map(& &1.id)
 
       assert tag_ids == [tag.id]

--- a/test/chat_api_web/controllers/issue_controller_test.exs
+++ b/test/chat_api_web/controllers/issue_controller_test.exs
@@ -1,0 +1,174 @@
+defmodule ChatApiWeb.IssueControllerTest do
+  use ChatApiWeb.ConnCase
+
+  import ChatApi.Factory
+  alias ChatApi.Issues.Issue
+
+  @create_attrs params_for(:issue, title: "some title")
+  @update_attrs %{
+    title: "some updated title"
+  }
+  @invalid_attrs %{title: nil}
+
+  setup %{conn: conn} do
+    account = insert(:account)
+    user = insert(:user, account: account)
+
+    conn = put_req_header(conn, "accept", "application/json")
+    authed_conn = Pow.Plug.assign_current_user(conn, user, [])
+
+    {:ok, conn: conn, authed_conn: authed_conn, account: account}
+  end
+
+  describe "index" do
+    test "lists all issues", %{authed_conn: authed_conn} do
+      resp = get(authed_conn, Routes.issue_path(authed_conn, :index))
+      assert json_response(resp, 200)["data"] == []
+    end
+  end
+
+  describe "create issue" do
+    test "renders issue when data is valid", %{authed_conn: authed_conn} do
+      resp = post(authed_conn, Routes.issue_path(authed_conn, :create), issue: @create_attrs)
+      assert %{"id" => id} = json_response(resp, 201)["data"]
+
+      resp = get(authed_conn, Routes.issue_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => _id,
+               "object" => "issue",
+               "title" => "some title"
+             } = json_response(resp, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn} do
+      resp = post(authed_conn, Routes.issue_path(authed_conn, :create), issue: @invalid_attrs)
+      assert json_response(resp, 422)["errors"] != %{}
+    end
+  end
+
+  describe "show issue" do
+    setup [:create_issue]
+
+    test "shows issue by id", %{
+      authed_conn: authed_conn,
+      issue: issue
+    } do
+      conn =
+        get(
+          authed_conn,
+          Routes.issue_path(authed_conn, :show, issue.id)
+        )
+
+      assert json_response(conn, 200)["data"]
+    end
+
+    test "renders 404 when asking for another user's issue", %{
+      authed_conn: authed_conn
+    } do
+      # Create a new account and give it a issue
+      another_account = insert(:account)
+
+      another_issue =
+        insert(:issue, %{
+          title: "Another issue title",
+          account: another_account
+        })
+
+      # Using the original session, try to delete the new account's issue
+      conn =
+        get(
+          authed_conn,
+          Routes.issue_path(authed_conn, :show, another_issue.id)
+        )
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "update issue" do
+    setup [:create_issue]
+
+    test "renders issue when data is valid", %{
+      authed_conn: authed_conn,
+      issue: %Issue{id: id} = issue
+    } do
+      conn =
+        put(authed_conn, Routes.issue_path(authed_conn, :update, issue), issue: @update_attrs)
+
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.issue_path(authed_conn, :show, id))
+
+      assert %{
+               "id" => _id,
+               "title" => "some updated title"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{authed_conn: authed_conn, issue: issue} do
+      conn =
+        put(authed_conn, Routes.issue_path(authed_conn, :update, issue), issue: @invalid_attrs)
+
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders 404 when updating another account's issue",
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a issue
+      another_account = insert(:account)
+
+      another_issue =
+        insert(:issue, %{
+          title: "Another issue title",
+          account: another_account
+        })
+
+      # Using the original session, try to update the new account's issue
+      conn =
+        put(
+          authed_conn,
+          Routes.issue_path(authed_conn, :update, another_issue),
+          issue: @update_attrs
+        )
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  describe "delete issue" do
+    setup [:create_issue]
+
+    test "deletes chosen issue", %{authed_conn: authed_conn, issue: issue} do
+      conn = delete(authed_conn, Routes.issue_path(authed_conn, :delete, issue))
+      assert response(conn, 204)
+
+      assert_error_sent(404, fn ->
+        get(authed_conn, Routes.issue_path(authed_conn, :show, issue))
+      end)
+    end
+
+    test "renders 404 when deleting another account's issue",
+         %{authed_conn: authed_conn} do
+      # Create a new account and give it a issue
+      another_account = insert(:account)
+
+      issue =
+        insert(:issue, %{
+          title: "Another issue title",
+          account: another_account
+        })
+
+      # Using the original session, try to delete the new account's issue
+      conn = delete(authed_conn, Routes.issue_path(authed_conn, :delete, issue))
+
+      assert json_response(conn, 404)
+    end
+  end
+
+  defp create_issue(%{account: account}) do
+    issue = insert(:issue, account: account)
+
+    %{issue: issue}
+  end
+end

--- a/test/chat_api_web/controllers/tag_controller_test.exs
+++ b/test/chat_api_web/controllers/tag_controller_test.exs
@@ -136,9 +136,9 @@ defmodule ChatApiWeb.TagControllerTest do
       conn = delete(authed_conn, Routes.tag_path(authed_conn, :delete, tag))
       assert response(conn, 204)
 
-      assert_error_sent 404, fn ->
+      assert_error_sent(404, fn ->
         get(authed_conn, Routes.tag_path(authed_conn, :show, tag))
-      end
+      end)
     end
 
     test "renders 404 when deleting another account's tag",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -109,6 +109,16 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def issue_factory do
+    %ChatApi.Issues.Issue{
+      title: sequence("some title"),
+      body: "some body",
+      state: "unstarted",
+      account: build(:account),
+      creator: build(:user)
+    }
+  end
+
   def message_factory do
     %ChatApi.Messages.Message{
       account: build(:account),


### PR DESCRIPTION
### Description

This PR will set up the `issues` table and some basic UI components for viewing issues.

### Issue

Fixes https://github.com/papercups-io/papercups/issues/749

### Screenshots

<img width="1303" alt="Screen Shot 2021-04-20 at 4 13 42 PM" src="https://user-images.githubusercontent.com/5264279/115458674-0735f180-a1f4-11eb-8331-95fb2e33de36.png">
<img width="1111" alt="Screen Shot 2021-04-20 at 4 13 35 PM" src="https://user-images.githubusercontent.com/5264279/115458677-0735f180-a1f4-11eb-91b2-f4fd562a87f8.png">

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
