### PR TITLE
Adds ability to filter customers on the customers page by tags

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -168,7 +168,7 @@ export const fetchCustomers = async (
 
   return request
     .get(`/api/customers`)
-    .query(filters)
+    .query(qs.stringify(filters, {arrayFormat: 'bracket'}))
     .set('Authorization', token)
     .then((res) => res.body);
 };

--- a/assets/src/components/customers/CustomerTagSelect.tsx
+++ b/assets/src/components/customers/CustomerTagSelect.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import * as API from '../../api';
+import {Tag} from '../../types';
+import {Select} from '../common';
+
+const {Option} = Select;
+
+type Props = {
+  onChange: (selectedTagIds: string[]) => void;
+  placeholder?: string;
+  style?: React.CSSProperties;
+};
+type State = {tags: Tag[]};
+
+class CustomerTagSelect extends React.Component<Props, State> {
+  state: State = {
+    tags: [],
+  };
+
+  async componentDidMount() {
+    const tags = await API.fetchAllTags();
+    this.setState({tags});
+  }
+
+  render() {
+    const {onChange, placeholder = 'Select tags', style = {}} = this.props;
+    const {tags} = this.state;
+    return (
+      <Select
+        allowClear
+        mode="multiple"
+        onChange={onChange}
+        placeholder={placeholder}
+        style={style}
+      >
+        {tags.map((tag) => (
+          <Option key={tag.id} value={tag.id}>
+            {tag.name}
+          </Option>
+        ))}
+      </Select>
+    );
+  }
+}
+
+export default CustomerTagSelect;

--- a/assets/src/components/customers/CustomerTagSelect.tsx
+++ b/assets/src/components/customers/CustomerTagSelect.tsx
@@ -3,7 +3,12 @@ import * as API from '../../api';
 import {Tag} from '../../types';
 import {Select} from '../common';
 
