### PR TITLE
Display notification to refresh page if socket disconnects

### DIFF
--- a/assets/src/components/conversations/ConversationNotificationManager.ts
+++ b/assets/src/components/conversations/ConversationNotificationManager.ts
@@ -1,11 +1,12 @@
 import {Channel, Socket} from 'phoenix';
-import {throttle} from 'lodash';
+import {once, throttle} from 'lodash';
 
 import logger from '../../logger';
 import {Conversation, Message} from '../../types';
 import {SOCKET_URL} from '../../socket';
 import * as API from '../../api';
 import {PhoenixPresence, PresenceDiff} from '../../presence';
+import {notification} from '../common';
 
 type Config = {
   accountId: string;
@@ -57,14 +58,25 @@ class ConversationNotificationManager {
     // TODO: attempt refreshing access token?
     this.socket.onError(
       throttle(
-        () =>
-          logger.error('Error connecting to socket. Try refreshing the page.'),
+        () => {
+          logger.error('Error connecting to socket. Try refreshing the page.');
+
+          this.displayRefreshNotification();
+        },
         30 * 1000 // throttle every 30 secs
       )
     );
 
     this.socket.connect();
   }
+
+  displayRefreshNotification = once(() => {
+    notification.error({
+      message: "You've been disconnected.",
+      duration: null,
+      description: 'Please refresh the page to reconnect.',
+    });
+  });
 
   joinChannel() {
     const {

--- a/assets/src/components/conversations/ConversationNotificationManager.ts
+++ b/assets/src/components/conversations/ConversationNotificationManager.ts
@@ -70,6 +70,7 @@ class ConversationNotificationManager {
     this.socket.connect();
   }
 
+  // We use lodash's `once` utility to make sure this notification only gets displayed once
   displayRefreshNotification = once(() => {
     notification.error({
       message: "You've been disconnected.",


### PR DESCRIPTION
### Description

Display notification to refresh the dashboard if socket disconnects.

This is a temporary solution until we can figure out a good way to reconnect a disconnected socket.

### Issue

https://github.com/papercups-io/papercups/issues/774

### Screenshots

<img width="803" alt="Screen Shot 2021-05-05 at 11 47 45 AM" src="https://user-images.githubusercontent.com/5264279/117170135-bc8dab00-ad97-11eb-8a5d-8b71cddcda8f.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
