### PR TITLE
Improve validation for Slack channel authorization

### DIFF
--- a/lib/chat_api/slack/validation.ex
+++ b/lib/chat_api/slack/validation.ex
@@ -55,12 +55,30 @@ defmodule ChatApi.Slack.Validation do
 
   @spec validate_authorization_channel_id(binary(), binary(), binary()) :: :ok | :error
   def validate_authorization_channel_id(slack_channel_id, account_id, integration_type) do
-    case SlackAuthorizations.get_authorization_by_account(account_id, %{
-           channel_id: slack_channel_id,
-           type: [neq: integration_type]
-         }) do
-      nil -> :ok
-      _match -> {:error, :duplicate_channel_id}
+    other_slack_authorization_for_account =
+      SlackAuthorizations.get_authorization_by_account(account_id, %{
+        channel_id: slack_channel_id,
+        type: [neq: integration_type]
+      })
+
+    potential_duplicate_from_other_account =
+      SlackAuthorizations.find_slack_authorization(%{
+        channel_id: slack_channel_id,
+        type: integration_type
+      })
+
+    case {other_slack_authorization_for_account, potential_duplicate_from_other_account} do
+      {%SlackAuthorization{} = _existing_with_same_channel, _} ->
+        {:error, :duplicate_channel_id}
+
+      {_, %SlackAuthorization{account_id: ^account_id}} ->
+        :ok
+
+      {_, %SlackAuthorization{account_id: _} = _match_from_different_account} ->
+        {:error, :duplicate_channel_id}
+
+      _ ->
+        :ok
     end
   end
 end

--- a/lib/chat_api/slack/validation.ex
+++ b/lib/chat_api/slack/validation.ex
@@ -71,6 +71,7 @@ defmodule ChatApi.Slack.Validation do
       {%SlackAuthorization{} = _existing_with_same_channel, _} ->
         {:error, :duplicate_channel_id}
 
+      # If account_id matches, the user is just reconnecting to the same channel, which is fine
       {_, %SlackAuthorization{account_id: ^account_id}} ->
         :ok
 

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -50,8 +50,8 @@ defmodule ChatApi.SlackTest do
                  "reply"
                )
 
-      # :ok if the account is different
-      assert :ok =
+      # :error if connecting to a channel that another account has already linked
+      assert {:error, :duplicate_channel_id} =
                Slack.Validation.validate_authorization_channel_id(
                  @slack_channel_id,
                  other_account_id,


### PR DESCRIPTION
### Description

This PR improves validation for Slack channel authorization, in order to prevent a common issue we see during demos of connecting to the same Slack channel from different accounts. (This should not be an issue for normal users, but will help us avoid messing up demos.)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