-const {Option} = Select;
+const filterSelectOption = (input: string, option: any) => {
+  const label = option && option.label ? String(option.label) : '';
+  const sanitized = label.toLowerCase().replace(/_/, ' ');
+
+  return sanitized.indexOf(input.toLowerCase()) >= 0;
+};
 
 type Props = {
   onChange: (selectedTagIds: string[]) => void;
@@ -25,20 +30,19 @@ class CustomerTagSelect extends React.Component<Props, State> {
   render() {
     const {onChange, placeholder = 'Select tags', style = {}} = this.props;
     const {tags} = this.state;
+
     return (
       <Select
         allowClear
         mode="multiple"
         onChange={onChange}
+        filterOption={filterSelectOption}
         placeholder={placeholder}
         style={style}
-      >
-        {tags.map((tag) => (
-          <Option key={tag.id} value={tag.id}>
-            {tag.name}
-          </Option>
-        ))}
-      </Select>
+        options={tags.map((tag) => {
+          return {value: tag.id, label: tag.name};
+        })}
+      />
     );
   }
 }

--- a/assets/src/components/customers/CustomersTableContainer.tsx
+++ b/assets/src/components/customers/CustomersTableContainer.tsx
@@ -119,34 +119,29 @@ class CustomersTableContainer extends React.Component<Props, State> {
         {actions && typeof actions === 'function' && (
           <Flex mb={3} sx={{justifyContent: 'space-between'}}>
             {/* TODO: this will be where we put our search box and other filters */}
-            <Box>
-              <Flex mx={-2} sx={{alignItems: 'center'}}>
-                <Box mx={2}>
-                  <Input.Search
-                    placeholder="Search customers..."
-                    allowClear
-                    onSearch={this.handleSearchCustomers}
-                    style={{width: 320}}
-                  />
-                </Box>
-
-                <Box mx={2}>
-                  <Checkbox
-                    checked={shouldIncludeAnonymous}
-                    onChange={this.handleToggleIncludeAnonymous}
-                  >
-                    Include anonymous
-                  </Checkbox>
-                </Box>
-              </Flex>
-              <Box mt={2}>
+            <Flex mx={-2} sx={{alignItems: 'center'}}>
+              <Box mx={2}>
+                <Input.Search
+                  placeholder="Search customers..."
+                  allowClear
+                  onSearch={this.handleSearchCustomers}
+                  style={{width: 280}}
+                />
+              </Box>
+              <Box ml={2} mr={3}>
                 <CustomerTagSelect
                   placeholder="Filter by tags"
                   onChange={this.handleTagsSelect}
-                  style={{width: 320}}
+                  style={{width: 280}}
                 />
               </Box>
-            </Box>
+              <Checkbox
+                checked={shouldIncludeAnonymous}
+                onChange={this.handleToggleIncludeAnonymous}
+              >
+                Include anonymous
+              </Checkbox>
+            </Flex>
 
             {/* 
               NB: this is where we allow passing in custom action components, 

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -60,7 +60,7 @@ defmodule ChatApi.Customers do
 
   @spec filter_by_tags(Ecto.Query.t(), map()) :: Ecto.Query.t()
   def filter_by_tags(query, %{"tag_ids" => tag_ids}) when not is_nil(tag_ids) do
-    # We need to return a query that includes only the customers that are tagged with the passed in tag_ids. We do this
+    # We need to return a query that includes only the customers that are tagged with the passed in tag_ids.
 
     # Here, we aggregate the number of tags each customer has, but we only count the ones included in tag_ids.
     # Essentially, we're querying the number of tag_ids each customer has.

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -16,6 +16,7 @@ defmodule ChatApi.Customers do
     Customer
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
+    |> filter_by_tags(filters)
     |> filter_by_tag(filters)
     |> filter_by_issue(filters)
     |> order_by(desc: :last_seen_at)
@@ -41,6 +42,7 @@ defmodule ChatApi.Customers do
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
     |> filter_by_tag(filters)
+    |> filter_by_tags(filters)
     |> filter_by_issue(filters)
     |> order_by(desc: :last_seen_at)
     |> preload(conversations: ^conversations_query)
@@ -55,6 +57,31 @@ defmodule ChatApi.Customers do
   end
 
   def filter_by_tag(query, _filters), do: query
+
+  @spec filter_by_tags(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  def filter_by_tags(query, %{"tag_ids" => tag_ids}) when not is_nil(tag_ids) do
+    # We need to return a query that includes only the customers that are tagged with the passed in tag_ids. We do this
+
+    # Here, we aggregate the number of tags each customer has, but we only count the ones included in tag_ids.
+    # Essentially, we're querying the number of tag_ids each customer has.
+    customer_tags_query =
+      from(ct in CustomerTag,
+        where: ct.tag_id in ^tag_ids,
+        group_by: ct.customer_id,
+        select: %{customer_id: ct.customer_id, tag_count: count(ct.tag_id)}
+      )
+
+    # Because tag_count represents the number of tag_ids each customer has,
+    # we're able to join the two query and filter only the customers that
+    # have exactly the same number of tag_ids.
+    from(c in query,
+      join: ct in subquery(customer_tags_query),
+      on: c.id == ct.customer_id,
+      where: ct.tag_count == ^length(tag_ids)
+    )
+  end
+
+  def filter_by_tags(query, _filters), do: query
 
   @spec filter_by_issue(Ecto.Query.t(), map()) :: Ecto.Query.t()
   def filter_by_issue(query, %{"issue_id" => issue_id}) when not is_nil(issue_id) do

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -69,18 +69,21 @@ defmodule ChatApi.CustomersTest do
       customer_ids =
         Customers.list_customers(account.id, %{"tag_ids" => [tag_1.id]})
         |> Enum.map(& &1.id)
+
       assert customer_ids == [customer_1.id, customer_2.id]
 
       # Filtering with multiple tags only returns customers who have all of them
       customer_ids =
         Customers.list_customers(account.id, %{"tag_ids" => [tag_1.id, tag_2.id]})
         |> Enum.map(& &1.id)
+
       assert customer_ids == [customer_1.id]
 
       # Filtering with a single tag that only one customer has
       customer_ids =
         Customers.list_customers(account.id, %{"tag_ids" => [tag_3.id]})
         |> Enum.map(& &1.id)
+
       assert customer_ids == [customer_2.id]
     end
 

--- a/test/chat_api/customers_test.exs
+++ b/test/chat_api/customers_test.exs
@@ -70,7 +70,7 @@ defmodule ChatApi.CustomersTest do
         Customers.list_customers(account.id, %{"tag_ids" => [tag_1.id]})
         |> Enum.map(& &1.id)
 
-      assert customer_ids == [customer_1.id, customer_2.id]
+      assert Enum.sort(customer_ids) == Enum.sort([customer_1.id, customer_2.id])
 
       # Filtering with multiple tags only returns customers who have all of them
       customer_ids =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -199,7 +199,7 @@ defmodule ChatApi.Factory do
     %ChatApi.Tags.CustomerTag{
       account: build(:account),
       customer: build(:customer),
-      tag: build(:tag),
+      tag: build(:tag)
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -195,6 +195,14 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def customer_tag_factory do
+    %ChatApi.Tags.CustomerTag{
+      account: build(:account),
+      customer: build(:customer),
+      tag: build(:tag),
+    }
+  end
+
   def user_invitation_factory do
     %ChatApi.UserInvitations.UserInvitation{
       account: build(:account),


### PR DESCRIPTION
### Description

This commit adds a new filter on the customer pages that allows users to filter by tags. 

### Issue

https://github.com/papercups-io/papercups/issues/807

### Screenshots

https://user-images.githubusercontent.com/1361509/117211810-7bad8a80-adc7-11eb-9905-aef9441e03b5.mp4

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
