### PR TITLE
Send initial message via Gmail from dashboard

### DIFF
--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -1,11 +1,116 @@
 import React from 'react';
+import {Box} from 'theme-ui';
+import {TooltipPlacement} from 'antd/lib/tooltip';
 
-import {Button, Modal, TextArea, Tooltip} from '../common';
+import {
+  Button,
+  Divider,
+  Input,
+  Modal,
+  Select,
+  TextArea,
+  Tooltip,
+} from '../common';
 import {SendOutlined} from '../icons';
 import * as API from '../../api';
 import logger from '../../logger';
-import {Conversation} from '../../types';
-import {TooltipPlacement} from 'antd/lib/tooltip';
+import {Conversation, ConversationSource} from '../../types';
+
+const DEFAULT_CONVERSATION_SOURCE: ConversationSource = 'chat';
+
+const NewConversationModal = ({
+  visible,
+  onCancel,
+  onSuccess,
+}: {
+  visible: boolean;
+  onCancel: () => void;
+  onSuccess: (params: Record<any, any>) => Promise<any>;
+}) => {
+  const [source, setConversationSource] = React.useState<ConversationSource>(
+    DEFAULT_CONVERSATION_SOURCE
+  );
+  const [subject, setSubject] = React.useState('');
+  const [message, setMessage] = React.useState('');
+  const [isSending, setSending] = React.useState(false);
+
+  const handleSendMessage = async () => {
+    setSending(true);
+
+    await onSuccess({
+      source,
+      subject,
+      message: {
+        body: message,
+        sent_at: new Date().toISOString(),
+      },
+    });
+
+    setSending(false);
+  };
+
+  return (
+    <Modal
+      title="Start a new conversation"
+      visible={visible}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          icon={<SendOutlined />}
+          loading={isSending}
+          onClick={handleSendMessage}
+        >
+          {isSending ? 'Sending' : 'Send'} as {source}
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Box>
+          {/* TODO: not sure if a select input is the best UX here... */}
+          <Select
+            id="icon_variant"
+            style={{width: 240}}
+            value={source}
+            onChange={setConversationSource}
+            options={['chat', 'email'].map((variant) => {
+              return {value: variant, label: `Send as ${variant}`};
+            })}
+          />
+        </Box>
+
+        <Divider />
+
+        {source === 'email' && (
+          <Box mb={3}>
+            <Input
+              id="subject"
+              type="text"
+              placeholder="Subject line"
+              autoFocus
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+            />
+          </Box>
+        )}
+        <Box mb={3}>
+          <TextArea
+            id="message"
+            placeholder="Enter a message..."
+            autoSize={{minRows: 4, maxRows: 6}}
+            autoFocus
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
 
 const ButtonWrapper = ({
   isDisabled = false,
@@ -46,40 +151,21 @@ export type Props = {
   onInitializeNewConversation?: (conservation: Conversation) => void;
 };
 
-export type State = {
-  isConversationModalOpen: boolean;
-  isSendingMessage: boolean;
-  message: string;
-};
+export const StartConversationButton = ({
+  customerId,
+  isDisabled,
+  disabledTooltipPlacement,
+  disabledTooltipTitle,
+  onInitializeNewConversation,
+}: Props) => {
+  const [isModalOpen, setModalOpen] = React.useState(false);
 
-export class StartConversationButton extends React.Component<Props, State> {
-  state: State = {
-    isConversationModalOpen: false,
-    isSendingMessage: false,
-    message: '',
-  };
+  const handleOpenNewConversationModal = () => setModalOpen(true);
+  const handleCloseNewConversationModal = () => setModalOpen(false);
 
-  handleOpenNewConversationModal = () => {
-    this.setState({isConversationModalOpen: true});
-  };
-
-  handleCloseNewConversationModal = () => {
-    this.setState({isConversationModalOpen: false});
-  };
-
-  initializeNewConversation = async () => {
-    const {customerId, onInitializeNewConversation} = this.props;
-    const {message} = this.state;
-
-    this.setState({isSendingMessage: true});
-
+  const initializeNewConversation = async (params: Record<any, any>) => {
     try {
-      const conversation = await API.createNewConversation(customerId, {
-        message: {
-          body: message,
-          sent_at: new Date().toISOString(),
-        },
-      });
+      const conversation = await API.createNewConversation(customerId, params);
 
       if (onInitializeNewConversation) {
         onInitializeNewConversation(conversation);
@@ -88,57 +174,25 @@ export class StartConversationButton extends React.Component<Props, State> {
       logger.error('Failed to initialize conversation!', err);
     }
 
-    this.setState({isConversationModalOpen: false, isSendingMessage: false});
+    handleCloseNewConversationModal();
   };
 
-  render() {
-    const {
-      isDisabled,
-      disabledTooltipPlacement,
-      disabledTooltipTitle,
-    } = this.props;
-    const {isConversationModalOpen, isSendingMessage, message} = this.state;
+  return (
+    <React.Fragment>
+      <ButtonWrapper
+        isDisabled={isDisabled}
+        disabledTooltipPlacement={disabledTooltipPlacement}
+        disabledTooltipTitle={disabledTooltipTitle}
+        onClick={handleOpenNewConversationModal}
+      />
 
-    return (
-      <React.Fragment>
-        <ButtonWrapper
-          isDisabled={isDisabled}
-          disabledTooltipPlacement={disabledTooltipPlacement}
-          disabledTooltipTitle={disabledTooltipTitle}
-          onClick={this.handleOpenNewConversationModal}
-        />
-
-        <Modal
-          title="Initialize a conversation"
-          visible={isConversationModalOpen}
-          onCancel={this.handleCloseNewConversationModal}
-          footer={[
-            <Button key="cancel" onClick={this.handleCloseNewConversationModal}>
-              Cancel
-            </Button>,
-            <Button
-              key="submit"
-              type="primary"
-              icon={<SendOutlined />}
-              loading={isSendingMessage}
-              onClick={this.initializeNewConversation}
-            >
-              Send
-            </Button>,
-          ]}
-        >
-          <TextArea
-            className="TextArea--transparent"
-            placeholder="Enter a message..."
-            autoSize={{maxRows: 4}}
-            autoFocus
-            value={message}
-            onChange={(e) => this.setState({message: e.target.value})}
-          />
-        </Modal>
-      </React.Fragment>
-    );
-  }
-}
+      <NewConversationModal
+        visible={isModalOpen}
+        onCancel={handleCloseNewConversationModal}
+        onSuccess={initializeNewConversation}
+      />
+    </React.Fragment>
+  );
+};
 
 export default StartConversationButton;

--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -13,7 +13,7 @@ const ButtonWrapper = ({
   disabledTooltipTitle = 'This customer already has an open conversation',
   onClick,
 }: {
-  isDisabled: boolean;
+  isDisabled?: boolean;
   disabledTooltipPlacement?: TooltipPlacement;
   disabledTooltipTitle?: string;
   onClick: () => void;
@@ -40,7 +40,7 @@ const ButtonWrapper = ({
 
 export type Props = {
   customerId: string;
-  isDisabled: boolean;
+  isDisabled?: boolean;
   disabledTooltipPlacement?: TooltipPlacement;
   disabledTooltipTitle?: string;
   onInitializeNewConversation?: (conservation: Conversation) => void;

--- a/assets/src/components/customers/CustomerDetailsConversations.tsx
+++ b/assets/src/components/customers/CustomerDetailsConversations.tsx
@@ -85,7 +85,6 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
         >
           <StartConversationButton
             customerId={customerId}
-            isDisabled={this.hasOpenConversation()}
             onInitializeNewConversation={this.fetchConversations}
           />
         </Flex>

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -88,9 +88,12 @@ export type FileUpload = {
 // Alias
 export type Attachment = FileUpload;
 
+export type ConversationSource = 'chat' | 'email' | 'slack' | 'sms';
+
 export type Conversation = {
   id: string;
-  source?: string;
+  source?: ConversationSource;
+  subject?: string;
   account_id: string;
   customer_id: string;
   customer: Customer;

--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -15,6 +15,7 @@ defmodule ChatApi.Conversations.Conversation do
           status: String.t(),
           priority: String.t(),
           source: String.t() | nil,
+          subject: String.t() | nil,
           read: boolean(),
           archived_at: any(),
           closed_at: any(),
@@ -42,6 +43,7 @@ defmodule ChatApi.Conversations.Conversation do
     field(:status, :string, default: "open")
     field(:priority, :string, default: "not_priority")
     field(:source, :string, default: "chat")
+    field(:subject, :string)
     field(:read, :boolean, default: false)
     field(:archived_at, :utc_datetime)
     field(:first_replied_at, :utc_datetime)
@@ -76,6 +78,7 @@ defmodule ChatApi.Conversations.Conversation do
       :first_replied_at,
       :closed_at,
       :source,
+      :subject,
       :metadata
     ])
     |> validate_required([:status, :account_id, :customer_id])

--- a/lib/chat_api/emails/helpers.ex
+++ b/lib/chat_api/emails/helpers.ex
@@ -28,9 +28,13 @@ defmodule ChatApi.Emails.Helpers do
     |> take_lowest_mx_record()
   end
 
+  def valid_format?(nil), do: false
+
   def valid_format?(email) do
     email =~ @email_regex
   end
+
+  def valid_mx?(nil), do: false
 
   def valid_mx?(email) do
     email

--- a/lib/chat_api/google/initialize_gmail_thread.ex
+++ b/lib/chat_api/google/initialize_gmail_thread.ex
@@ -1,0 +1,84 @@
+defmodule ChatApi.Google.InitializeGmailThread do
+  @moduledoc false
+
+  require Logger
+
+  alias ChatApi.{Accounts, Conversations, Google, Messages}
+  alias ChatApi.Conversations.Conversation
+  alias ChatApi.Customers.Customer
+  alias ChatApi.Messages.Message
+
+  @spec send!(binary(), Conversation.t()) :: Message.t()
+  def send!(
+        text,
+        %Conversation{
+          id: conversation_id,
+          account_id: account_id,
+          subject: subject
+        }
+      ) do
+    with %{refresh_token: refresh_token, user_id: user_id} = _authorization <-
+           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+         %{"emailAddress" => from} <- Google.Gmail.get_profile(refresh_token),
+         %Conversation{customer: %Customer{email: to} = _customer} <-
+           Conversations.get_conversation!(conversation_id),
+         true <- ChatApi.Emails.Helpers.valid_format?(to) do
+      subject =
+        case subject do
+          nil -> get_default_subject(account_id)
+          str -> str
+        end
+
+      %{
+        "id" => gmail_message_id,
+        "threadId" => gmail_thread_id
+      } =
+        Google.Gmail.send_message(refresh_token, %{
+          to: to,
+          from: from,
+          subject: subject,
+          text: text
+        })
+
+      {:ok, _gmail_conversation_thread} =
+        Google.create_gmail_conversation_thread(%{
+          gmail_thread_id: gmail_thread_id,
+          gmail_initial_subject: subject,
+          conversation_id: conversation_id,
+          account_id: account_id
+        })
+
+      gmail_message =
+        gmail_message_id
+        |> Google.Gmail.get_message(refresh_token)
+        |> Google.Gmail.format_thread_message()
+
+      %{
+        body: text,
+        conversation_id: conversation_id,
+        account_id: account_id,
+        user_id: user_id,
+        source: "email",
+        metadata: Google.Gmail.format_message_metadata(gmail_message),
+        sent_at:
+          with {unix, _} <- Integer.parse(gmail_message.ts),
+               {:ok, datetime} <- DateTime.from_unix(unix, :millisecond) do
+            datetime
+          else
+            _ -> DateTime.utc_now()
+          end
+      }
+      |> Messages.create_and_fetch!()
+      |> Messages.Notification.broadcast_to_admin!()
+      |> Messages.Notification.notify(:slack)
+      |> Messages.Notification.notify(:mattermost)
+      |> Messages.Notification.notify(:webhooks)
+    end
+  end
+
+  defp get_default_subject(account_id) do
+    account = Accounts.get_account!(account_id)
+
+    "New message from #{account.company_name}"
+  end
+end

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -10,6 +10,7 @@ defmodule ChatApi.Messages.Message do
 
   @type t :: %__MODULE__{
           body: String.t(),
+          subject: String.t() | nil,
           sent_at: DateTime.t() | nil,
           seen_at: DateTime.t() | nil,
           source: String.t(),
@@ -38,6 +39,7 @@ defmodule ChatApi.Messages.Message do
     field(:seen_at, :utc_datetime)
     field(:source, :string, default: "chat")
     field(:type, :string, default: "reply")
+    field(:subject, :string)
     field(:private, :boolean, default: false)
     field(:metadata, :map)
 
@@ -66,6 +68,7 @@ defmodule ChatApi.Messages.Message do
       :sent_at,
       :seen_at,
       :source,
+      :subject,
       :metadata
     ])
     |> validate_required([:account_id, :conversation_id])

--- a/lib/chat_api/slack/client.ex
+++ b/lib/chat_api/slack/client.ex
@@ -74,6 +74,23 @@ defmodule ChatApi.Slack.Client do
     end
   end
 
+  @spec list_messages(binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
+  def list_messages(channel, access_token) do
+    if should_execute?(access_token) do
+      get("/conversations.history",
+        query: [channel: channel],
+        headers: [
+          {"Authorization", "Bearer " <> access_token}
+        ]
+      )
+    else
+      # Inspect what would've been sent for debugging
+      Logger.info("Would have retrieved messages from channel #{inspect(channel)}")
+
+      {:ok, nil}
+    end
+  end
+
   @spec retrieve_message(binary(), binary(), binary()) :: {:ok, nil} | Tesla.Env.result()
   def retrieve_message(channel, ts, access_token) do
     if should_execute?(access_token) do

--- a/priv/repo/migrations/20210425174238_add_subject_to_conversations_and_messages.exs
+++ b/priv/repo/migrations/20210425174238_add_subject_to_conversations_and_messages.exs
@@ -1,0 +1,13 @@
+defmodule ChatApi.Repo.Migrations.AddSubjectToConversationsAndMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:conversations) do
+      add(:subject, :string)
+    end
+
+    alter table(:messages) do
+      add(:subject, :string)
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR sets up the logic to send an email message (via Gmail) from the dashboard.

### Issue

https://github.com/papercups-io/papercups/issues/754

### Screenshots

**Send from customer details page:**
![send-as-gmail](https://user-images.githubusercontent.com/5264279/116128696-35ee1500-a697-11eb-82f9-54ec090090b4.gif)

**Sent email in Gmail inbox:**
<img width="400" alt="Screen Shot 2021-04-26 at 1 56 14 PM" src="https://user-images.githubusercontent.com/5264279/116128703-39819c00-a697-11eb-8751-61d75779c674.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
