### PR TITLE
Enable viewing and sending messages to conversation in modal

### DIFF
--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -5,7 +5,6 @@ import {useConversations} from '../conversations/ConversationsProvider';
 import ConversationMessages from '../conversations/ConversationMessages';
 import ConversationFooter from '../conversations/ConversationFooter';
 import {Conversation, Message, User} from '../../types';
-import {formatCustomerDisplayName} from '../customers/support';
 
 type Props = {
   visible?: boolean;
@@ -67,8 +66,7 @@ class ConversationModal extends React.Component<Props> {
         <Flex
           sx={{
             width: '100%',
-            height: '100%',
-            maxHeight: '64vh',
+            height: '64vh',
             flexDirection: 'column',
             bg: colors.white,
             flex: 1,

--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
 import {Flex} from 'theme-ui';
-import {colors} from '../common';
+import {colors, Modal} from '../common';
 import {useConversations} from '../conversations/ConversationsProvider';
 import ConversationMessages from '../conversations/ConversationMessages';
 import ConversationFooter from '../conversations/ConversationFooter';
 import {Conversation, Message, User} from '../../types';
+import {formatCustomerDisplayName} from '../customers/support';
 
 type Props = {
+  visible?: boolean;
   conversation: Conversation;
   currentUser: User | null;
   messages: Array<Message>;
   onSendMessage: (message: Partial<Message>, cb: () => void) => void;
+  onClose: () => void;
 };
 
-class ConversationSidebar extends React.Component<Props, any> {
+class ConversationModal extends React.Component<Props> {
   scrollToEl: any;
 
-  componentDidMount() {
-    this.scrollIntoView();
-  }
-
-  componentDidUpdate(prev: Props) {
-    const {messages: previousMessages} = prev;
-    const {messages} = this.props;
-
-    if (messages.length > previousMessages.length) {
+  componentDidUpdate() {
+    if (this.props.visible) {
       this.scrollIntoView();
     }
   }
@@ -49,41 +45,59 @@ class ConversationSidebar extends React.Component<Props, any> {
   };
 
   render() {
-    const {currentUser, messages = []} = this.props;
+    const {
+      visible,
+      conversation,
+      currentUser,
+      messages = [],
+      onClose,
+    } = this.props;
+    const {customer} = conversation;
+    const identifer = customer.name || customer.email || 'Anonymous User';
+    const title = `Conversation with ${identifer}`;
 
     return (
-      <Flex
-        className="rr-block"
-        sx={{
-          width: '100%',
-          height: '100%',
-          flexDirection: 'column',
-          bg: colors.white,
-          border: `1px solid rgba(0,0,0,.06)`,
-          boxShadow: 'rgba(0, 0, 0, 0.1) 0px 0px 4px',
-          flex: 1,
-        }}
+      <Modal
+        title={title}
+        visible={visible}
+        bodyStyle={{padding: 0}}
+        onCancel={onClose}
+        footer={null}
       >
-        <ConversationMessages
-          sx={{p: 3}}
-          messages={messages}
-          currentUser={currentUser}
-          setScrollRef={(el) => (this.scrollToEl = el)}
-        />
+        <Flex
+          sx={{
+            width: '100%',
+            height: '100%',
+            maxHeight: '64vh',
+            flexDirection: 'column',
+            bg: colors.white,
+            flex: 1,
+          }}
+        >
+          <ConversationMessages
+            messages={messages}
+            currentUser={currentUser}
+            setScrollRef={(el) => (this.scrollToEl = el)}
+          />
 
-        <ConversationFooter
-          sx={{px: 3, pb: 3}}
-          onSendMessage={this.handleSendMessage}
-        />
-      </Flex>
+          <ConversationFooter
+            sx={{px: 3, pb: 3}}
+            onSendMessage={this.handleSendMessage}
+          />
+        </Flex>
+      </Modal>
     );
   }
 }
 
-const ConversationSidebarWrapper = ({
+const ConversationModalWrapper = ({
+  visible,
   conversationId,
+  onClose,
 }: {
+  visible?: boolean;
   conversationId: string;
+  onClose: () => void;
 }) => {
   const {
     loading,
@@ -115,13 +129,15 @@ const ConversationSidebarWrapper = ({
   }
 
   return (
-    <ConversationSidebar
+    <ConversationModal
+      visible={visible}
       conversation={conversation}
       messages={messages}
       currentUser={currentUser}
       onSendMessage={onSendMessage}
+      onClose={onClose}
     />
   );
 };
 
-export default ConversationSidebarWrapper;
+export default ConversationModalWrapper;

--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -11,21 +11,32 @@ type Props = {
   conversation: Conversation;
   currentUser: User | null;
   messages: Array<Message>;
-  onSendMessage: (message: Partial<Message>, cb: () => void) => void;
+  onSendMessage: (message: Partial<Message>, cb?: () => void) => void;
   onClose: () => void;
 };
 
 class ConversationModal extends React.Component<Props> {
   scrollToEl: any;
 
-  componentDidUpdate() {
-    if (this.props.visible) {
+  componentDidUpdate(prev: Props) {
+    if (
+      this.props.messages.length > prev.messages.length ||
+      (this.props.visible && !prev.visible)
+    ) {
       this.scrollIntoView();
     }
   }
 
   scrollIntoView = () => {
     this.scrollToEl && this.scrollToEl.scrollIntoView();
+  };
+
+  handleSetScrollRef = (el: HTMLDivElement | null) => {
+    this.scrollToEl = el;
+
+    if (el) {
+      this.scrollIntoView();
+    }
   };
 
   handleSendMessage = (message: Partial<Message>) => {
@@ -35,12 +46,7 @@ class ConversationModal extends React.Component<Props> {
       return null;
     }
 
-    this.props.onSendMessage(
-      {...message, conversation_id: conversationId},
-      () => {
-        this.scrollIntoView();
-      }
-    );
+    this.props.onSendMessage({...message, conversation_id: conversationId});
   };
 
   render() {
@@ -75,7 +81,7 @@ class ConversationModal extends React.Component<Props> {
           <ConversationMessages
             messages={messages}
             currentUser={currentUser}
-            setScrollRef={(el) => (this.scrollToEl = el)}
+            setScrollRef={this.handleSetScrollRef}
           />
 
           <ConversationFooter
@@ -118,7 +124,6 @@ const ConversationModalWrapper = ({
     return null;
   }
 
-  // TODO: fix case where conversation is closed!
   const conversation = conversationsById[conversationId] || null;
   const messages = messagesByConversation[conversationId] || null;
 

--- a/assets/src/components/customers/CustomerDetailsConversations.tsx
+++ b/assets/src/components/customers/CustomerDetailsConversations.tsx
@@ -8,17 +8,22 @@ import {Conversation} from '../../types';
 import {getColorByUuid} from '../conversations/support';
 import ConversationItem from '../conversations/ConversationItem';
 import StartConversationButton from '../conversations/StartConversationButton';
+import ConversationModal from '../conversations/ConversationModal';
 import {sortConversationMessages} from '../../utils';
 
 type Props = {customerId: string; history: History};
 type State = {
   conversations: Conversation[];
+  selectedConversationId: string | null;
+  isModalVisible: boolean;
   isLoading: boolean;
 };
 
 class CustomerDetailsConversations extends React.Component<Props, State> {
   state: State = {
     conversations: [],
+    selectedConversationId: null,
+    isModalVisible: false,
     isLoading: true,
   };
 
@@ -45,19 +50,24 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
   };
 
   handleSelectConversation = (conversationId: string) => {
-    const conversation = this.state.conversations.find(
-      (conversation) => conversation.id === conversationId
-    );
-    const isClosed = conversation && conversation.status === 'closed';
-    const url = isClosed
-      ? `/conversations/closed?cid=${conversationId}`
-      : `/conversations/all?cid=${conversationId}`;
-    this.props.history.push(url);
+    this.setState({
+      selectedConversationId: conversationId,
+      isModalVisible: true,
+    });
+  };
+
+  handleCloseConversationModal = () => {
+    this.setState({selectedConversationId: null, isModalVisible: false});
   };
 
   render() {
     const {customerId} = this.props;
-    const {isLoading, conversations} = this.state;
+    const {
+      isLoading,
+      isModalVisible,
+      conversations,
+      selectedConversationId,
+    } = this.state;
 
     if (isLoading) {
       return (
@@ -109,6 +119,14 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
           })
         ) : (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        )}
+
+        {selectedConversationId && (
+          <ConversationModal
+            visible={isModalVisible}
+            conversationId={selectedConversationId}
+            onClose={() => this.setState({selectedConversationId: null})}
+          />
         )}
       </>
     );

--- a/assets/src/components/customers/CustomerDetailsConversations.tsx
+++ b/assets/src/components/customers/CustomerDetailsConversations.tsx
@@ -57,6 +57,9 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
   };
 
   handleCloseConversationModal = () => {
+    // TODO: figure out a better way to ensure that conversations are up to date
+    // (we probably want to use the ConversationsProvider to listen for updates)
+    this.fetchConversations();
     this.setState({selectedConversationId: null, isModalVisible: false});
   };
 
@@ -125,7 +128,7 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
           <ConversationModal
             visible={isModalVisible}
             conversationId={selectedConversationId}
-            onClose={() => this.setState({selectedConversationId: null})}
+            onClose={this.handleCloseConversationModal}
           />
         )}
       </>

--- a/assets/src/components/customers/CustomerDetailsConversations.tsx
+++ b/assets/src/components/customers/CustomerDetailsConversations.tsx
@@ -72,22 +72,6 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
       selectedConversationId,
     } = this.state;
 
-    if (isLoading) {
-      return (
-        <Flex
-          p={4}
-          sx={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Spinner size={40} />
-        </Flex>
-      );
-    }
-
     return (
       <>
         <Flex
@@ -101,6 +85,19 @@ class CustomerDetailsConversations extends React.Component<Props, State> {
             onInitializeNewConversation={this.fetchConversations}
           />
         </Flex>
+        {isLoading && conversations.length === 0 && (
+          <Flex
+            p={4}
+            sx={{
+              flex: 1,
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '100%',
+            }}
+          >
+            <Spinner size={40} />
+          </Flex>
+        )}
         {conversations.length > 0 ? (
           conversations.map((conversation) => {
             const {

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -70,13 +70,19 @@ const CustomersTable = ({
       title: 'Email',
       dataIndex: 'email',
       key: 'email',
-      render: (value: string) => {
-        return value ? (
-          <Text>{value}</Text>
-        ) : (
-          <Text style={{opacity: 0.8}} type="secondary">
-            --
-          </Text>
+      render: (value: string, record: Customer) => {
+        const {id: customerId} = record;
+
+        return (
+          <Link to={`/customers/${customerId}`}>
+            {value ? (
+              <Text>{value}</Text>
+            ) : (
+              <Text style={{opacity: 0.8}} type="secondary">
+                --
+              </Text>
+            )}
+          </Link>
         );
       },
     },
@@ -85,14 +91,19 @@ const CustomersTable = ({
       dataIndex: 'name',
       key: 'name',
       render: (value: string, record: Customer) => {
-        const hasEmail = record.email && record.email.length > 0;
+        const {id: customerId, email} = record;
+        const hasEmail = email && email.length > 0;
 
-        return value ? (
-          <Text>{value}</Text>
-        ) : (
-          <Text style={{opacity: 0.8}} type="secondary">
-            {hasEmail ? '--' : 'Anonymous User'}
-          </Text>
+        return (
+          <Link to={`/customers/${customerId}`}>
+            {value ? (
+              <Text>{value}</Text>
+            ) : (
+              <Text style={{opacity: 0.8}} type="secondary">
+                {hasEmail ? '--' : 'Anonymous User'}
+              </Text>
+            )}
+          </Link>
         );
       },
     },


### PR DESCRIPTION
### Description

This PR sets up the ConversationModal, which will allow us to view and send messages within a conversation in a modal UI. This will make it so we don't always have to navigate to the conversations dashboard to do this.

### Screenshots

![conversation-modal](https://user-images.githubusercontent.com/5264279/116313576-f0574800-a77b-11eb-996d-128ff82cfcbe.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
