### PR TITLE
Adds inboxes for email, live chat, and slack

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -51,6 +51,7 @@ import AllConversations from './conversations/AllConversations';
 import MyConversations from './conversations/MyConversations';
 import PriorityConversations from './conversations/PriorityConversations';
 import ClosedConversations from './conversations/ClosedConversations';
+import ConversationsBySource from './conversations/ConversationsBySource';
 import IntegrationsOverview from './integrations/IntegrationsOverview';
 import BillingOverview from './billing/BillingOverview';
 import CustomersPage from './customers/CustomersPage';
@@ -338,6 +339,60 @@ const Dashboard = (props: RouteComponentProps) => {
                 </Menu.Item>
               </Menu.SubMenu>
               <Menu.SubMenu
+                key="inbox-channels"
+                icon={<MailOutlined />}
+                title="Channels"
+              >
+                <Menu.Item key="live-chat">
+                  <Link to="/conversations/live-chat">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>Live Chat</Box>
+                      <Badge
+                        count={getUnreadCount(inboxes.bySource['chat'] ?? [])}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
+                <Menu.Item key="email">
+                  <Link to="/conversations/email">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>Email</Box>
+                      <Badge
+                        count={getUnreadCount(inboxes.bySource['email'] ?? [])}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
+                <Menu.Item key="slack">
+                  <Link to="/conversations/slack">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>Slack</Box>
+                      <Badge
+                        count={getUnreadCount(inboxes.bySource['slack'] ?? [])}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
+              </Menu.SubMenu>
+              <Menu.SubMenu
                 key="sessions"
                 icon={<VideoCameraOutlined />}
                 title="Sessions"
@@ -441,6 +496,15 @@ const Dashboard = (props: RouteComponentProps) => {
             path="/conversations/priority"
             component={PriorityConversations}
           />
+          <Route path="/conversations/live-chat">
+            <ConversationsBySource title="Live Chat" source="chat" />
+          </Route>
+          <Route path="/conversations/email">
+            <ConversationsBySource title="Email" source="email" />
+          </Route>
+          <Route path="/conversations/slack">
+            <ConversationsBySource title="Slack" source="slack" />
+          </Route>
           <Route path="/conversations/closed" component={ClosedConversations} />
           <Route
             path="/conversations/:id"

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -351,7 +351,7 @@ const Dashboard = (props: RouteComponentProps) => {
                         justifyContent: 'space-between',
                       }}
                     >
-                      <Box mr={2}>Live Chat</Box>
+                      <Box mr={2}>Live chat</Box>
                       <Badge
                         count={getUnreadCount(inboxes.bySource['chat'] ?? [])}
                         style={{borderColor: '#FF4D4F'}}
@@ -497,7 +497,7 @@ const Dashboard = (props: RouteComponentProps) => {
             component={PriorityConversations}
           />
           <Route path="/conversations/live-chat">
-            <ConversationsBySource title="Live Chat" source="chat" />
+            <ConversationsBySource title="Live chat" source="chat" />
           </Route>
           <Route path="/conversations/email">
             <ConversationsBySource title="Email" source="email" />

--- a/assets/src/components/conversations/ConversationsBySource.tsx
+++ b/assets/src/components/conversations/ConversationsBySource.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ConversationsDashboard from './ConversationsDashboard';
+import {useConversations} from './ConversationsProvider';
+import * as API from '../../api';
+
+type Props = {
+  source: string;
+  title: string;
+};
+
+const ConversationsBySource = ({source, title}: Props) => {
+  const {
+    loading,
+    currentUser,
+    account,
+    messagesByConversation = {},
+    inboxes,
+    onSetConversations,
+    onSelectConversation,
+    onUpdateConversation,
+    onDeleteConversation,
+    onSendMessage,
+  } = useConversations();
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const fetcher = (query = {}) => {
+    return API.fetchAllConversations({...query, source});
+  };
+
+  const inbox = inboxes.bySource[source];
+
+  return (
+    <ConversationsDashboard
+      loading={loading}
+      title={title}
+      account={account}
+      conversationIds={inbox ?? []}
+      messagesByConversation={messagesByConversation}
+      fetcher={fetcher}
+      onRetrieveConversations={onSetConversations}
+      onSelectConversation={onSelectConversation}
+      onUpdateConversation={onUpdateConversation}
+      onDeleteConversation={onDeleteConversation}
+      onSendMessage={onSendMessage}
+    />
+  );
+};
+
+export default ConversationsBySource;


### PR DESCRIPTION
### Description

This commit adds inboxes for email, live chat, and slack. You can navigate to them using the left-side navigation under Channels. It basically works by filtering the open conversations and grouping them by their source. 

### Issue

https://github.com/papercups-io/papercups/issues/760

### Screenshots

https://user-images.githubusercontent.com/1361509/116291660-d826ff00-a762-11eb-8e87-7f5b970543d7.mp4

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [x] No frontend compilation warnings
