### PR TITLE
Adds markdown rendering to customer notes

### DIFF
--- a/assets/src/components/customers/CustomerDetailsNotes.tsx
+++ b/assets/src/components/customers/CustomerDetailsNotes.tsx
@@ -3,7 +3,6 @@ import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
 
 import {
-  Button,
   colors,
   Divider,
   Empty,

--- a/assets/src/components/customers/CustomerDetailsNotes.tsx
+++ b/assets/src/components/customers/CustomerDetailsNotes.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import dayjs from 'dayjs';
 import {Box, Flex} from 'theme-ui';
 
-import {colors, Divider, Empty, Popconfirm, Text} from '../common';
+import {
+  Button,
+  colors,
+  Divider,
+  Empty,
+  MarkdownRenderer,
+  Popconfirm,
+  Text,
+} from '../common';
 import {CustomerNote} from '../../types';
 import {formatRelativeTime} from '../../utils';
 import * as API from '../../api';
@@ -114,36 +122,45 @@ const CustomerDetailNote = ({
   if (note.author) {
     const {display_name: displayName, full_name: fullName, email} = note.author;
     const authorName = displayName || fullName;
-    authorIdentifier = !!authorName ? `${authorName} · ${email}` : email;
+    authorIdentifier = !!authorName ? `${authorName} (${email})` : email;
   }
 
   return (
-    <Popconfirm
-      title="Delete this note?"
-      okText="Delete"
-      cancelText="Cancel"
-      placement="left"
-      onConfirm={() => onDeleteNote(note)}
+    <Box
+      py={3}
+      px={3}
+      mb={2}
+      sx={{
+        bg: colors.note,
+        borderRadius: 2,
+      }}
     >
-      <Box
-        py={2}
-        px={3}
-        mb={2}
-        sx={{
-          bg: colors.note,
-          borderRadius: 2,
-          cursor: 'pointer',
-        }}
-      >
-        <Box mb={3} sx={{whiteSpace: 'break-spaces'}}>
-          {note.body}
+      <Flex>
+        <Box mb={3} pr={3} sx={{flexGrow: 1}}>
+          <MarkdownRenderer source={note.body} />
         </Box>
-        <Flex sx={{justifyContent: 'space-between'}}>
-          <Text type="secondary">{authorIdentifier}</Text>
-          <Text type="secondary">{formatRelativeTime(dayjs(createdAt))}</Text>
-        </Flex>
-      </Box>
-    </Popconfirm>
+        <Popconfirm
+          title="Delete this note?"
+          okText="Delete"
+          cancelText="Cancel"
+          placement="left"
+          onConfirm={() => onDeleteNote(note)}
+        >
+          <Text
+            type="danger"
+            style={{cursor: 'pointer', alignSelf: 'flex-start'}}
+          >
+            Delete
+          </Text>
+        </Popconfirm>
+      </Flex>
+
+      <Text type="secondary">
+        <span>
+          {authorIdentifier} — {formatRelativeTime(dayjs(createdAt))}
+        </span>
+      </Text>
+    </Box>
   );
 };
 


### PR DESCRIPTION
### Description

Similarly to chat messages, we want to be able to write and render markdown in customer notes. 

Because we're introducing markdown, we need to be able to click on things like links. Instead of trigger the delete confirmation when the whole note is clicked, I introduced a Delete link in the top right corner.

### Issue

https://github.com/papercups-io/papercups/issues/750

### Screenshots

![image](https://user-images.githubusercontent.com/1361509/115456949-c63cdd80-a1f1-11eb-9761-7b0bb16c6263.png)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
