### PR TITLE
Set up SocketProvider to manage websocket in client

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -32,6 +32,7 @@ import {
   isHostedProd,
   isStorytimeEnabled,
 } from '../config';
+import {SOCKET_URL} from '../socket';
 import analytics from '../analytics';
 import {
   getBrowserVisibilityInfo,
@@ -40,6 +41,7 @@ import {
 } from '../utils';
 import {Account, User} from '../types';
 import {useAuth} from './auth/AuthProvider';
+import {SocketProvider, SocketContext} from './auth/SocketProvider';
 import AccountOverview from './account/AccountOverview';
 import TeamOverview from './account/TeamOverview';
 import UserProfile from './account/UserProfile';
@@ -568,10 +570,20 @@ const Dashboard = (props: RouteComponentProps) => {
 };
 
 const DashboardWrapper = (props: RouteComponentProps) => {
+  const {refresh} = useAuth();
+
   return (
-    <ConversationsProvider>
-      <Dashboard {...props} />
-    </ConversationsProvider>
+    <SocketProvider url={SOCKET_URL} refresh={refresh}>
+      <SocketContext.Consumer>
+        {({socket}) => {
+          return (
+            <ConversationsProvider socket={socket}>
+              <Dashboard {...props} />
+            </ConversationsProvider>
+          );
+        }}
+      </SocketContext.Consumer>
+    </SocketProvider>
   );
 };
 

--- a/assets/src/components/auth/AuthProvider.tsx
+++ b/assets/src/components/auth/AuthProvider.tsx
@@ -10,6 +10,7 @@ export const AuthContext = React.createContext<{
   register: (params: any) => Promise<void>;
   login: (params: any) => Promise<void>;
   logout: () => Promise<void>;
+  refresh: (token: string) => Promise<void>;
 }>({
   isAuthenticated: false,
   tokens: null,
@@ -17,6 +18,7 @@ export const AuthContext = React.createContext<{
   register: () => Promise.resolve(),
   login: () => Promise.resolve(),
   logout: () => Promise.resolve(),
+  refresh: () => Promise.resolve(),
 });
 
 export const useAuth = () => useContext(AuthContext);
@@ -138,6 +140,7 @@ export class AuthProvider extends React.Component<Props, State> {
           register: this.register,
           login: this.login,
           logout: this.logout,
+          refresh: this.refresh,
         }}
       >
         {this.props.children}

--- a/assets/src/components/auth/SocketProvider.tsx
+++ b/assets/src/components/auth/SocketProvider.tsx
@@ -102,10 +102,6 @@ export class SocketProvider extends React.Component<Props, State> {
     const {socket} = this.state;
 
     socket.disconnect(cb);
-    // // TODO: are these necessary?
-    // socket.onOpen(noop);
-    // socket.onClose(noop);
-    // socket.onError(noop);
   };
 
   render() {

--- a/assets/src/components/auth/SocketProvider.tsx
+++ b/assets/src/components/auth/SocketProvider.tsx
@@ -1,0 +1,120 @@
+import React, {useContext} from 'react';
+import {Socket} from 'phoenix';
+import {throttle} from 'lodash';
+import {SOCKET_URL} from '../../socket';
+import * as API from '../../api';
+import logger from '../../logger';
+import {noop} from '../../utils';
+
+export const SocketContext = React.createContext<{
+  socket: Socket;
+  hasConnectionError?: boolean;
+}>({
+  socket: new Socket(SOCKET_URL),
+  hasConnectionError: false,
+});
+
+export const useSocket = () => useContext(SocketContext);
+
+type Props = {
+  url?: string;
+  options?: any;
+  refresh: (token: string) => Promise<void>;
+} & React.PropsWithChildren<{}>;
+
+type State = {
+  socket: Socket;
+  history: Array<Socket>;
+};
+
+export class SocketProvider extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const {url = SOCKET_URL} = props;
+    const socket = new Socket(url, {params: {token: API.getAccessToken()}});
+
+    this.state = {
+      socket,
+      history: [socket],
+    };
+  }
+
+  componentDidMount() {
+    this.connect();
+  }
+
+  componentWillUnmount() {
+    this.disconnect();
+  }
+
+  createNewSocket = () => {
+    const {url = SOCKET_URL} = this.props;
+
+    return new Socket(url, {params: {token: API.getAccessToken()}});
+  };
+
+  connect = () => {
+    const {socket} = this.state;
+
+    socket.connect();
+
+    socket.onOpen(() => {
+      logger.debug(`Successfully connected to socket!`, socket);
+    });
+
+    socket.onClose(() => {
+      logger.debug(`Socket successfully closed!`, socket);
+    });
+
+    socket.onError(
+      throttle(() => {
+        logger.error(
+          `Error connecting to socket. Try refreshing the page.`,
+          socket
+        );
+
+        this.reconnect();
+      }, 10000)
+    );
+  };
+
+  reconnect = () => {
+    this.disconnect(async () => {
+      const token = API.getRefreshToken();
+
+      if (!token) {
+        // Attempt connect again
+        return this.connect();
+      }
+
+      await this.props.refresh(token);
+
+      const socket = this.createNewSocket();
+
+      this.setState({socket, history: [socket, ...this.state.history]}, () =>
+        this.connect()
+      );
+    });
+  };
+
+  disconnect = (cb = noop) => {
+    const {socket} = this.state;
+
+    socket.disconnect(cb);
+    // // TODO: are these necessary?
+    // socket.onOpen(noop);
+    // socket.onClose(noop);
+    // socket.onError(noop);
+  };
+
+  render() {
+    return (
+      <SocketContext.Provider value={{socket: this.state.socket}}>
+        {this.props.children}
+      </SocketContext.Provider>
+    );
+  }
+}
+
+export default SocketProvider;

--- a/assets/src/components/conversations/SidebarCustomerIssues.tsx
+++ b/assets/src/components/conversations/SidebarCustomerIssues.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
-import {Socket} from 'phoenix';
 import {Text, Tooltip} from '../common';
 import * as API from '../../api';
 import {Issue} from '../../types';
 import logger from '../../logger';
-import {SOCKET_URL} from '../../socket';
+import {useSocket} from '../auth/SocketProvider';
 import {IssueStateTag} from '../issues/IssuesTable';
 import {NewIssueModalButton} from '../issues/NewIssueModal';
 import Spinner from '../Spinner';
@@ -14,14 +13,9 @@ import Spinner from '../Spinner';
 const SidebarCustomerIssues = ({customerId}: {customerId: string}) => {
   const [loading, setLoading] = React.useState(false);
   const [customerIssues, setCustomerIssues] = React.useState<Array<Issue>>([]);
+  const {socket} = useSocket();
 
   React.useEffect(() => {
-    // TODO: move to a top-level SocketProvider?
-    const token = API.getAccessToken();
-    const socket = new Socket(SOCKET_URL, {params: {token}});
-
-    socket.connect();
-
     const channel = socket.channel(`issue:lobby:${customerId}`, {});
 
     channel.on('issue:created', () => refreshCustomerIssues());
@@ -37,11 +31,10 @@ const SidebarCustomerIssues = ({customerId}: {customerId: string}) => {
       });
 
     return () => {
-      socket.disconnect();
       channel.leave();
     };
     // eslint-disable-next-line
-  }, [customerId]);
+  }, [customerId, socket]);
 
   React.useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
### Description

Set up SocketProvider to manage websocket in client and make it easier to handle reconnections.

### Issue

https://github.com/papercups-io/papercups/issues/774

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
