### PR TITLE
Set up API for finding GitHub issues by url

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -870,6 +870,25 @@ export const fetchGithubRepos = async (token = getAccessToken()) => {
     .then((res) => res.body.data);
 };
 
+export const findGithubIssues = async (
+  query: {
+    url?: string;
+    owner?: string;
+    repo?: string;
+  },
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/github/issues`)
+    .query(query)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export type EmailParams = {
   recipient: string;
   subject: string;

--- a/assets/src/components/issues/IssueDetailsPage.tsx
+++ b/assets/src/components/issues/IssueDetailsPage.tsx
@@ -5,6 +5,8 @@ import {
   colors,
   shadows,
   Button,
+  Divider,
+  MarkdownRenderer,
   Popconfirm,
   Result,
   Text,
@@ -189,20 +191,17 @@ class IssueDetailsPage extends React.Component<Props, State> {
             <Button icon={<ArrowLeftOutlined />}>Back to all issues</Button>
           </Link>
 
-          {/* TODO: implement me! */}
-          {false && (
-            <Popconfirm
-              title="Are you sure you want to delete this issue?"
-              okText="Yes"
-              cancelText="No"
-              placement="bottomLeft"
-              onConfirm={this.handleDeleteIssue}
-            >
-              <Button danger loading={deleting} icon={<DeleteOutlined />}>
-                Delete issue
-              </Button>
-            </Popconfirm>
-          )}
+          <Popconfirm
+            title="Are you sure you want to delete this issue?"
+            okText="Yes"
+            cancelText="No"
+            placement="bottomLeft"
+            onConfirm={this.handleDeleteIssue}
+          >
+            <Button danger loading={deleting} icon={<DeleteOutlined />}>
+              Delete issue
+            </Button>
+          </Popconfirm>
         </Flex>
 
         <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
@@ -221,19 +220,9 @@ class IssueDetailsPage extends React.Component<Props, State> {
           <Box sx={{flex: 1, pr: 4}}>
             {/* TODO: style the issue details similar to GitHub? */}
             <DetailsSectionCard>
-              <Box mb={3}>
-                <Box>
-                  <Text strong>Title</Text>
-                </Box>
-                <Text>{title}</Text>
-              </Box>
+              <MarkdownRenderer source={description || '_No description_'} />
 
-              <Box mb={3}>
-                <Box>
-                  <Text strong>Description</Text>
-                </Box>
-                <Text>{description || 'N/A'}</Text>
-              </Box>
+              <Divider />
 
               <Box mb={3}>
                 <Box>

--- a/assets/src/components/issues/IssuesOverview.tsx
+++ b/assets/src/components/issues/IssuesOverview.tsx
@@ -7,8 +7,9 @@ import * as T from '../../types';
 import logger from '../../logger';
 import IssuesTable from './IssuesTable';
 import NewIssueModal from './NewIssueModal';
+import {RouteComponentProps} from 'react-router';
 
-type Props = {};
+type Props = RouteComponentProps & {};
 type State = {
   filterQuery: string;
   filteredIssues: Array<T.Issue>;
@@ -94,9 +95,11 @@ class IssuesOverview extends React.Component<Props, State> {
     this.setState({isNewIssueModalVisible: false});
   };
 
-  handleNewIssueCreated = () => {
+  handleNewIssueCreated = (issue: T.Issue) => {
     this.handleNewIssueModalClosed();
     this.handleRefreshIssues();
+
+    this.props.history.push(`/issues/${issue.id}`);
   };
 
   render() {

--- a/assets/src/components/issues/IssuesTable.tsx
+++ b/assets/src/components/issues/IssuesTable.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import {Flex} from 'theme-ui';
 import {Button, Dropdown, Menu, Table, Tag, Text} from '../common';
 import {SettingOutlined} from '../icons';
 import * as API from '../../api';
 import * as T from '../../types';
+import {formatRelativeTime} from '../../utils';
+
+dayjs.extend(utc);
 
 export const IssueStateTag = ({state}: {state: T.IssueState}) => {
   switch (state) {
@@ -68,15 +73,16 @@ export const IssuesTable = ({
       },
     },
     {
-      title: 'Description',
-      dataIndex: 'body',
-      key: 'body',
+      title: 'Last updated',
+      dataIndex: 'updated_at',
+      key: 'updated_at',
       render: (value: string, record: T.Issue) => {
         const {id: issueId} = record;
+        const formatted = formatRelativeTime(dayjs.utc(value));
 
         return (
           <Link to={`/issues/${issueId}`}>
-            <Text>{value || '--'}</Text>
+            <Text>{formatted || '--'}</Text>
           </Link>
         );
       },

--- a/assets/src/components/issues/NewIssueModal.tsx
+++ b/assets/src/components/issues/NewIssueModal.tsx
@@ -28,7 +28,7 @@ const NewIssueModal = ({
 }: {
   visible: boolean;
   customerId?: string;
-  onSuccess: (params: any) => void;
+  onSuccess: (issue: Issue) => void;
   onCancel: () => void;
 }) => {
   const DEFAULT_ISSUE_STATE: IssueState = 'unstarted';

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -104,6 +104,7 @@ defmodule ChatApiWeb.Router do
     get("/github/authorization", GithubController, :authorization)
     delete("/github/authorizations/:id", GithubController, :delete)
     get("/github/repos", GithubController, :repos)
+    get("/github/issues", GithubController, :issues)
     get("/google/auth", GoogleController, :auth)
     get("/google/oauth", GoogleController, :callback)
     get("/google/authorization", GoogleController, :authorization)

--- a/lib/chat_api_web/views/issue_view.ex
+++ b/lib/chat_api_web/views/issue_view.ex
@@ -14,6 +14,8 @@ defmodule ChatApiWeb.IssueView do
     %{
       id: issue.id,
       object: "issue",
+      created_at: issue.inserted_at,
+      updated_at: issue.updated_at,
       title: issue.title,
       body: issue.body,
       state: issue.state,


### PR DESCRIPTION
### Description

This PR sets up an API for finding GitHub issues by url, so that we can make it easier to create a Papercups issue from an existing GitHub issue.

![sync-issue-from-github](https://user-images.githubusercontent.com/5264279/116594169-e9e9dd00-a8ef-11eb-81af-6281e0d37d6c.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
