### PR TITLE
Adds shortcut for submitting notes

### DIFF
--- a/assets/src/components/customers/CustomerDetailsNewNoteInput.tsx
+++ b/assets/src/components/customers/CustomerDetailsNewNoteInput.tsx
@@ -41,6 +41,12 @@ const CustomerDetailNewNoteInput = ({
     setIsSaving(false);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.keyCode === 13 && e.metaKey) {
+      handleSaveNote();
+    }
+  };
+
   return (
     <Box mb={2}>
       <TextArea
@@ -50,6 +56,7 @@ const CustomerDetailNewNoteInput = ({
         disabled={isSaving}
         value={note}
         onChange={handleNoteChange}
+        onKeyDown={handleKeyDown}
       />
       {errorMessage && (
         <Box mt={3}>

--- a/assets/src/components/customers/CustomerDetailsNewNoteInput.tsx
+++ b/assets/src/components/customers/CustomerDetailsNewNoteInput.tsx
@@ -42,7 +42,7 @@ const CustomerDetailNewNoteInput = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.keyCode === 13 && e.metaKey) {
+    if (e.key === 'Enter' && e.metaKey) {
       handleSaveNote();
     }
   };


### PR DESCRIPTION
### Description

Notes can now be submitted using metakey + enter. For macs, this is cmd + enter. For windows, it's window + enter.

### Issue

https://github.com/papercups-io/papercups/issues/778

### Screenshots

https://user-images.githubusercontent.com/1361509/116297029-dfe9a200-a768-11eb-948c-6adce5c297b1.mp4

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [x] No frontend compilation warnings
