### PR TITLE
Make it possible to send messages to customers directly from table view

### DIFF
--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -8,43 +8,82 @@ import {
   Input,
   Modal,
   Select,
+  Text,
   TextArea,
   Tooltip,
 } from '../common';
 import {SendOutlined} from '../icons';
 import * as API from '../../api';
-import logger from '../../logger';
+import {isValidEmail, formatServerError} from '../../utils';
 import {Conversation, ConversationSource} from '../../types';
+import logger from '../../logger';
 
-const DEFAULT_CONVERSATION_SOURCE: ConversationSource = 'chat';
+const CONVERSATION_SOURCE_OPTIONS: Array<ConversationSource> = [
+  'chat',
+  'email',
+];
+const DEFAULT_CONVERSATION_SOURCE = CONVERSATION_SOURCE_OPTIONS[0];
 
 const NewConversationModal = ({
+  customerId,
   visible,
   onCancel,
   onSuccess,
 }: {
+  customerId: string;
   visible: boolean;
   onCancel: () => void;
-  onSuccess: (params: Record<any, any>) => Promise<any>;
+  onSuccess: (conversation: Conversation) => void;
 }) => {
+  const [availableSources, setAvailableSources] = React.useState<
+    Array<ConversationSource>
+  >(['chat']);
   const [source, setConversationSource] = React.useState<ConversationSource>(
     DEFAULT_CONVERSATION_SOURCE
   );
   const [subject, setSubject] = React.useState('');
   const [message, setMessage] = React.useState('');
   const [isSending, setSending] = React.useState(false);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (visible) {
+      Promise.all([
+        API.fetchGoogleAuthorization('gmail'),
+        API.fetchCustomer(customerId, {expand: []}),
+      ]).then(([authorization, customer]) => {
+        const hasValidAuth = !!(authorization && authorization.id);
+        const hasValidCustomerEmail = !!isValidEmail(customer?.email);
+        const canSendEmail = hasValidAuth && hasValidCustomerEmail;
+
+        if (canSendEmail) {
+          setAvailableSources(['chat', 'email']);
+        } else {
+          setAvailableSources(['chat']);
+        }
+      });
+    }
+  }, [customerId, visible]);
 
   const handleSendMessage = async () => {
     setSending(true);
 
-    await onSuccess({
-      source,
-      subject,
-      message: {
-        body: message,
-        sent_at: new Date().toISOString(),
-      },
-    });
+    try {
+      const conversation = await API.createNewConversation(customerId, {
+        source,
+        subject,
+        message: {
+          body: message,
+          sent_at: new Date().toISOString(),
+        },
+      });
+
+      onSuccess(conversation);
+    } catch (err) {
+      logger.error('Failed to create new conversation:', err);
+      const errorMessage = formatServerError(err);
+      setErrorMessage(errorMessage);
+    }
 
     setSending(false);
   };
