### PR TITLE
Support personal Gmail account integration

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -807,8 +807,15 @@ export const deleteTwilioAuthorization = async (
     .set('Authorization', token);
 };
 
+type GoogleIntegrationClient = 'gmail' | 'sheets';
+type GoogleIntegrationType = 'personal' | 'support';
+type GoogleIntegrationParams = {
+  client: GoogleIntegrationClient;
+  type?: GoogleIntegrationType;
+};
+
 export const fetchGoogleAuthorization = async (
-  client: 'gmail' | 'sheets',
+  query: GoogleIntegrationParams,
   token = getAccessToken()
 ) => {
   if (!token) {
@@ -817,7 +824,7 @@ export const fetchGoogleAuthorization = async (
 
   return request
     .get(`/api/google/authorization`)
-    .query({client})
+    .query(query)
     .set('Authorization', token)
     .then((res) => res.body.data);
 };

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -7,6 +7,8 @@ import {
   Conversation,
   Customer,
   CustomerNote,
+  GoogleAuthParams,
+  GoogleIntegrationParams,
   Issue,
   Tag,
   User,
@@ -807,13 +809,6 @@ export const deleteTwilioAuthorization = async (
     .set('Authorization', token);
 };
 
-type GoogleIntegrationClient = 'gmail' | 'sheets';
-type GoogleIntegrationType = 'personal' | 'support';
-type GoogleIntegrationParams = {
-  client: GoogleIntegrationClient;
-  type?: GoogleIntegrationType;
-};
-
 export const fetchGoogleAuthorization = async (
   query: GoogleIntegrationParams,
   token = getAccessToken()
@@ -1028,8 +1023,7 @@ export const authorizeGmailIntegration = async (
 };
 
 export const authorizeGoogleIntegration = async (
-  code: string,
-  scope?: string | null,
+  query: GoogleAuthParams,
   token = getAccessToken()
 ) => {
   if (!token) {
@@ -1038,7 +1032,7 @@ export const authorizeGoogleIntegration = async (
 
   return request
     .get(`/api/google/oauth`)
-    .query({code, scope})
+    .query(query)
     .set('Authorization', token)
     .then((res) => res.body.data);
 };

--- a/assets/src/components/account/UserProfile.tsx
+++ b/assets/src/components/account/UserProfile.tsx
@@ -349,7 +349,7 @@ class UserProfile extends React.Component<Props, State> {
           </Paragraph>
         </Box>
 
-        <Box>
+        <Box mb={3}>
           <PersonalGmailAuthorizationButton
             isConnected={hasGmailConnection}
             authorizationId={gmailAuthorizationId}

--- a/assets/src/components/account/UserProfile.tsx
+++ b/assets/src/components/account/UserProfile.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import {RouteComponentProps} from 'react-router';
 import {Box, Flex} from 'theme-ui';
+import qs from 'query-string';
 import {
   colors,
+  notification,
   Button,
   Checkbox,
   Divider,
@@ -11,14 +14,16 @@ import {
 } from '../common';
 import * as API from '../../api';
 import logger from '../../logger';
+import {PersonalGmailAuthorizationButton} from '../integrations/GoogleAuthorizationButton';
 
-type Props = {};
+type Props = RouteComponentProps<{}> & {};
 type State = {
   email: string;
   fullName: string;
   displayName: string;
   profilePhotoUrl: string;
   shouldEmailOnNewMessages: boolean;
+  personalGmailAuthorization: any | null;
   isLoading: boolean;
   isEditing: boolean;
 };
@@ -32,16 +37,57 @@ class UserProfile extends React.Component<Props, State> {
     displayName: '',
     profilePhotoUrl: '',
     shouldEmailOnNewMessages: false,
+    personalGmailAuthorization: null,
     isLoading: true,
     isEditing: false,
   };
 
   async componentDidMount() {
+    const {location, history} = this.props;
+    const {search} = location;
+    const q = qs.parse(search);
+    const code = q.code ? String(q.code) : null;
+
+    if (code) {
+      const success = await this.authorizeGoogleIntegration(code, q);
+
+      if (success) {
+        history.push('/account/profile');
+      }
+    }
+
     await this.fetchLatestProfile();
     await this.fetchLatestSettings();
+    await this.fetchGmailAuthorization();
 
     this.setState({isLoading: false});
   }
+
+  authorizeGoogleIntegration = async (code: string, query: any) => {
+    const scope = query.scope ? String(query.scope) : null;
+    const state = query.state ? String(query.state) : null;
+
+    return API.authorizeGoogleIntegration({code, scope, state})
+      .then((result) => {
+        logger.debug('Successfully authorized Google:', result);
+
+        return true;
+      })
+      .catch((err) => {
+        logger.error('Failed to authorize Google:', err);
+
+        const description =
+          err?.response?.body?.error?.message || err?.message || String(err);
+
+        notification.error({
+          message: 'Failed to authorize Google',
+          duration: null,
+          description,
+        });
+
+        return false;
+      });
+  };
 
   fetchLatestProfile = async () => {
     const profile = await API.fetchUserProfile();
@@ -85,6 +131,25 @@ class UserProfile extends React.Component<Props, State> {
         shouldEmailOnNewMessages: false,
       });
     }
+  };
+
+  fetchGmailAuthorization = async () => {
+    const authorization = await API.fetchGoogleAuthorization({
+      client: 'gmail',
+      type: 'personal',
+    });
+
+    this.setState({
+      personalGmailAuthorization: authorization,
+    });
+  };
+
+  handleDisconnectGmail = async (authorizationId: string) => {
+    return API.deleteGoogleAuthorization(authorizationId)
+      .then(() => this.fetchGmailAuthorization())
+      .catch((err) =>
+        logger.error('Failed to remove Gmail authorization:', err)
+      );
   };
 
   handleChangeFullName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -152,6 +217,7 @@ class UserProfile extends React.Component<Props, State> {
       fullName,
       displayName,
       profilePhotoUrl,
+      personalGmailAuthorization,
       shouldEmailOnNewMessages,
       isEditing,
     } = this.state;
@@ -159,6 +225,9 @@ class UserProfile extends React.Component<Props, State> {
     if (isLoading) {
       return null; // TODO: switch to loading state
     }
+
+    const gmailAuthorizationId = personalGmailAuthorization?.id;
+    const hasGmailConnection = !!gmailAuthorizationId;
 
     return (
       <Box p={4}>
@@ -268,6 +337,25 @@ class UserProfile extends React.Component<Props, State> {
         >
           Send email alert on new messages
         </Checkbox>
+
+        <Divider />
+
+        <Title level={3}>Link Gmail Account</Title>
+
+        <Box mb={3} sx={{maxWidth: 480}}>
+          <Paragraph>
+            By linking your Gmail account, you can send emails directly from
+            Papercups.
+          </Paragraph>
+        </Box>
+
+        <Box>
+          <PersonalGmailAuthorizationButton
+            isConnected={hasGmailConnection}
+            authorizationId={gmailAuthorizationId}
+            onDisconnectGmail={this.handleDisconnectGmail}
+          />
+        </Box>
       </Box>
     );
   }

--- a/assets/src/components/conversations/StartConversationButton.tsx
+++ b/assets/src/components/conversations/StartConversationButton.tsx
@@ -49,7 +49,7 @@ const NewConversationModal = ({
   React.useEffect(() => {
     if (visible) {
       Promise.all([
-        API.fetchGoogleAuthorization('gmail'),
+        API.fetchGoogleAuthorization({client: 'gmail'}),
         API.fetchCustomer(customerId, {expand: []}),
       ]).then(([authorization, customer]) => {
         const hasValidAuth = !!(authorization && authorization.id);

--- a/assets/src/components/integrations/GoogleAuthorizationButton.tsx
+++ b/assets/src/components/integrations/GoogleAuthorizationButton.tsx
@@ -3,20 +3,20 @@ import {Box, Flex} from 'theme-ui';
 import {Button, Popconfirm, Tooltip} from '../common';
 import {getGoogleAuthUrl} from './support';
 
-export const GoogleAuthorizationButton = ({
+export const SupportGmailAuthorizationButton = ({
   isConnected,
   authorizationId,
   onDisconnectGmail,
 }: {
-  isConnected: boolean;
-  authorizationId: string | null;
+  isConnected?: boolean;
+  authorizationId?: string | null;
   onDisconnectGmail: (id: string) => void;
 }) => {
   if (isConnected && authorizationId) {
     return (
       <Flex mx={-1}>
         <Box mx={1}>
-          <a href={getGoogleAuthUrl('gmail')}>
+          <a href={getGoogleAuthUrl({client: 'gmail', type: 'support'})}>
             <Button>Reconnect</Button>
           </a>
         </Box>
@@ -34,6 +34,7 @@ export const GoogleAuthorizationButton = ({
       </Flex>
     );
   }
+
   return (
     <Tooltip
       title={
@@ -43,8 +44,59 @@ export const GoogleAuthorizationButton = ({
         </Box>
       }
     >
-      <a href={getGoogleAuthUrl('gmail')}>
+      <a href={getGoogleAuthUrl({client: 'gmail', type: 'support'})}>
         <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
+      </a>
+    </Tooltip>
+  );
+};
+
+export const PersonalGmailAuthorizationButton = ({
+  isConnected,
+  authorizationId,
+  onDisconnectGmail,
+}: {
+  isConnected?: boolean;
+  authorizationId?: string | null;
+  onDisconnectGmail: (id: string) => void;
+}) => {
+  if (isConnected && authorizationId) {
+    return (
+      <Flex mx={-1}>
+        <Box mx={1}>
+          <a href={getGoogleAuthUrl({client: 'gmail', type: 'personal'})}>
+            <Button>Reconnect with Gmail</Button>
+          </a>
+        </Box>
+        <Box mx={1}>
+          <Popconfirm
+            title="Are you sure you want to disconnect from Gmail?"
+            okText="Yes"
+            cancelText="No"
+            placement="topLeft"
+            onConfirm={() => onDisconnectGmail(authorizationId)}
+          >
+            <Button danger>Disconnect from Gmail</Button>
+          </Popconfirm>
+        </Box>
+      </Flex>
+    );
+  }
+
+  return (
+    <Tooltip
+      placement="right"
+      title={
+        <Box>
+          Our verification with the Google API is pending, but you can still
+          link your Gmail account to opt into new features.
+        </Box>
+      }
+    >
+      <a href={getGoogleAuthUrl({client: 'gmail', type: 'personal'})}>
+        <Button type="primary">
+          {isConnected ? 'Reconnect with Gmail' : 'Connect with Gmail'}
+        </Button>
       </a>
     </Tooltip>
   );

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -157,7 +157,10 @@ class IntegrationsOverview extends React.Component<Props, State> {
   };
 
   fetchGmailIntegration = async (): Promise<IntegrationType> => {
-    const auth = await API.fetchGoogleAuthorization('gmail');
+    const auth = await API.fetchGoogleAuthorization({
+      client: 'gmail',
+      type: 'support',
+    });
 
     return {
       key: 'gmail',
@@ -171,7 +174,7 @@ class IntegrationsOverview extends React.Component<Props, State> {
   };
 
   fetchGoogleSheetsIntegration = async (): Promise<IntegrationType> => {
-    const auth = await API.fetchGoogleAuthorization('sheets');
+    const auth = await API.fetchGoogleAuthorization({client: 'sheets'});
 
     return {
       key: 'sheets',

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -290,8 +290,9 @@ class IntegrationsOverview extends React.Component<Props, State> {
     }
 
     const scope = q.scope ? String(q.scope) : null;
+    const state = q.state ? String(q.state) : null;
 
-    return API.authorizeGoogleIntegration(code, scope)
+    return API.authorizeGoogleIntegration({code, scope, state})
       .then((result) => logger.debug('Successfully authorized Google:', result))
       .catch((err) => {
         logger.error('Failed to authorize Google:', err);

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -5,7 +5,7 @@ import {colors, Button, Popconfirm, Table, Tag, Text, Tooltip} from '../common';
 import {IntegrationType, getSlackAuthUrl, getGoogleAuthUrl} from './support';
 import {MattermostAuthorizationButton} from './MattermostAuthorizationModal';
 import {TwilioAuthorizationButton} from './TwilioAuthorizationModal';
-import {GoogleAuthorizationButton} from './GoogleAuthorizationButton';
+import {SupportGmailAuthorizationButton} from './GoogleAuthorizationButton';
 import {GithubAuthorizationButton} from './GithubAuthorizationButton';
 
 const IntegrationsTable = ({
@@ -117,7 +117,7 @@ const IntegrationsTable = ({
             );
           case 'gmail':
             return (
-              <GoogleAuthorizationButton
+              <SupportGmailAuthorizationButton
                 isConnected={isConnected}
                 authorizationId={authorizationId}
                 onDisconnectGmail={onDisconnectGmail}
@@ -134,7 +134,7 @@ const IntegrationsTable = ({
                   </Box>
                 }
               >
-                <a href={getGoogleAuthUrl('sheets')}>
+                <a href={getGoogleAuthUrl({client: 'sheets'})}>
                   <Button>{isConnected ? 'Reconnect' : 'Connect'}</Button>
                 </a>
               </Tooltip>

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -59,8 +59,11 @@ export const getSlackAuthUrl = (type = 'reply') => {
   return `https://slack.com/oauth/v2/authorize?${query}`;
 };
 
-export const getGoogleAuthUrl = (client: 'gmail' | 'sheets') => {
+export const getGoogleAuthUrl = (
+  client: 'gmail' | 'sheets',
+  type: 'support' | 'personal' = 'support'
+) => {
   const origin = isDev ? 'http://localhost:4000' : window.location.origin;
 
-  return `${origin}/google/auth?client=${client}`;
+  return `${origin}/google/auth?client=${client}&type=${type}`;
 };

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -1,5 +1,6 @@
 import qs from 'query-string';
 import {SLACK_CLIENT_ID, isDev} from '../../config';
+import {GoogleIntegrationParams} from '../../types';
 
 export type IntegrationType = {
   key:
@@ -59,10 +60,7 @@ export const getSlackAuthUrl = (type = 'reply') => {
   return `https://slack.com/oauth/v2/authorize?${query}`;
 };
 
-export const getGoogleAuthUrl = (
-  client: 'gmail' | 'sheets',
-  type: 'support' | 'personal' = 'support'
-) => {
+export const getGoogleAuthUrl = ({client, type}: GoogleIntegrationParams) => {
   const origin = isDev ? 'http://localhost:4000' : window.location.origin;
 
   return `${origin}/google/auth?client=${client}&type=${type}`;

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -246,3 +246,16 @@ export type Pagination = {
   total_pages?: number;
   total_entries?: number;
 };
+
+export type GoogleIntegrationClient = 'gmail' | 'sheets';
+export type GoogleIntegrationType = 'personal' | 'support';
+export type GoogleIntegrationParams = {
+  client: GoogleIntegrationClient;
+  type?: GoogleIntegrationType;
+};
+
+export type GoogleAuthParams = {
+  code: string;
+  state?: string | null;
+  scope?: string | null;
+};

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -122,7 +122,7 @@ case mailer_adapter do
   "Swoosh.Adapters.Local" ->
     config :swoosh,
       serve_mailbox: System.get_env("LOCAL_SERVE_MAILBOX", "true") == "true",
-      preview_port: System.get_env("LOCAL_MAILBOX_PREVIEW_PORT", "4001") |> String.to_integer()
+      preview_port: System.get_env("LOCAL_MAILBOX_PREVIEW_PORT", "8080") |> String.to_integer()
 
     config :chat_api, ChatApi.Mailers, adapter: Swoosh.Adapters.Local
 

--- a/lib/chat_api/emails.ex
+++ b/lib/chat_api/emails.ex
@@ -3,7 +3,7 @@ defmodule ChatApi.Emails do
 
   require Logger
 
-  alias ChatApi.Repo
+  alias ChatApi.{Accounts, Repo, Users}
   alias ChatApi.Emails.Email
   alias ChatApi.Messages.Message
   alias ChatApi.Users.{User, UserSettings}
@@ -31,13 +31,22 @@ defmodule ChatApi.Emails do
     user |> Email.password_reset() |> deliver()
   end
 
-  @spec format_sender_name(User.t(), Account.t()) :: binary
-  def format_sender_name(user, account) do
+  @spec format_sender_name(User.t() | binary(), Account.t() | binary()) :: binary()
+  def format_sender_name(%User{} = user, %Account{} = account) do
     case user.profile do
       %{display_name: display_name} when not is_nil(display_name) -> display_name
       %{full_name: full_name} when not is_nil(full_name) -> full_name
-      _ -> account.company_name
+      _ -> "#{account.company_name} Team"
     end
+  end
+
+  def format_sender_name(user_id, account_id)
+      when is_integer(user_id) and is_binary(account_id) do
+    account = Accounts.get_account!(account_id)
+
+    user_id
+    |> Users.get_user_info()
+    |> format_sender_name(account)
   end
 
   @spec send_conversation_reply_email(keyword()) :: deliver_result()

--- a/lib/chat_api/github/helpers.ex
+++ b/lib/chat_api/github/helpers.ex
@@ -36,7 +36,7 @@ defmodule ChatApi.Github.Helpers do
   end
 
   @spec parse_github_repo_url(binary()) ::
-          {:error, :invalid_github_repo_url} | {:ok, %{id: binary, owner: binary, repo: binary}}
+          {:error, :invalid_github_repo_url} | {:ok, %{owner: binary, repo: binary}}
   def parse_github_repo_url(url) do
     url
     |> extract_github_url_path()

--- a/lib/chat_api/google.ex
+++ b/lib/chat_api/google.ex
@@ -58,16 +58,27 @@ defmodule ChatApi.Google do
     |> Repo.one()
   end
 
-  @spec get_default_gmail_authorization(binary(), integer()) :: GoogleAuthorization.t() | nil
-  def get_default_gmail_authorization(account_id, user_id) do
-    personal =
+  def get_personal_gmail_authorization(account_id, user_id),
+    do:
       get_authorization_by_account(account_id, %{
         client: "gmail",
         type: "personal",
         user_id: user_id
       })
 
-    case personal do
+  def get_support_gmail_authorization(account_id, _user_id),
+    do: get_support_gmail_authorization(account_id)
+
+  def get_support_gmail_authorization(account_id),
+    do:
+      get_authorization_by_account(account_id, %{
+        client: "gmail",
+        type: "support"
+      })
+
+  @spec get_default_gmail_authorization(binary(), integer()) :: GoogleAuthorization.t() | nil
+  def get_default_gmail_authorization(account_id, user_id) do
+    case get_personal_gmail_authorization(account_id, user_id) do
       %GoogleAuthorization{} = auth -> auth
       nil -> get_authorization_by_account(account_id, %{client: "gmail"})
     end

--- a/lib/chat_api/google.ex
+++ b/lib/chat_api/google.ex
@@ -4,8 +4,7 @@ defmodule ChatApi.Google do
   """
 
   import Ecto.Query, warn: false
-  alias ChatApi.Repo
-
+  alias ChatApi.{Accounts, Emails, Repo}
   alias ChatApi.Google.{GoogleAuthorization, GmailConversationThread}
 
   #############################################################################
@@ -59,7 +58,7 @@ defmodule ChatApi.Google do
     |> Repo.one()
   end
 
-  @spec get_default_gmail_authorization(binary(), binary()) :: GoogleAuthorization.t() | nil
+  @spec get_default_gmail_authorization(binary(), integer()) :: GoogleAuthorization.t() | nil
   def get_default_gmail_authorization(account_id, user_id) do
     personal =
       get_authorization_by_account(account_id, %{
@@ -84,6 +83,16 @@ defmodule ChatApi.Google do
     else
       create_google_authorization(params)
     end
+  end
+
+  @spec format_sender_display_name(GoogleAuthorization.t(), integer(), binary()) :: binary()
+  def format_sender_display_name(%GoogleAuthorization{type: "personal"}, user_id, account_id),
+    do: Emails.format_sender_name(user_id, account_id)
+
+  def format_sender_display_name(_, _, account_id) do
+    account = Accounts.get_account!(account_id)
+
+    "#{account.company_name} Team"
   end
 
   # Pulled from https://hexdocs.pm/ecto/dynamic-queries.html#building-dynamic-queries

--- a/lib/chat_api/google/auth.ex
+++ b/lib/chat_api/google/auth.ex
@@ -1,12 +1,13 @@
 defmodule ChatApi.Google.Auth do
   use OAuth2.Strategy
 
-  def client do
+  def client(params \\ []) do
     OAuth2.Client.new(
       strategy: __MODULE__,
       client_id: System.get_env("PAPERCUPS_GOOGLE_CLIENT_ID"),
       client_secret: System.get_env("PAPERCUPS_GOOGLE_CLIENT_SECRET"),
-      redirect_uri: System.get_env("PAPERCUPS_GOOGLE_REDIRECT_URI"),
+      redirect_uri:
+        Keyword.get(params, :redirect_uri, System.get_env("PAPERCUPS_GOOGLE_REDIRECT_URI")),
       site: "https://accounts.google.com",
       authorize_url: "/o/oauth2/auth",
       token_url: "/o/oauth2/token"
@@ -25,7 +26,9 @@ defmodule ChatApi.Google.Auth do
   end
 
   def authorize_url!(params \\ []) do
-    OAuth2.Client.authorize_url!(client(), params)
+    params
+    |> client()
+    |> OAuth2.Client.authorize_url!(params)
   end
 
   # You can pass options to the underlying http library via `opts` parameter

--- a/lib/chat_api/google/auth.ex
+++ b/lib/chat_api/google/auth.ex
@@ -38,7 +38,7 @@ defmodule ChatApi.Google.Auth do
         OAuth2.Client.get_token!(refresh_client(), params, headers, opts)
 
       _ ->
-        OAuth2.Client.get_token!(client(), params, headers, opts)
+        params |> client() |> OAuth2.Client.get_token!(params, headers, opts)
     end
   end
 

--- a/lib/chat_api/google/google_authorization.ex
+++ b/lib/chat_api/google/google_authorization.ex
@@ -12,6 +12,7 @@ defmodule ChatApi.Google.GoogleAuthorization do
           token_type: String.t() | nil,
           expires_at: integer(),
           scope: String.t() | nil,
+          type: String.t() | nil,
           metadata: any(),
           # Foreign keys
           account_id: Ecto.UUID.t(),
@@ -30,6 +31,7 @@ defmodule ChatApi.Google.GoogleAuthorization do
     field(:token_type, :string)
     field(:expires_at, :integer)
     field(:scope, :string)
+    field(:type, :string)
     field(:metadata, :map)
 
     belongs_to(:account, Account)
@@ -48,10 +50,12 @@ defmodule ChatApi.Google.GoogleAuthorization do
       :token_type,
       :expires_at,
       :scope,
+      :type,
       :metadata,
       :user_id,
       :account_id
     ])
     |> validate_required([:client, :refresh_token, :user_id, :account_id])
+    |> validate_inclusion(:type, ["personal", "support", "sheets"])
   end
 end

--- a/lib/chat_api/google/initialize_gmail_thread.ex
+++ b/lib/chat_api/google/initialize_gmail_thread.ex
@@ -75,6 +75,8 @@ defmodule ChatApi.Google.InitializeGmailThread do
   end
 
   defp get_gmail_authorization(account_id) do
+    # TODO: if a personal authorization exists, use that -- otherwise fall back to the account-level
+    # (Will need to pass in a user_id as well to get the personal account)
     case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
       %Google.GoogleAuthorization{} = auth -> {:ok, auth}
       _ -> {:error, "Missing Gmail integration"}

--- a/lib/chat_api/google/initialize_gmail_thread.ex
+++ b/lib/chat_api/google/initialize_gmail_thread.ex
@@ -3,24 +3,27 @@ defmodule ChatApi.Google.InitializeGmailThread do
 
   require Logger
 
-  alias ChatApi.{Accounts, Conversations, Google, Messages}
+  alias ChatApi.{Accounts, Conversations, Emails, Google, Messages, Users}
   alias ChatApi.Conversations.Conversation
   alias ChatApi.Customers.Customer
   alias ChatApi.Messages.Message
 
-  @spec send(binary(), Conversation.t()) :: Message.t() | {:error, String.t()}
+  @spec send(binary(), Conversation.t(), binary()) :: Message.t() | {:error, String.t()}
   def send(
         text,
         %Conversation{
           id: conversation_id,
           account_id: account_id,
           subject: subject
-        }
+        },
+        user_id
       ) do
     with {:ok, %{refresh_token: refresh_token, user_id: user_id}} <-
-           get_gmail_authorization(account_id),
+           get_gmail_authorization(account_id, user_id),
          {:ok, from} <- get_authorized_gmail_address(refresh_token),
          {:ok, to} <- validate_conversation_customer_email(conversation_id) do
+      sender = Emails.format_sender_name(user_id, account_id)
+
       subject =
         case subject do
           nil -> get_default_subject(account_id)
@@ -33,7 +36,7 @@ defmodule ChatApi.Google.InitializeGmailThread do
       } =
         Google.Gmail.send_message(refresh_token, %{
           to: to,
-          from: from,
+          from: {sender, from},
           subject: subject,
           text: text
         })
@@ -74,10 +77,8 @@ defmodule ChatApi.Google.InitializeGmailThread do
     end
   end
 
-  defp get_gmail_authorization(account_id) do
-    # TODO: if a personal authorization exists, use that -- otherwise fall back to the account-level
-    # (Will need to pass in a user_id as well to get the personal account)
-    case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
+  defp get_gmail_authorization(account_id, user_id) do
+    case Google.get_default_gmail_authorization(account_id, user_id) do
       %Google.GoogleAuthorization{} = auth -> {:ok, auth}
       _ -> {:error, "Missing Gmail integration"}
     end

--- a/lib/chat_api/google/initialize_gmail_thread.ex
+++ b/lib/chat_api/google/initialize_gmail_thread.ex
@@ -81,7 +81,7 @@ defmodule ChatApi.Google.InitializeGmailThread do
   @spec get_gmail_authorization(binary(), integer()) ::
           {:ok, GoogleAuthorization.t()} | {:error, binary()}
   defp get_gmail_authorization(account_id, user_id) do
-    case Google.get_default_gmail_authorization(account_id, user_id) do
+    case Google.get_support_gmail_authorization(account_id, user_id) do
       %Google.GoogleAuthorization{} = auth -> {:ok, auth}
       _ -> {:error, "Missing Gmail integration"}
     end

--- a/lib/chat_api/google/initialize_gmail_thread.ex
+++ b/lib/chat_api/google/initialize_gmail_thread.ex
@@ -3,12 +3,13 @@ defmodule ChatApi.Google.InitializeGmailThread do
 
   require Logger
 
-  alias ChatApi.{Accounts, Conversations, Emails, Google, Messages, Users}
+  alias ChatApi.{Accounts, Conversations, Google, Messages}
   alias ChatApi.Conversations.Conversation
   alias ChatApi.Customers.Customer
+  alias ChatApi.Google.GoogleAuthorization
   alias ChatApi.Messages.Message
 
-  @spec send(binary(), Conversation.t(), binary()) :: Message.t() | {:error, String.t()}
+  @spec send(binary(), Conversation.t(), integer()) :: Message.t() | {:error, String.t()}
   def send(
         text,
         %Conversation{
@@ -18,11 +19,11 @@ defmodule ChatApi.Google.InitializeGmailThread do
         },
         user_id
       ) do
-    with {:ok, %{refresh_token: refresh_token, user_id: user_id}} <-
+    with {:ok, %{refresh_token: refresh_token, user_id: _auth_user_id} = authorization} <-
            get_gmail_authorization(account_id, user_id),
          {:ok, from} <- get_authorized_gmail_address(refresh_token),
          {:ok, to} <- validate_conversation_customer_email(conversation_id) do
-      sender = Emails.format_sender_name(user_id, account_id)
+      sender = Google.format_sender_display_name(authorization, user_id, account_id)
 
       subject =
         case subject do
@@ -77,6 +78,8 @@ defmodule ChatApi.Google.InitializeGmailThread do
     end
   end
 
+  @spec get_gmail_authorization(binary(), integer()) ::
+          {:ok, GoogleAuthorization.t()} | {:error, binary()}
   defp get_gmail_authorization(account_id, user_id) do
     case Google.get_default_gmail_authorization(account_id, user_id) do
       %Google.GoogleAuthorization{} = auth -> {:ok, auth}
@@ -84,6 +87,7 @@ defmodule ChatApi.Google.InitializeGmailThread do
     end
   end
 
+  @spec get_authorized_gmail_address(binary()) :: {:ok, binary()} | {:error, binary()}
   defp get_authorized_gmail_address(refresh_token) do
     case Google.Gmail.get_profile(refresh_token) do
       %{"emailAddress" => from} -> {:ok, from}
@@ -91,6 +95,7 @@ defmodule ChatApi.Google.InitializeGmailThread do
     end
   end
 
+  @spec validate_conversation_customer_email(binary()) :: {:ok, binary()} | {:error, binary()}
   defp validate_conversation_customer_email(conversation_id) do
     with %Conversation{customer: %Customer{email: email}} <-
            Conversations.get_conversation!(conversation_id),
@@ -101,6 +106,7 @@ defmodule ChatApi.Google.InitializeGmailThread do
     end
   end
 
+  @spec get_default_subject(binary()) :: binary()
   defp get_default_subject(account_id) do
     account = Accounts.get_account!(account_id)
 

--- a/lib/chat_api/newsletters/pg.ex
+++ b/lib/chat_api/newsletters/pg.ex
@@ -105,7 +105,7 @@ defmodule ChatApi.Newsletters.Pg do
          %{refresh_token: sheets_token} <-
            Google.get_authorization_by_account(account_id, %{client: "sheets"}),
          %{refresh_token: gmail_token} <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
+           Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}) do
       url = pick_essay_url(Date.utc_today(), start_date)
 
       recipients =

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -281,13 +281,15 @@ defmodule ChatApiWeb.ConversationController do
 
   @spec maybe_create_message(Plug.Conn.t(), Conversation.t(), map()) :: any()
   defp maybe_create_message(
-         _conn,
+         conn,
          %Conversation{source: "email"} = conversation,
          %{"message" => %{"body" => body} = _message_params}
        ) do
-    case ChatApi.Google.InitializeGmailThread.send(body, conversation) do
-      %Messages.Message{} -> :ok
-      {:error, message} -> {:error, :unprocessable_entity, message}
+    with %{id: user_id} <- conn.assigns.current_user do
+      case ChatApi.Google.InitializeGmailThread.send(body, conversation, user_id) do
+        %Messages.Message{} -> :ok
+        {:error, message} -> {:error, :unprocessable_entity, message}
+      end
     end
   end
 

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -7,9 +7,9 @@ defmodule ChatApiWeb.GmailController do
 
   @spec send(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def send(conn, %{"recipient" => recipient, "subject" => subject, "message" => message}) do
-    with %{account_id: account_id, email: email} <- conn.assigns.current_user,
+    with %{account_id: account_id, email: email, id: user_id} <- conn.assigns.current_user,
          %{refresh_token: refresh_token} <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_default_gmail_authorization(account_id, user_id),
          %{token: %{access_token: access_token}} <-
            Google.Auth.get_token!(refresh_token: refresh_token) do
       ChatApi.Emails.send_via_gmail(access_token, %{

--- a/lib/chat_api_web/controllers/gmail_controller.ex
+++ b/lib/chat_api_web/controllers/gmail_controller.ex
@@ -9,17 +9,15 @@ defmodule ChatApiWeb.GmailController do
   def send(conn, %{"recipient" => recipient, "subject" => subject, "message" => message}) do
     with %{account_id: account_id, email: email, id: user_id} <- conn.assigns.current_user,
          %{refresh_token: refresh_token} <-
-           Google.get_default_gmail_authorization(account_id, user_id),
-         %{token: %{access_token: access_token}} <-
-           Google.Auth.get_token!(refresh_token: refresh_token) do
-      ChatApi.Emails.send_via_gmail(access_token, %{
+           Google.get_support_gmail_authorization(account_id, user_id) do
+      Google.Gmail.send_message(refresh_token, %{
         to: recipient,
         from: email,
         subject: subject,
         text: message
       })
       |> case do
-        {:ok, result} ->
+        %{"id" => _id} = result ->
           json(conn, %{ok: true, data: result})
 
         error ->

--- a/lib/chat_api_web/controllers/google_controller.ex
+++ b/lib/chat_api_web/controllers/google_controller.ex
@@ -87,27 +87,13 @@ defmodule ChatApiWeb.GoogleController do
         _ -> raise "Unrecognized client: #{client}"
       end
 
-    default_redirect_uri = System.get_env("PAPERCUPS_GOOGLE_REDIRECT_URI")
-
-    redirect_uri =
-      case Map.get(params, "type") do
-        "support" ->
-          System.get_env("PAPERCUPS_SUPPORT_GMAIL_REDIRECT_URI", default_redirect_uri)
-
-        "personal" ->
-          System.get_env("PAPERCUPS_PERSONAL_GMAIL_REDIRECT_URI", default_redirect_uri)
-
-        _ ->
-          default_redirect_uri
-      end
-
     redirect(conn,
       external:
         Google.Auth.authorize_url!(
           scope: scope,
           prompt: "consent",
           access_type: "offline",
-          redirect_uri: redirect_uri
+          redirect_uri: get_redirect_uri(params)
         )
     )
   end
@@ -121,26 +107,12 @@ defmodule ChatApiWeb.GoogleController do
         _ -> raise "Unrecognized client: #{client}"
       end
 
-    default_redirect_uri = System.get_env("PAPERCUPS_GOOGLE_REDIRECT_URI")
-
-    redirect_uri =
-      case Map.get(params, "type") do
-        "support" ->
-          System.get_env("PAPERCUPS_SUPPORT_GMAIL_REDIRECT_URI", default_redirect_uri)
-
-        "personal" ->
-          System.get_env("PAPERCUPS_PERSONAL_GMAIL_REDIRECT_URI", default_redirect_uri)
-
-        _ ->
-          default_redirect_uri
-      end
-
     url =
       Google.Auth.authorize_url!(
         scope: scope,
         prompt: "consent",
         access_type: "offline",
-        redirect_uri: redirect_uri
+        redirect_uri: get_redirect_uri(params)
       )
 
     json(conn, %{data: %{url: url}})
@@ -153,6 +125,22 @@ defmodule ChatApiWeb.GoogleController do
            Google.get_google_authorization!(id),
          {:ok, %GoogleAuthorization{}} <- Google.delete_google_authorization(auth) do
       send_resp(conn, :no_content, "")
+    end
+  end
+
+  @spec get_redirect_uri(map()) :: String.t() | nil
+  defp get_redirect_uri(params) do
+    default_redirect_uri = System.get_env("PAPERCUPS_GOOGLE_REDIRECT_URI")
+
+    case Map.get(params, "type") do
+      "support" ->
+        System.get_env("PAPERCUPS_SUPPORT_GMAIL_REDIRECT_URI", default_redirect_uri)
+
+      "personal" ->
+        System.get_env("PAPERCUPS_PERSONAL_GMAIL_REDIRECT_URI", default_redirect_uri)
+
+      _ ->
+        default_redirect_uri
     end
   end
 

--- a/lib/mix/tasks/enable_gmail_inbox_sync.ex
+++ b/lib/mix/tasks/enable_gmail_inbox_sync.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.EnableGmailInboxSync do
           {:error, binary() | Ecto.Changeset.t()}
           | {:ok, ChatApi.Google.GoogleAuthorization.t()}
   def enable_gmail_sync(account_id, history_id) do
-    case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
+    case Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}) do
       %GoogleAuthorization{} = authorization ->
         Google.update_google_authorization(authorization, %{
           metadata: %{next_history_id: history_id}
@@ -70,11 +70,7 @@ defmodule Mix.Tasks.EnableGmailInboxSync do
           {:error, binary() | Ecto.Changeset.t()}
           | {:ok, ChatApi.Google.GoogleAuthorization.t()}
   def enable_gmail_sync(account_id) do
-    case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
-      %GoogleAuthorization{refresh_token: _, metadata: %{"next_history_id" => next_history_id}}
-      when is_binary(next_history_id) ->
-        {:error, "Gmail syncing is already enabled for this account"}
-
+    case Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}) do
       %GoogleAuthorization{refresh_token: token} = authorization ->
         history_id =
           token

--- a/lib/mix/tasks/sync_gmail_inbox.ex
+++ b/lib/mix/tasks/sync_gmail_inbox.ex
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.SyncGmailInbox do
            refresh_token: refresh_token,
            metadata: %{"next_history_id" => start_history_id}
          } = authorization <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}),
          %{"emailAddress" => email} <- Gmail.get_profile(refresh_token),
          %{"historyId" => next_history_id, "history" => [_ | _] = history} <-
            Gmail.list_history(refresh_token,
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.SyncGmailInbox do
   @spec sync_messages(binary(), binary()) :: :ok
   def sync_messages(account_id, start_history_id) do
     with %GoogleAuthorization{refresh_token: refresh_token} = authorization <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}),
          %{"emailAddress" => email} <- Gmail.get_profile(refresh_token),
          %{"historyId" => next_history_id, "history" => [_ | _] = history} <-
            Gmail.list_history(refresh_token,
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.SyncGmailInbox do
   @spec sync_messages_by_label(binary(), binary(), binary()) :: :ok | :error
   def sync_messages_by_label(account_id, start_history_id, label_id) do
     with %GoogleAuthorization{refresh_token: refresh_token} = authorization <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}),
          %{"emailAddress" => email} <- Gmail.get_profile(refresh_token),
          %{"historyId" => next_history_id, "history" => [_ | _] = history} <-
            Gmail.list_history(refresh_token,

--- a/lib/workers/enable_gmail_inbox_sync.ex
+++ b/lib/workers/enable_gmail_inbox_sync.ex
@@ -32,11 +32,7 @@ defmodule ChatApi.Workers.EnableGmailInboxSync do
           {:error, binary() | Ecto.Changeset.t()}
           | {:ok, ChatApi.Google.GoogleAuthorization.t()}
   def enable_gmail_sync(account_id) do
-    case Google.get_authorization_by_account(account_id, %{client: "gmail"}) do
-      %GoogleAuthorization{refresh_token: _, metadata: %{"next_history_id" => next_history_id}}
-      when is_binary(next_history_id) ->
-        {:error, "Gmail syncing is already enabled for this account"}
-
+    case Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}) do
       %GoogleAuthorization{refresh_token: token} = authorization ->
         history_id =
           token

--- a/lib/workers/send_gmail_notification.ex
+++ b/lib/workers/send_gmail_notification.ex
@@ -14,12 +14,13 @@ defmodule ChatApi.Workers.SendGmailNotification do
             "id" => message_id,
             "account_id" => account_id,
             "conversation_id" => conversation_id,
+            "user_id" => user_id,
             "body" => body
           }
         }
       }) do
     with %{refresh_token: refresh_token} = _authorization <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_default_gmail_authorization(account_id, user_id),
          %{gmail_initial_subject: gmail_initial_subject, gmail_thread_id: gmail_thread_id} <-
            Google.get_thread_by_conversation_id(conversation_id),
          %{

--- a/lib/workers/send_gmail_notification.ex
+++ b/lib/workers/send_gmail_notification.ex
@@ -4,7 +4,7 @@ defmodule ChatApi.Workers.SendGmailNotification do
   use Oban.Worker, queue: :mailers
   import Ecto.Query, warn: false
   require Logger
-  alias ChatApi.{Conversations, Google, Messages}
+  alias ChatApi.{Accounts, Conversations, Google, Messages}
 
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: :ok
@@ -29,7 +29,8 @@ defmodule ChatApi.Workers.SendGmailNotification do
            "gmail_to" => gmail_to,
            "gmail_cc" => gmail_cc,
            "gmail_references" => gmail_references
-         } = last_gmail_message <- extract_last_gmail_message!(conversation_id) do
+         } = last_gmail_message <- extract_last_gmail_message!(conversation_id),
+         %{company_name: company_name} <- Accounts.get_account!(account_id) do
       Logger.info("Last Gmail message: #{inspect(last_gmail_message)}")
 
       # TODO: double check logic for determining from/to/cc/etc
@@ -65,7 +66,7 @@ defmodule ChatApi.Workers.SendGmailNotification do
         end
 
       payload = %{
-        from: from,
+        from: {"#{company_name} Team", from},
         subject: "Re: #{gmail_initial_subject}",
         text: body,
         to: to,

--- a/lib/workers/send_gmail_notification.ex
+++ b/lib/workers/send_gmail_notification.ex
@@ -20,7 +20,7 @@ defmodule ChatApi.Workers.SendGmailNotification do
         }
       }) do
     with %{refresh_token: refresh_token} = authorization <-
-           Google.get_default_gmail_authorization(account_id, user_id),
+           Google.get_support_gmail_authorization(account_id, user_id),
          %{gmail_initial_subject: gmail_initial_subject, gmail_thread_id: gmail_thread_id} <-
            Google.get_thread_by_conversation_id(conversation_id),
          %{

--- a/lib/workers/sync_gmail_inbox.ex
+++ b/lib/workers/sync_gmail_inbox.ex
@@ -20,7 +20,7 @@ defmodule ChatApi.Workers.SyncGmailInbox do
            refresh_token: refresh_token,
            metadata: %{"next_history_id" => start_history_id}
          } = authorization <-
-           Google.get_authorization_by_account(account_id, %{client: "gmail"}),
+           Google.get_authorization_by_account(account_id, %{client: "gmail", type: "support"}),
          %{"emailAddress" => email} <- Gmail.get_profile(refresh_token),
          %{"historyId" => next_history_id, "history" => [_ | _] = history} <-
            Gmail.list_history(refresh_token,

--- a/priv/repo/migrations/20210519180207_add_type_to_google_authorizations.exs
+++ b/priv/repo/migrations/20210519180207_add_type_to_google_authorizations.exs
@@ -1,0 +1,25 @@
+defmodule ChatApi.Repo.Migrations.AddTypeToGoogleAuthorizations do
+  use Ecto.Migration
+
+  def up do
+    alter table(:google_authorizations) do
+      # At some point, it may make sense to make this an enum ("personal", "support", etc)
+      # Note that this is currently only used for the Gmail integration (i.e. not Google Sheets)
+      add(:type, :string)
+    end
+
+    execute("""
+    UPDATE google_authorizations SET type = 'support' WHERE scope = 'https://www.googleapis.com/auth/gmail.modify';
+    """)
+
+    execute("""
+    UPDATE google_authorizations SET type = 'sheets' WHERE scope = 'https://www.googleapis.com/auth/spreadsheets';
+    """)
+  end
+
+  def down do
+    alter table(:google_authorizations) do
+      remove(:type, :string)
+    end
+  end
+end

--- a/test/chat_api/users_test.exs
+++ b/test/chat_api/users_test.exs
@@ -115,7 +115,8 @@ defmodule ChatApi.UsersTest do
       user = Users.get_user_info(user.id)
 
       refute user.profile
-      assert "Test Inc" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Test Inc Team" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Test Inc Team" = ChatApi.Emails.format_sender_name(user.id, account.id)
     end
 
     test "Emails.format_sender_name/1 returns the company name when no display_name or full_name are set",
@@ -125,7 +126,8 @@ defmodule ChatApi.UsersTest do
 
       user = Users.get_user_info(user.id)
 
-      assert "Test Inc" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Test Inc Team" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Test Inc Team" = ChatApi.Emails.format_sender_name(user.id, account.id)
     end
 
     test "Emails.format_sender_name/1 prioritizes the display_name if both display_name and full_name are set",
@@ -136,6 +138,7 @@ defmodule ChatApi.UsersTest do
       user = Users.get_user_info(user.id)
 
       assert "Alex" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Alex" = ChatApi.Emails.format_sender_name(user.id, account.id)
 
       assert {:ok, %UserProfile{}} =
                Users.update_user_profile(user.id, %{display_name: nil, full_name: "Alex R"})
@@ -143,6 +146,7 @@ defmodule ChatApi.UsersTest do
       user = Users.get_user_info(user.id)
 
       assert "Alex R" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Alex R" = ChatApi.Emails.format_sender_name(user.id, account.id)
 
       assert {:ok, %UserProfile{}} =
                Users.update_user_profile(user.id, %{display_name: "Alex", full_name: nil})
@@ -150,6 +154,7 @@ defmodule ChatApi.UsersTest do
       user = Users.get_user_info(user.id)
 
       assert "Alex" = ChatApi.Emails.format_sender_name(user, account)
+      assert "Alex" = ChatApi.Emails.format_sender_name(user.id, account.id)
     end
   end
 


### PR DESCRIPTION
### Description

Support integration with personal Gmail accounts. These will not be auto-synced like the support email, but will allow users to send emails directly from Papercups (as if they were sending from Gmail) in the future.

### Issue

This just sets up the boilerplate for integrating with personal Gmail accounts. There are some edge cases we need to iron out in the behavior, for example:
- If a user starts a thread from their personal account, what happens if a teammate who DOESN'T have a personal integration also sends a message in the thread? Do we just send as the support/account-level integration? What if there is no support/account-level integration? Do we send on behalf of the original sender?
- How do we handle syncing of personal accounts? We don't want to sync all messages by default, but it probably makes sense to sync messages from existing threads in Papercups?
- How do we handle existing threads if a user decides to disconnect their account? (I guess this applies for both personal and support/account-level integrations)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
