### PR TITLE
Remove unused list tags fn

### DIFF
--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -10,7 +10,7 @@ defmodule ChatApi.Conversations do
   alias ChatApi.Conversations.Conversation
   alias ChatApi.Customers.Customer
   alias ChatApi.Messages.Message
-  alias ChatApi.Tags.{Tag, ConversationTag}
+  alias ChatApi.Tags.ConversationTag
 
   @spec list_conversations_by_account(binary(), map()) :: [Conversation.t()]
   def list_conversations_by_account(account_id, filters \\ %{}) do

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -470,17 +470,6 @@ defmodule ChatApi.Conversations do
     count_agent_replies(conversation_id) > 0
   end
 
-  @spec list_tags(binary()) :: [Tag.t()]
-  def list_tags(id) do
-    # TODO: optimize this query
-    Conversation
-    |> Repo.get(id)
-    |> case do
-      nil -> []
-      found -> found |> Repo.preload(:tags) |> Map.get(:tags)
-    end
-  end
-
   @spec get_tag(Conversation.t(), binary()) :: ConversationTag.t() | nil
   def get_tag(%Conversation{id: id, account_id: account_id} = _conversation, tag_id) do
     ConversationTag

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -341,23 +341,6 @@ defmodule ChatApi.Customers do
     count > 0
   end
 
-  @spec list_tags(nil | binary() | Customer.t()) :: nil | [Tag.t()]
-  def list_tags(nil), do: []
-
-  def list_tags(%Customer{} = customer) do
-    customer |> Repo.preload(:tags) |> Map.get(:tags)
-  end
-
-  def list_tags(id) do
-    # TODO: optimize this query
-    Customer
-    |> Repo.get(id)
-    |> case do
-      nil -> []
-      found -> found |> Repo.preload(:tags) |> Map.get(:tags)
-    end
-  end
-
   @spec get_tag(Customer.t(), binary()) :: nil | CustomerTag.t()
   def get_tag(%Customer{id: id, account_id: account_id} = _customer, tag_id) do
     CustomerTag

--- a/lib/chat_api/customers.ex
+++ b/lib/chat_api/customers.ex
@@ -9,7 +9,7 @@ defmodule ChatApi.Customers do
   alias ChatApi.Conversations
   alias ChatApi.Customers.Customer
   alias ChatApi.Issues.CustomerIssue
-  alias ChatApi.Tags.{CustomerTag, Tag}
+  alias ChatApi.Tags.CustomerTag
 
   @spec list_customers(binary(), map()) :: [Customer.t()]
   def list_customers(account_id, filters \\ %{}) do


### PR DESCRIPTION
### Description

There was unused function `list_tags/1` in **Conversations** and **Customers** module that I removed. It seems like now `list_tags/1` function only exists in Tags module from where it gets used. Likewise also remove Tag module alias from them as they were unused.

### Issue

N/A

### Screenshots

N/A

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