@@ -73,12 +112,16 @@ const NewConversationModal = ({
         <Box>
           {/* TODO: not sure if a select input is the best UX here... */}
           <Select
-            id="icon_variant"
+            id="source"
             style={{width: 240}}
             value={source}
             onChange={setConversationSource}
-            options={['chat', 'email'].map((variant) => {
-              return {value: variant, label: `Send as ${variant}`};
+            options={CONVERSATION_SOURCE_OPTIONS.map((source) => {
+              return {
+                value: source,
+                label: `Send as ${source}`,
+                disabled: availableSources.indexOf(source) === -1,
+              };
             })}
           />
         </Box>
@@ -107,6 +150,12 @@ const NewConversationModal = ({
             onChange={(e) => setMessage(e.target.value)}
           />
         </Box>
+
+        {errorMessage && (
+          <Box mb={-3}>
+            <Text type="danger">{errorMessage}</Text>
+          </Box>
+        )}
       </Box>
     </Modal>
   );
@@ -165,15 +214,9 @@ export const StartConversationWrapper = ({
   const handleOpenNewConversationModal = () => setModalOpen(true);
   const handleCloseNewConversationModal = () => setModalOpen(false);
 
-  const initializeNewConversation = async (params: Record<any, any>) => {
-    try {
-      const conversation = await API.createNewConversation(customerId, params);
-
-      if (onInitializeNewConversation) {
-        onInitializeNewConversation(conversation);
-      }
-    } catch (err) {
-      logger.error('Failed to initialize conversation!', err);
+  const onSuccess = (conversation: Conversation) => {
+    if (typeof onInitializeNewConversation === 'function') {
+      onInitializeNewConversation(conversation);
     }
 
     handleCloseNewConversationModal();
@@ -184,9 +227,10 @@ export const StartConversationWrapper = ({
       {children(handleOpenNewConversationModal)}
 
       <NewConversationModal
+        customerId={customerId}
         visible={isModalOpen}
         onCancel={handleCloseNewConversationModal}
-        onSuccess={initializeNewConversation}
+        onSuccess={onSuccess}
       />
     </React.Fragment>
   );

--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -151,13 +151,15 @@ export type Props = {
   onInitializeNewConversation?: (conservation: Conversation) => void;
 };
 
-export const StartConversationButton = ({
+export const StartConversationWrapper = ({
+  children,
   customerId,
-  isDisabled,
-  disabledTooltipPlacement,
-  disabledTooltipTitle,
   onInitializeNewConversation,
-}: Props) => {
+}: {
+  children: (handleOpenModal: () => void) => React.ReactElement;
+  customerId: string;
+  onInitializeNewConversation?: (conservation: Conversation) => void;
+}) => {
   const [isModalOpen, setModalOpen] = React.useState(false);
 
   const handleOpenNewConversationModal = () => setModalOpen(true);
@@ -179,12 +181,7 @@ export const StartConversationButton = ({
 
   return (
     <React.Fragment>
-      <ButtonWrapper
-        isDisabled={isDisabled}
-        disabledTooltipPlacement={disabledTooltipPlacement}
-        disabledTooltipTitle={disabledTooltipTitle}
-        onClick={handleOpenNewConversationModal}
-      />
+      {children(handleOpenNewConversationModal)}
 
       <NewConversationModal
         visible={isModalOpen}
@@ -192,6 +189,30 @@ export const StartConversationButton = ({
         onSuccess={initializeNewConversation}
       />
     </React.Fragment>
+  );
+};
+
+export const StartConversationButton = ({
+  customerId,
+  isDisabled,
+  disabledTooltipPlacement,
+  disabledTooltipTitle,
+  onInitializeNewConversation,
+}: Props) => {
+  return (
+    <StartConversationWrapper
+      customerId={customerId}
+      onInitializeNewConversation={onInitializeNewConversation}
+    >
+      {(onClick) => (
+        <ButtonWrapper
+          isDisabled={isDisabled}
+          disabledTooltipPlacement={disabledTooltipPlacement}
+          disabledTooltipTitle={disabledTooltipTitle}
+          onClick={onClick}
+        />
+      )}
+    </StartConversationWrapper>
   );
 };
 

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -27,12 +27,8 @@ const CustomersTable = ({
   shouldIncludeAnonymous?: boolean;
   action?: (customer: Customer) => React.ReactElement;
   pagination?: false | TablePaginationConfig;
-  onUpdate: () => Promise<void>;
+  onUpdate?: () => Promise<void>;
 }) => {
-  const [selectedCustomerId, setSelectedCustomerId] = React.useState<
-    string | null
-  >(null);
-
   const isCustomerOnline = (customer: Customer) => {
     const {id: customerId} = customer;
 

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import {Box} from 'theme-ui';
+import {Link} from 'react-router-dom';
+import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import {Customer} from '../../types';
-import {Badge, Button, Table, Text, Tooltip} from '../common';
-import CustomerDetailsModal from './CustomerDetailsModal';
 import {TablePaginationConfig} from 'antd/lib/table';
+import {Customer} from '../../types';
+import {Badge, Button, Dropdown, Menu, Table, Text, Tooltip} from '../common';
+import {SettingOutlined} from '../icons';
+import {StartConversationWrapper} from '../conversations/StartConversationButton';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -133,25 +135,42 @@ const CustomersTable = ({
       dataIndex: 'action',
       key: 'action',
       render: (value: string, record: Customer) => {
-        if (action && typeof action === 'function') {
-          return action(record);
-        }
-
         const {id: customerId} = record;
 
         return (
-          <>
-            <Button onClick={() => setSelectedCustomerId(customerId)}>
-              View more
-            </Button>
-            <CustomerDetailsModal
-              customer={record}
-              isVisible={selectedCustomerId === record.id}
-              onClose={() => setSelectedCustomerId(null)}
-              onUpdate={onUpdate}
-              onDelete={onUpdate}
-            />
-          </>
+          <Flex sx={{justifyContent: 'flex-end'}}>
+            <StartConversationWrapper customerId={customerId}>
+              {(handleOpenNewConversationModal) => {
+                const handleMenuClick = (data: any) => {
+                  switch (data.key) {
+                    case 'message':
+                      return handleOpenNewConversationModal();
+                    default:
+                      return null;
+                  }
+                };
+
+                return (
+                  <Dropdown
+                    overlay={
+                      <Menu onClick={handleMenuClick}>
+                        <Menu.Item key="profile">
+                          <Link to={`/customers/${customerId}`}>
+                            View profile
+                          </Link>
+                        </Menu.Item>
+                        <Menu.Item key="message">
+                          Start new conversation
+                        </Menu.Item>
+                      </Menu>
+                    }
+                  >
+                    <Button icon={<SettingOutlined />} />
+                  </Dropdown>
+                );
+              }}
+            </StartConversationWrapper>
+          </Flex>
         );
       },
     },

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -5,7 +5,16 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import {TablePaginationConfig} from 'antd/lib/table';
 import {Customer} from '../../types';
-import {Badge, Button, Dropdown, Menu, Table, Text, Tooltip} from '../common';
+import {
+  notification,
+  Badge,
+  Button,
+  Dropdown,
+  Menu,
+  Table,
+  Text,
+  Tooltip,
+} from '../common';
 import {SettingOutlined} from '../icons';
 import {StartConversationWrapper} from '../conversations/StartConversationButton';
 
@@ -135,7 +144,24 @@ const CustomersTable = ({
 
         return (
           <Flex sx={{justifyContent: 'flex-end'}}>
-            <StartConversationWrapper customerId={customerId}>
+            <StartConversationWrapper
+              customerId={customerId}
+              onInitializeNewConversation={(conversation) =>
+                notification.success({
+                  message: `Message successfully sent.`,
+                  description: (
+                    <Text>
+                      Click{' '}
+                      <a href={`/conversations/all?cid=${conversation.id}`}>
+                        here
+                      </a>{' '}
+                      to view the conversation.
+                    </Text>
+                  ),
+                  duration: 10,
+                })
+              }
+            >
               {(handleOpenNewConversationModal) => {
                 const handleMenuClick = (data: any) => {
                   switch (data.key) {

--- a/assets/src/components/customers/CustomersTableContainer.tsx
+++ b/assets/src/components/customers/CustomersTableContainer.tsx
@@ -149,11 +149,6 @@ class CustomersTableContainer extends React.Component<Props, State> {
             total: pagination.total_entries,
             onChange: this.handlePageChange,
           }}
-          action={(customer: Customer) => (
-            <Link to={`/customers/${customer.id}`}>
-              <Button>View profile</Button>
-            </Link>
-          )}
           onUpdate={this.handleRefreshCustomers}
         />
       </Box>

--- a/assets/src/components/customers/CustomersTableContainer.tsx
+++ b/assets/src/components/customers/CustomersTableContainer.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import {debounce} from 'lodash';
-import {Button, Checkbox, Input} from '../common';
+import {Checkbox, Input} from '../common';
 import * as API from '../../api';
 import logger from '../../logger';
 import {Customer, Pagination} from '../../types';

--- a/assets/src/utils.ts
+++ b/assets/src/utils.ts
@@ -17,6 +17,14 @@ export const hasValidStripeKey = () => {
   return key && key.startsWith('pk_');
 };
 
+export const isValidEmail = (email?: string | null) => {
+  if (!email) {
+    return false;
+  }
+  // Super basic validation: https://stackoverflow.com/a/4964763
+  return /(.+)@(.+){2,}\.(.+){2,}/.test(email);
+};
+
 export const formatRelativeTime = (date: dayjs.Dayjs) => {
   const seconds = dayjs().diff(date, 'second');
   const mins = Math.floor(seconds / 60);

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -285,9 +285,11 @@ defmodule ChatApiWeb.ConversationController do
          %Conversation{source: "email"} = conversation,
          %{"message" => %{"body" => body} = _message_params}
        ) do
-    ChatApi.Google.InitializeGmailThread.send!(body, conversation)
-
-    :ok
+    case ChatApi.Google.InitializeGmailThread.send(body, conversation) do
+      %Messages.Message{} -> :ok
+      {:error, message} -> {:error, :unprocessable_entity, message}
+      _ -> {:error, :unprocessable_entity, "Failed to send message"}
+    end
   end
 
   defp maybe_create_message(


### PR DESCRIPTION
### Description

This PR makes it possible to send messages to customers directly from table view (rather than just the customer details view)

(TODO: disable sending email for customers without an `email`, and for accounts without a gmail authorization)

### Screenshots

![send-gmail-from-table](https://user-images.githubusercontent.com/5264279/116152358-d0f4e800-a6b3-11eb-8b9f-0fe9dd1e3981.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
