### PR TITLE
Hide tags filter input for customers on issue details page

### DIFF
--- a/assets/src/components/customers/CustomersPage.tsx
+++ b/assets/src/components/customers/CustomersPage.tsx
@@ -31,6 +31,7 @@ const CustomersPage = () => {
 
         <CustomersTableContainer
           currentlyOnline={online}
+          includeTagFilterInput
           actions={(onSuccess) => <NewCustomerButton onSuccess={onSuccess} />}
         />
       </Box>

--- a/assets/src/components/customers/CustomersTableContainer.tsx
+++ b/assets/src/components/customers/CustomersTableContainer.tsx
@@ -12,6 +12,9 @@ type Props = {
   currentlyOnline?: any;
   shouldIncludeAnonymous?: boolean;
   defaultFilters?: Record<string, any>;
+  includeSearchInput?: boolean;
+  includeTagFilterInput?: boolean;
+  includeAnonymousUserFilter?: boolean;
   actions?: (
     refreshCustomerData: (filters?: any) => void
   ) => React.ReactElement;
@@ -111,7 +114,13 @@ class CustomersTableContainer extends React.Component<Props, State> {
   };
 
   render() {
-    const {currentlyOnline, actions} = this.props;
+    const {
+      currentlyOnline,
+      includeSearchInput = true,
+      includeTagFilterInput = false,
+      includeAnonymousUserFilter = true,
+      actions,
+    } = this.props;
     const {loading, customers, pagination, shouldIncludeAnonymous} = this.state;
 
     return (
@@ -120,27 +129,33 @@ class CustomersTableContainer extends React.Component<Props, State> {
           <Flex mb={3} sx={{justifyContent: 'space-between'}}>
             {/* TODO: this will be where we put our search box and other filters */}
             <Flex mx={-2} sx={{alignItems: 'center'}}>
-              <Box mx={2}>
-                <Input.Search
-                  placeholder="Search customers..."
-                  allowClear
-                  onSearch={this.handleSearchCustomers}
-                  style={{width: 280}}
-                />
-              </Box>
-              <Box ml={2} mr={3}>
-                <CustomerTagSelect
-                  placeholder="Filter by tags"
-                  onChange={this.handleTagsSelect}
-                  style={{width: 280}}
-                />
-              </Box>
-              <Checkbox
-                checked={shouldIncludeAnonymous}
-                onChange={this.handleToggleIncludeAnonymous}
-              >
-                Include anonymous
-              </Checkbox>
+              {includeSearchInput && (
+                <Box mx={2}>
+                  <Input.Search
+                    placeholder="Search customers..."
+                    allowClear
+                    onSearch={this.handleSearchCustomers}
+                    style={{width: 280}}
+                  />
+                </Box>
+              )}
+              {includeTagFilterInput && (
+                <Box ml={2} mr={3}>
+                  <CustomerTagSelect
+                    placeholder="Filter by tags"
+                    onChange={this.handleTagsSelect}
+                    style={{width: 280}}
+                  />
+                </Box>
+              )}
+              {includeAnonymousUserFilter && (
+                <Checkbox
+                  checked={shouldIncludeAnonymous}
+                  onChange={this.handleToggleIncludeAnonymous}
+                >
+                  Include anonymous
+                </Checkbox>
+              )}
             </Flex>
 
             {/* 


### PR DESCRIPTION
### Description

Hide tags filter input for customers on issue details page

### Issue

Fixes https://github.com/papercups-io/papercups/issues/844

### Screenshots

**Before:**
<img width="1398" alt="Screen Shot 2021-05-24 at 11 37 35 AM" src="https://user-images.githubusercontent.com/5264279/119371646-9a939400-bc84-11eb-8ea9-ad80e0601940.png">

**After:**
<img width="1394" alt="Screen Shot 2021-05-24 at 11 37 23 AM" src="https://user-images.githubusercontent.com/5264279/119371707-9d8e8480-bc84-11eb-8e1f-c303e7af30de.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
