### PR TITLE
Implement modal for editing issue details

### DIFF
--- a/assets/src/components/customers/CustomerDetailsNotes.tsx
+++ b/assets/src/components/customers/CustomerDetailsNotes.tsx
@@ -62,23 +62,7 @@ class CustomerDetailsNotes extends React.Component<Props, State> {
 
   render() {
     const {customerId} = this.props;
-    const {isLoading, customerNotes} = this.state;
-
-    if (isLoading) {
-      return (
-        <Flex
-          p={4}
-          sx={{
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            height: '100%',
-          }}
-        >
-          <Spinner size={40} />
-        </Flex>
-      );
-    }
+    const {isLoading, customerNotes = []} = this.state;
 
     return (
       <Box p={3}>
@@ -89,6 +73,19 @@ class CustomerDetailsNotes extends React.Component<Props, State> {
 
         <Divider />
 
+        {isLoading && customerNotes.length === 0 && (
+          <Flex
+            p={4}
+            sx={{
+              flex: 1,
+              justifyContent: 'center',
+              alignItems: 'center',
+              height: '100%',
+            }}
+          >
+            <Spinner size={40} />
+          </Flex>
+        )}
         {customerNotes.length === 0 ? (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
         ) : (

--- a/assets/src/components/issues/IssueDetailsPage.tsx
+++ b/assets/src/components/issues/IssueDetailsPage.tsx
@@ -17,8 +17,9 @@ import {sleep} from '../../utils';
 import Spinner from '../Spinner';
 import logger from '../../logger';
 import CustomersTableContainer from '../customers/CustomersTableContainer';
-import {IssueStateTag} from './IssuesTable';
 import {SearchCustomersModalButton} from '../customers/SearchCustomers';
+import {IssueStateTag} from './IssuesTable';
+import {UpdateIssueModalButton} from './UpdateIssueModal';
 
 const isValidGithubUrl = (url: string): boolean => {
   return url.indexOf('github.com/') !== -1;
@@ -207,17 +208,18 @@ class IssueDetailsPage extends React.Component<Props, State> {
         <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
           <Title level={2}>{title || 'Issue details'}</Title>
 
-          {/* 
-          TODO: implement me!
-
-          <Button onClick={this.handleOpenUpdateIssueModal}>
-            Edit issue details
-          </Button> 
-          */}
+          <UpdateIssueModalButton
+            type="default"
+            issue={issue}
+            onSuccess={this.handleRefreshIssue}
+          >
+            Edit
+          </UpdateIssueModalButton>
         </Flex>
 
         <Flex>
           <Box sx={{flex: 1, pr: 4}}>
+            {/* TODO: style the issue details similar to GitHub? */}
             <DetailsSectionCard>
               <Box mb={3}>
                 <Box>
@@ -259,7 +261,7 @@ class IssueDetailsPage extends React.Component<Props, State> {
             </DetailsSectionCard>
           </Box>
 
-          <Box sx={{flex: 3}}>
+          <Box sx={{flex: 2}}>
             <DetailsSectionCard>
               <Flex
                 mb={3}

--- a/assets/src/components/issues/IssuesTable.tsx
+++ b/assets/src/components/issues/IssuesTable.tsx
@@ -57,16 +57,28 @@ export const IssuesTable = ({
       title: 'Title',
       dataIndex: 'title',
       key: 'title',
-      render: (value: string) => {
-        return <Text>{value}</Text>;
+      render: (value: string, record: T.Issue) => {
+        const {id: issueId} = record;
+
+        return (
+          <Link to={`/issues/${issueId}`}>
+            <Text>{value}</Text>
+          </Link>
+        );
       },
     },
     {
       title: 'Description',
       dataIndex: 'body',
       key: 'body',
-      render: (value: string) => {
-        return value || '--';
+      render: (value: string, record: T.Issue) => {
+        const {id: issueId} = record;
+
+        return (
+          <Link to={`/issues/${issueId}`}>
+            <Text>{value || '--'}</Text>
+          </Link>
+        );
       },
     },
     {

--- a/assets/src/components/issues/UpdateIssueModal.tsx
+++ b/assets/src/components/issues/UpdateIssueModal.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import {capitalize} from 'lodash';
+import {ButtonProps} from 'antd/lib/button';
+import {Button, Input, Modal, Select, Text, TextArea} from '../common';
+import * as API from '../../api';
+import {Issue, IssueState} from '../../types';
+import logger from '../../logger';
+import {formatServerError} from '../../utils';
+
+const UpdateIssueModal = ({
+  visible,
+  issue,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  issue: Issue;
+  onSuccess: (params: any) => void;
+  onCancel: () => void;
+}) => {
+  const [title, setTitle] = React.useState(issue.title ?? '');
+  const [body, setBody] = React.useState(issue.body ?? '');
+  const [githubIssueUrl, setGithubIssueUrl] = React.useState(
+    issue.github_issue_url ?? ''
+  );
+  const [status, setStatus] = React.useState<IssueState>(issue.state ?? '');
+  const [error, setErrorMessage] = React.useState<string | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const handleChangeTitle = (e: any) => setTitle(e.target.value);
+  const handleChangeBody = (e: any) => setBody(e.target.value);
+  const handleChangeGithubIssueUrl = (e: any) =>
+    setGithubIssueUrl(e.target.value);
+
+  const resetInputFields = () => {
+    setTitle(issue.title ?? '');
+    setBody(issue.body ?? '');
+    setGithubIssueUrl(issue.github_issue_url ?? '');
+    setStatus(issue.state ?? '');
+    setErrorMessage(null);
+  };
+
+  const handleCancelIssue = () => {
+    onCancel();
+
+    setTimeout(() => resetInputFields(), 400);
+  };
+
+  const handleUpdateIssue = async () => {
+    setIsSaving(true);
+
+    try {
+      const result = await API.updateIssue(issue.id, {
+        title,
+        body,
+        github_issue_url: githubIssueUrl,
+        state: status,
+      });
+
+      onSuccess(result);
+    } catch (err) {
+      logger.error('Error creating issue:', err);
+      const errorMessage = formatServerError(err);
+      setErrorMessage(errorMessage);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Update issue"
+      visible={visible}
+      width={400}
+      onOk={handleUpdateIssue}
+      onCancel={handleCancelIssue}
+      footer={[
+        <Button key="cancel" onClick={handleCancelIssue}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleUpdateIssue}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Box mb={3}>
+          <label htmlFor="title">Title</label>
+          <Input
+            id="title"
+            type="text"
+            value={title}
+            onChange={handleChangeTitle}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="body">Description</label>
+          <TextArea
+            id="body"
+            placeholder="Optional"
+            value={body}
+            onChange={handleChangeBody}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="github_issue_url">GitHub Issue URL</label>
+          <Input
+            id="github_issue_url"
+            type="text"
+            placeholder="https://github.com/my/repo/issues/123"
+            value={githubIssueUrl}
+            onChange={handleChangeGithubIssueUrl}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="state">Status</label>
+          <Box>
+            <Select
+              style={{width: '100%'}}
+              value={status}
+              onChange={setStatus}
+              options={[
+                'unstarted',
+                'in_progress',
+                'in_review',
+                'done',
+                'closed',
+              ].map((value: string) => {
+                const formatted = value.split('_').join(' ');
+
+                return {value, label: capitalize(formatted)};
+              })}
+            />
+          </Box>
+        </Box>
+
+        {error && (
+          <Box mb={-3}>
+            <Text type="danger">{error}</Text>
+          </Box>
+        )}
+      </Box>
+    </Modal>
+  );
+};
+
+type CommonProps = {
+  issue: Issue;
+  onSuccess: (data: Issue) => void;
+};
+
+export const UpdateIssueModalButton = ({
+  issue,
+  onSuccess,
+  ...props
+}: CommonProps & ButtonProps) => {
+  const [isModalOpen, setModalOpen] = React.useState(false);
+
+  const handleOpenModal = () => setModalOpen(true);
+  const handleCloseModal = () => setModalOpen(false);
+  const handleSuccess = (issue: Issue) => {
+    handleCloseModal();
+    onSuccess(issue);
+  };
+
+  return (
+    <>
+      <Button type="primary" {...props} onClick={handleOpenModal} />
+      <UpdateIssueModal
+        visible={isModalOpen}
+        issue={issue}
+        onCancel={handleCloseModal}
+        onSuccess={handleSuccess}
+      />
+    </>
+  );
+};
+
+export default UpdateIssueModal;


### PR DESCRIPTION
### Description

Adds ability to edit an issue on the issue details page.

### Issue

https://github.com/papercups-io/papercups/issues/785

### Screenshots

![edit-issue-modal](https://user-images.githubusercontent.com/5264279/116430565-f51c0a80-a814-11eb-842d-dee9a2a9e662.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
