### PR TITLE
Set up read-only notes overview page

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1142,12 +1142,8 @@ export const enableAccountUser = async (
     .then((res) => res.body.data);
 };
 
-export type CustomerNotesListResponse = {
-  data: Array<CustomerNote>;
-};
-
-export const fetchCustomerNotes = async (
-  customerId: string,
+export const fetchNotes = async (
+  query = {},
   token = getAccessToken()
 ): Promise<CustomerNote[]> => {
   if (!token) {
@@ -1156,9 +1152,21 @@ export const fetchCustomerNotes = async (
 
   return request
     .get('/api/notes')
-    .query({customer_id: customerId})
+    .query(query)
     .set('Authorization', token)
     .then((res) => res.body.data);
+};
+
+export type CustomerNotesListResponse = {
+  data: Array<CustomerNote>;
+};
+
+export const fetchCustomerNotes = async (
+  customerId: string,
+  query = {},
+  token = getAccessToken()
+): Promise<CustomerNote[]> => {
+  return fetchNotes({...query, customer_id: customerId}, token);
 };
 
 export const createCustomerNote = async (

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -68,6 +68,7 @@ import TagsOverview from './tags/TagsOverview';
 import TagDetailsPage from './tags/TagDetailsPage';
 import IssuesOverview from './issues/IssuesOverview';
 import IssueDetailsPage from './issues/IssueDetailsPage';
+import NotesOverview from './notes/NotesOverview';
 
 const {
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
@@ -463,6 +464,7 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/tags" component={TagsOverview} />
           <Route path="/issues/:id" component={IssueDetailsPage} />
           <Route path="/issues" component={IssuesOverview} />
+          <Route path="/notes" component={NotesOverview} />
           <Route path="*" render={() => <Redirect to="/conversations/all" />} />
         </Switch>
       </Layout>

--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -65,6 +65,7 @@ export const colors = {
   text: 'rgba(0, 0, 0, 0.65)',
   secondary: 'rgba(0, 0, 0, 0.45)',
   note: '#fff1b8',
+  noteSecondary: 'rgba(254,237,175,.4)',
 };
 
 export const shadows = {

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -133,7 +133,7 @@ const ConversationFooter = ({
           pb={2}
           pt={1}
           sx={{
-            background: isPrivateNote ? 'rgba(254,237,175,.4)' : colors.white,
+            background: isPrivateNote ? colors.noteSecondary : colors.white,
             border: '1px solid #f5f5f5',
             borderRadius: 4,
             boxShadow: 'rgba(0, 0, 0, 0.1) 0px 0px 8px',

--- a/assets/src/components/conversations/SidebarCustomerNotes.tsx
+++ b/assets/src/components/conversations/SidebarCustomerNotes.tsx
@@ -67,7 +67,7 @@ const SidebarCustomerNotes = ({customerId}: {customerId: string}) => {
 
   return (
     <Box>
-      <Box mb={2} sx={{bg: 'rgba(254,237,175,.4)'}}>
+      <Box mb={2} sx={{bg: colors.noteSecondary}}>
         <TextArea
           style={{background: 'transparent'}}
           placeholder="Add a note"

--- a/assets/src/components/customers/CustomerDetailsNotes.tsx
+++ b/assets/src/components/customers/CustomerDetailsNotes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import {Box, Flex} from 'theme-ui';
 
 import {
@@ -18,6 +19,8 @@ import * as API from '../../api';
 import CustomerDetailsNewNoteInput from './CustomerDetailsNewNoteInput';
 import logger from '../../logger';
 import Spinner from '../Spinner';
+
+dayjs.extend(utc);
 
 type Props = {customerId: string};
 type State = {
@@ -128,13 +131,13 @@ const CustomerDetailNote = ({
 }) => {
   const {created_at: createdAt, author} = note;
   const formattedAuthor = formatNoteAuthor(author);
-  const formattedTimestamp = formatRelativeTime(dayjs(createdAt));
+  const formattedTimestamp = formatRelativeTime(dayjs.utc(createdAt));
 
   return (
     <Box
       mb={2}
       sx={{
-        bg: colors.note,
+        bg: colors.noteSecondary,
         borderRadius: 2,
       }}
     >

--- a/assets/src/components/customers/SearchCustomers.tsx
+++ b/assets/src/components/customers/SearchCustomers.tsx
@@ -5,17 +5,8 @@ import {ButtonProps} from 'antd/lib/button';
 import * as API from '../../api';
 import {Customer} from '../../types';
 import {AutoComplete, Button, Modal} from '../common';
+import {formatCustomerDisplayName} from './support';
 import logger from '../../logger';
-
-const formatCustomerDisplayName = (customer: Customer) => {
-  const {name, email} = customer;
-
-  if (name && email) {
-    return `${name} (${email})`;
-  }
-
-  return name || email || 'Anonymous User';
-};
 
 type Props = {
   placeholder?: string;

--- a/assets/src/components/customers/support.ts
+++ b/assets/src/components/customers/support.ts
@@ -1,6 +1,7 @@
 import * as API from '../../api';
 import logger from '../../logger';
 import {download} from '../../utils';
+import {Customer} from '../../types';
 
 export const exportCustomerData = async (customerId: string) => {
   try {
@@ -12,4 +13,14 @@ export const exportCustomerData = async (customerId: string) => {
   } catch (err) {
     logger.error('Failed to export customer:', err);
   }
+};
+
+export const formatCustomerDisplayName = (customer: Customer) => {
+  const {name, email} = customer;
+
+  if (name && email) {
+    return `${name} (${email})`;
+  }
+
+  return name || email || 'Anonymous User';
 };

--- a/assets/src/components/notes/NotesOverview.tsx
+++ b/assets/src/components/notes/NotesOverview.tsx
@@ -61,6 +61,71 @@ const notesByCustomer = (
   });
 };
 
+const NotesByCustomer = ({notes}: {notes: Array<T.CustomerNote>}) => {
+  return (
+    <Box>
+      {notesByCustomer(notes).map(({customer, notes: customerNotes = []}) => {
+        const identifier = formatCustomerDisplayName(customer);
+
+        return (
+          <Box mb={4} ml={2}>
+            <Box mb={1}>
+              <Link to={`/customers/${customer.id}?tab=notes`}>
+                <Text strong>{identifier}</Text>
+              </Link>
+            </Box>
+
+            {customerNotes.map((note) => {
+              const date = dayjs.utc(note.created_at).toDate();
+              const ts = dayjs(date).format('ddd, MMM D h:mm A');
+
+              return (
+                <Box
+                  key={note.id}
+                  px={3}
+                  pt={1}
+                  pb={2}
+                  mb={2}
+                  sx={{
+                    bg: colors.noteSecondary,
+                    borderRadius: 2,
+                  }}
+                >
+                  <Flex mb={1} sx={{justifyContent: 'flex-end'}}>
+                    <Text type="secondary" style={{fontSize: 12}}>
+                      {ts}
+                    </Text>
+                  </Flex>
+
+                  <MarkdownRenderer source={note.body} />
+                </Box>
+              );
+            })}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+const NotesByDate = ({notes}: {notes: Array<T.CustomerNote>}) => {
+  return (
+    <Box>
+      {notesByDate(notes).map(({date, notes = []}) => {
+        const formatted = dayjs(date).format('MMMM DD, YYYY');
+
+        return (
+          <Box mb={5}>
+            <Title level={3}>{formatted}</Title>
+
+            <NotesByCustomer notes={notes} />
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
 type Props = {};
 type State = {
   loading: boolean;
@@ -90,81 +155,35 @@ class NotesOverview extends React.Component<Props, State> {
 
     if (loading) {
       return (
-        <Flex
-          sx={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Spinner size={40} />
-        </Flex>
+        <Box p={4} sx={{maxWidth: 1080}}>
+          <Flex
+            sx={{
+              flex: 1,
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '100%',
+            }}
+          >
+            <Spinner size={40} />
+          </Flex>
+        </Box>
       );
     } else if (notes.length === 0) {
       return (
-        <Result
-          status="success"
-          title="No notes"
-          subTitle="You haven't written any customer notes yet!"
-        />
+        <Box p={4} sx={{maxWidth: 1080}}>
+          <Result
+            status="success"
+            title="No notes"
+            subTitle="You haven't written any customer notes yet!"
+          />
+        </Box>
       );
     }
 
     return (
       <Box p={4} sx={{maxWidth: 1080}}>
         <Box my={4}>
-          {notesByDate(notes).map(({date, notes = []}) => {
-            const formatted = dayjs(date).format('MMMM DD, YYYY');
-
-            return (
-              <Box mb={5}>
-                <Title level={3}>{formatted}</Title>
-                {notesByCustomer(notes).map(
-                  ({customer, notes: customerNotes = []}) => {
-                    const identifier = formatCustomerDisplayName(customer);
-
-                    return (
-                      <Box mb={4} ml={2}>
-                        <Box mb={1}>
-                          <Link to={`/customers/${customer.id}?tab=notes`}>
-                            <Text strong>{identifier}</Text>
-                          </Link>
-                        </Box>
-
-                        {customerNotes.map((note) => {
-                          const date = dayjs.utc(note.created_at).toDate();
-                          const ts = dayjs(date).format('ddd, MMM D h:mm A');
-
-                          return (
-                            <Box
-                              key={note.id}
-                              px={3}
-                              pt={1}
-                              pb={2}
-                              mb={2}
-                              sx={{
-                                bg: colors.noteSecondary,
-                                borderRadius: 2,
-                              }}
-                            >
-                              <Flex mb={1} sx={{justifyContent: 'flex-end'}}>
-                                <Text type="secondary" style={{fontSize: 12}}>
-                                  {ts}
-                                </Text>
-                              </Flex>
-
-                              <MarkdownRenderer source={note.body} />
-                            </Box>
-                          );
-                        })}
-                      </Box>
-                    );
-                  }
-                )}
-              </Box>
-            );
-          })}
+          <NotesByDate notes={notes} />
         </Box>
       </Box>
     );

--- a/assets/src/components/notes/NotesOverview.tsx
+++ b/assets/src/components/notes/NotesOverview.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+import {Box, Flex} from 'theme-ui';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import {colors, MarkdownRenderer, Result, Text, Title} from '../common';
+import * as API from '../../api';
+import * as T from '../../types';
+import {formatCustomerDisplayName} from '../customers/support';
+import logger from '../../logger';
+import Spinner from '../Spinner';
+
+dayjs.extend(utc);
+
+const notesByDate = (notes: Array<T.CustomerNote>) => {
+  if (notes.length === 0) {
+    return [];
+  }
+
+  const grouped = notes.reduce((acc, note) => {
+    const date = dayjs.utc(note.created_at).format('YYYY-MM-DD');
+
+    return {...acc, [date]: (acc[date] || []).concat(note)};
+  }, {} as {[date: string]: Array<T.CustomerNote>});
+
+  return Object.keys(grouped)
+    .sort((a, b) => +new Date(b) - +new Date(a))
+    .map((date) => {
+      return {date, notes: grouped[date]};
+    });
+};
+
+const notesByCustomer = (
+  notes: Array<T.CustomerNote>
+): Array<{customer: T.Customer; notes: Array<T.CustomerNote>}> => {
+  if (notes.length === 0) {
+    return [];
+  }
+
+  const grouped = notes.reduce((acc, note) => {
+    const {customer_id: customerId} = note;
+
+    return {...acc, [customerId]: (acc[customerId] || []).concat(note)};
+  }, {} as {[customerId: string]: Array<T.CustomerNote>});
+
+  const customersById = notes.reduce((acc, note) => {
+    const {customer_id: id, customer} = note;
+
+    if (!customer) {
+      return acc;
+    }
+
+    return {...acc, [id]: customer};
+  }, {} as {[id: string]: T.Customer});
+
+  return Object.keys(grouped).map((customerId) => {
+    const notes = grouped[customerId];
+    const customer = customersById[customerId] as T.Customer;
+
+    return {customer, notes};
+  });
+};
+
+type Props = {};
+type State = {
+  loading: boolean;
+  notes: Array<T.CustomerNote>;
+};
+
+class NotesOverview extends React.Component<Props, State> {
+  state: State = {
+    loading: true,
+    notes: [],
+  };
+
+  async componentDidMount() {
+    try {
+      const notes = await API.fetchNotes();
+
+      this.setState({notes});
+    } catch (err) {
+      logger.error('Error retrieving notes!', err);
+    }
+
+    this.setState({loading: false});
+  }
+
+  render() {
+    const {loading, notes = []} = this.state;
+
+    if (loading) {
+      return (
+        <Flex
+          sx={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Spinner size={40} />
+        </Flex>
+      );
+    } else if (notes.length === 0) {
+      return (
+        <Result
+          status="success"
+          title="No notes"
+          subTitle="You haven't written any customer notes yet!"
+        />
+      );
+    }
+
+    return (
+      <Box p={4} sx={{maxWidth: 1080}}>
+        <Box my={4}>
+          {notesByDate(notes).map(({date, notes = []}) => {
+            const formatted = dayjs(date).format('MMMM DD, YYYY');
+
+            return (
+              <Box mb={5}>
+                <Title level={3}>{formatted}</Title>
+                {notesByCustomer(notes).map(
+                  ({customer, notes: customerNotes = []}) => {
+                    const identifier = formatCustomerDisplayName(customer);
+
+                    return (
+                      <Box mb={4} ml={2}>
+                        <Box mb={1}>
+                          <Link to={`/customers/${customer.id}?tab=notes`}>
+                            <Text strong>{identifier}</Text>
+                          </Link>
+                        </Box>
+
+                        {customerNotes.map((note) => {
+                          const date = dayjs.utc(note.created_at).toDate();
+                          const ts = dayjs(date).format('ddd, MMM D h:mm A');
+
+                          return (
+                            <Box
+                              key={note.id}
+                              px={3}
+                              pt={1}
+                              pb={2}
+                              mb={2}
+                              sx={{
+                                bg: colors.noteSecondary,
+                                borderRadius: 2,
+                              }}
+                            >
+                              <Flex mb={1} sx={{justifyContent: 'flex-end'}}>
+                                <Text type="secondary" style={{fontSize: 12}}>
+                                  {ts}
+                                </Text>
+                              </Flex>
+
+                              <MarkdownRenderer source={note.body} />
+                            </Box>
+                          );
+                        })}
+                      </Box>
+                    );
+                  }
+                )}
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    );
+  }
+}
+
+export default NotesOverview;

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -114,6 +114,7 @@ export type CustomerNote = {
   created_at: string;
   updated_at: string;
   author?: User;
+  customer?: Customer;
 };
 
 export type Tag = {

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import {range} from 'lodash';
 import qs from 'query-string';
 import {env} from './config';
 import {Message} from './types';
@@ -97,6 +98,17 @@ export const isValidUuid = (id: any) => {
   const regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
   return regex.test(id);
+};
+
+export const generateDateRange = (
+  start: dayjs.Dayjs,
+  finish: dayjs.Dayjs
+): Array<dayjs.Dayjs> => {
+  const diff = finish.endOf('day').diff(start.startOf('day'), 'day');
+
+  return range(diff + 1).map((n) => {
+    return start.add(n, 'day');
+  });
 };
 
 export const sortConversationMessages = (messages: Array<Message>) => {

--- a/lib/chat_api/notes.ex
+++ b/lib/chat_api/notes.ex
@@ -8,15 +8,6 @@ defmodule ChatApi.Notes do
 
   alias ChatApi.Notes.Note
 
-  # TODO: remove and replace with `list_notes_by_account/2`
-  @spec list_notes_for_customer(account_id: binary, customer_id: binary) :: [Note.t()]
-  def list_notes_for_customer(account_id: account_id, customer_id: customer_id) do
-    Note
-    |> where(account_id: ^account_id, customer_id: ^customer_id)
-    |> order_by(desc: :inserted_at)
-    |> Repo.all()
-  end
-
   @spec list_notes_by_account(binary(), map()) :: [Note.t()]
   def list_notes_by_account(account_id, filters) do
     Note
@@ -24,7 +15,7 @@ defmodule ChatApi.Notes do
     |> where(^filter_where(filters))
     |> order_by(desc: :inserted_at)
     |> Repo.all()
-    |> Repo.preload(author: :profile)
+    |> Repo.preload([:customer, author: :profile])
   end
 
   @spec get_note!(binary()) :: Note.t()

--- a/lib/chat_api_web/controllers/note_controller.ex
+++ b/lib/chat_api_web/controllers/note_controller.ex
@@ -4,9 +4,9 @@ defmodule ChatApiWeb.NoteController do
   alias ChatApi.Notes
   alias ChatApi.Notes.Note
 
-  action_fallback ChatApiWeb.FallbackController
+  action_fallback(ChatApiWeb.FallbackController)
 
-  plug :authorize when action in [:show, :update, :delete]
+  plug(:authorize when action in [:show, :update, :delete])
 
   def authorize(conn, _) do
     id = conn.path_params["id"]

--- a/lib/chat_api_web/views/note_view.ex
+++ b/lib/chat_api_web/views/note_view.ex
@@ -3,9 +3,11 @@ defmodule ChatApiWeb.NoteView do
 
   alias ChatApiWeb.{
     NoteView,
+    CustomerView,
     UserView
   }
 
+  alias ChatApi.Customers.Customer
   alias ChatApi.Users.User
 
   def render("index.json", %{notes: notes}) do
@@ -27,7 +29,13 @@ defmodule ChatApiWeb.NoteView do
       updated_at: note.updated_at
     }
     |> maybe_render_author(note)
+    |> maybe_render_customer(note)
   end
+
+  defp maybe_render_customer(json, %{customer: %Customer{} = customer}),
+    do: Map.merge(json, %{customer: render_one(customer, CustomerView, "customer.json")})
+
+  defp maybe_render_customer(json, _), do: json
 
   defp maybe_render_author(json, %{author: author}) do
     case author do

--- a/test/chat_api/notes_test.exs
+++ b/test/chat_api/notes_test.exs
@@ -42,28 +42,6 @@ defmodule ChatApi.NotesTest do
       assert note_ids == []
     end
 
-    test "list_notes_for_customer/1 returns all notes for the given account and customer", %{
-      note: note,
-      account: account,
-      customer: customer
-    } do
-      note_ids =
-        Notes.list_notes_for_customer(account_id: account.id, customer_id: customer.id)
-        |> Enum.map(& &1.id)
-
-      assert note_ids == [note.id]
-    end
-
-    test "list_notes_for_customer/1 returns empty [] when customer cannot be matched", %{
-      account: account
-    } do
-      note_ids =
-        Notes.list_notes_for_customer(account_id: account.id, customer_id: UUID.generate())
-        |> Enum.map(& &1.id)
-
-      assert note_ids == []
-    end
-
     test "get_note!/1 returns the note with given id", %{note: note} do
       found = Notes.get_note!(note.id)
       assert found.id == note.id


### PR DESCRIPTION
### Description

It's hard to view all customer notes in one place, so this PR sets up a basic UI to make that possible.

### Issue

https://github.com/papercups-io/papercups/issues/781

### Screenshots

<img width="1253" alt="Screen Shot 2021-04-26 at 11 16 33 AM" src="https://user-images.githubusercontent.com/5264279/116107337-f1f01580-a680-11eb-8c41-eea7f1367b00.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
