### PR TITLE
Add endpoint to retrieve authorized GitHub repos

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -859,6 +859,17 @@ export const deleteGithubAuthorization = async (
     .set('Authorization', token);
 };
 
+export const fetchGithubRepos = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/github/repos`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export type EmailParams = {
   recipient: string;
   subject: string;

--- a/lib/chat_api_web/controllers/github_controller.ex
+++ b/lib/chat_api_web/controllers/github_controller.ex
@@ -73,6 +73,20 @@ defmodule ChatApiWeb.GithubController do
     end
   end
 
+  @spec repos(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def repos(conn, _payload) do
+    with %{account_id: account_id} <- conn.assigns.current_user,
+         %GithubAuthorization{} = auth <- Github.get_authorization_by_account(account_id),
+         {:ok, %{body: %{"repositories" => repos}}} <- Github.Client.list_installation_repos(auth) do
+      json(conn, %{data: repos})
+    else
+      error ->
+        Logger.error("Could not retrieve GitHub repos: #{inspect(error)}")
+
+        json(conn, %{data: []})
+    end
+  end
+
   @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def delete(conn, %{"id" => id}) do
     with %{account_id: _account_id} <- conn.assigns.current_user,

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -103,6 +103,7 @@ defmodule ChatApiWeb.Router do
     get("/github/oauth", GithubController, :oauth)
     get("/github/authorization", GithubController, :authorization)
     delete("/github/authorizations/:id", GithubController, :delete)
+    get("/github/repos", GithubController, :repos)
     get("/google/auth", GoogleController, :auth)
     get("/google/oauth", GoogleController, :callback)
     get("/google/authorization", GoogleController, :authorization)


### PR DESCRIPTION
### Description

Add endpoint to retrieve authorized GitHub repos.

This will be necessary in case we need the user to select a primary repo to connect with (since GitHub authorizations support multiple repos)

### Issue

https://github.com/papercups-io/papercups/issues/745

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
