### PR TITLE
Adds ability to archive conversation from UI in both open/closed state

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -585,6 +585,20 @@ export const deleteConversation = async (
     .then((res) => res.body);
 };
 
+export const archiveConversation = async (
+  conversationId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/conversations/${conversationId}/archive`)
+    .set('Authorization', token)
+    .then((res) => res.body);
+};
+
 export const createNewMessage = async (
   conversationId: string,
   message: any,

--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -134,29 +134,14 @@ const ConversationHeader = ({
           </Box>
 
           {status === 'closed' ? (
-            <Fragment>
-              <Box mx={1}>
-                <Tooltip title="Reopen conversation" placement="bottomRight">
-                  <Button
-                    icon={<UploadOutlined />}
-                    onClick={() => onReopenConversation(conversationId)}
-                  />
-                </Tooltip>
-              </Box>
-              <Box mx={1}>
-                <Popconfirm
-                  title="Are you sure you want to delete this conversation?"
-                  okText="Yes"
-                  cancelText="No"
-                  placement="leftBottom"
-                  onConfirm={() => onDeleteConversation(conversationId)}
-                >
-                  <Tooltip title="Delete conversation" placement="bottomRight">
-                    <Button icon={<DeleteOutlined />} />
-                  </Tooltip>
-                </Popconfirm>
-              </Box>
-            </Fragment>
+            <Box mx={1}>
+              <Tooltip title="Reopen conversation" placement="bottomRight">
+                <Button
+                  icon={<UploadOutlined />}
+                  onClick={() => onReopenConversation(conversationId)}
+                />
+              </Tooltip>
+            </Box>
           ) : (
             <Box mx={1}>
               <Tooltip title="Close conversation" placement="bottomRight">
@@ -167,6 +152,20 @@ const ConversationHeader = ({
               </Tooltip>
             </Box>
           )}
+
+          <Box mx={1}>
+            <Popconfirm
+              title="Are you sure you want to delete this conversation?"
+              okText="Yes"
+              cancelText="No"
+              placement="leftBottom"
+              onConfirm={() => onDeleteConversation(conversationId)}
+            >
+              <Tooltip title="Delete conversation" placement="bottomRight">
+                <Button icon={<DeleteOutlined />} />
+              </Tooltip>
+            </Popconfirm>
+          </Box>
         </Flex>
       </Flex>
     </header>

--- a/assets/src/components/conversations/ConversationHeader.tsx
+++ b/assets/src/components/conversations/ConversationHeader.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react';
+import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';

--- a/assets/src/components/conversations/ConversationsProvider.tsx
+++ b/assets/src/components/conversations/ConversationsProvider.tsx
@@ -526,7 +526,7 @@ export class ConversationsProvider extends React.Component<Props, State> {
     const {conversationsById} = this.state;
 
     try {
-      await API.deleteConversation(conversationId);
+      await API.archiveConversation(conversationId);
 
       delete conversationsById[conversationId];
     } catch (err) {

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -136,6 +136,7 @@ defmodule ChatApiWeb.Router do
     resources("/canned_responses", CannedResponseController, except: [:new, :edit])
 
     get("/slack_conversation_threads", SlackConversationThreadController, :index)
+    post("/conversations/:conversation_id/archive", ConversationController, :archive)
     get("/conversations/:conversation_id/previous", ConversationController, :previous)
     get("/conversations/:conversation_id/related", ConversationController, :related)
     post("/conversations/:conversation_id/share", ConversationController, :share)

--- a/test/chat_api_web/controllers/conversation_controller_test.exs
+++ b/test/chat_api_web/controllers/conversation_controller_test.exs
@@ -155,6 +155,21 @@ defmodule ChatApiWeb.ConversationControllerTest do
     end
   end
 
+  describe "archive conversation" do
+    test "archives chosen conversation", %{
+      authed_conn: authed_conn,
+      conversation: %Conversation{id: id} = conversation
+    } do
+      conn = post(authed_conn, Routes.conversation_path(authed_conn, :archive, conversation))
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(authed_conn, Routes.conversation_path(authed_conn, :index))
+      ids = json_response(conn, 200)["data"] |> Enum.map(& &1["id"])
+
+      refute Enum.member?(ids, id)
+    end
+  end
+
   # TODO: add some more tests!
   describe "adding/removing tags" do
     test "adds a tag",


### PR DESCRIPTION
### Description

Adds ability to archive conversation from UI in both open/closed state.

(Before, users could only delete conversations when in a closed state)

### Issue

Fixes https://github.com/papercups-io/papercups/issues/746

### Screenshots

<img width="1417" alt="Screen Shot 2021-04-22 at 4 37 29 PM" src="https://user-images.githubusercontent.com/5264279/115781940-0c787500-a389-11eb-8991-65f81522cadd.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
