### PR TITLE
Improve Slack notification preview on initial message

### DIFF
--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -844,6 +844,7 @@ defmodule ChatApi.Slack.Helpers do
     %{
       "channel" => channel,
       "unfurl_links" => false,
+      "text" => text,
       "blocks" => [
         %{
           "type" => "section",


### PR DESCRIPTION
### Description

Improve Slack notification preview on initial message so it doesn't say "this content cannot be displayed"

### Issue

Fixes https://github.com/papercups-io/papercups/issues/804

### Screenshots

<img width="373" alt="Screen Shot 2021-05-04 at 4 48 37 PM" src="https://user-images.githubusercontent.com/5264279/117067911-995fee80-acf8-11eb-8ddd-a591c955d6c9.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
