### PR TITLE
Adds better error reporting when socket errors and try to reconnect

### DIFF
--- a/assets/src/components/conversations/ConversationNotificationManager.ts
+++ b/assets/src/components/conversations/ConversationNotificationManager.ts
@@ -37,7 +37,6 @@ class ConversationNotificationManager {
 
     socket.onOpen(() => logger.debug('Successfully connected to socket!'));
 
-    // TODO: attempt refreshing access token?
     socket.onError(
       throttle(
         (error) => {


### PR DESCRIPTION
### Description

When the socket used for managing conversations errors out, we currently only log an error message. This commit logs the error as well to provide more visibility into why it's erroring and attempts to reconnect when it does error.

### Issue

https://github.com/papercups-io/papercups/issues/774

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [x] No frontend compilation warnings
