### PR TITLE
Fix how messages are synced to Slack channel when integrations is added/changed

### DIFF
--- a/lib/chat_api/messages.ex
+++ b/lib/chat_api/messages.ex
@@ -22,14 +22,22 @@ defmodule ChatApi.Messages do
   end
 
   @spec list_by_conversation(binary(), binary(), keyword()) :: [Message.t()]
-  def list_by_conversation(conversation_id, account_id, limit: limit) do
+  def list_by_conversation(conversation_id, account_id, opts \\ []) do
     Message
     |> where(account_id: ^account_id, conversation_id: ^conversation_id)
-    |> order_by(desc: :inserted_at)
-    |> limit(^limit)
+    |> handle_order_by(opts)
+    |> maybe_limit(opts)
     |> preload([:attachments, :customer, [user: :profile]])
     |> Repo.all()
   end
+
+  @spec handle_order_by(Ecto.Query.t(), keyword()) :: Ecto.Query.t()
+  def handle_order_by(query, order_by: order_by), do: query |> order_by(^order_by)
+  def handle_order_by(query, _opts), do: query |> order_by(desc: :inserted_at)
+
+  @spec maybe_limit(Ecto.Query.t(), keyword()) :: Ecto.Query.t()
+  def maybe_limit(query, limit: limit), do: query |> limit(^limit)
+  def maybe_limit(query, _opts), do: query
 
   @spec count_messages_by_account(binary()) :: integer()
   def count_messages_by_account(account_id) do

--- a/lib/chat_api/slack/notification.ex
+++ b/lib/chat_api/slack/notification.ex
@@ -14,7 +14,9 @@ defmodule ChatApi.Slack.Notification do
     Messages.Message
   }
 
+  alias ChatApi.Conversations.Conversation
   alias ChatApi.Users.{User, UserProfile}
+  alias ChatApi.SlackAuthorizations.SlackAuthorization
   alias ChatApi.SlackConversationThreads.SlackConversationThread
 
   @spec log(binary()) :: :ok | Tesla.Env.result()
@@ -49,51 +51,30 @@ defmodule ChatApi.Slack.Notification do
       ) do
     Logger.info("Calling ChatApi.Slack.Notification.notify_primary_channel")
     # TODO: handle getting all these fields in a separate function?
-    with %{customer: customer} = conversation <-
+    with %Conversation{} = conversation <-
            Conversations.get_conversation_with!(conversation_id, :customer),
-         %{access_token: access_token, channel: channel, channel_id: channel_id} = authorization <-
+         %SlackAuthorization{channel_id: channel_id} = authorization <-
            SlackAuthorizations.get_authorization_by_account(account_id, %{type: "reply"}),
          is_first_message <-
            Conversations.is_first_message?(conversation_id, message_id),
          thread <-
            SlackConversationThreads.get_thread_by_conversation_id(conversation_id, channel_id),
          :ok <- validate_send_to_primary_channel(thread, is_first_message: is_first_message) do
-      # TODO: use a struct here?
-      %{
-        conversation: conversation,
-        message: message,
-        authorization: authorization,
-        thread: thread
-      }
-      |> Slack.Helpers.get_message_text()
-      |> Slack.Helpers.get_message_payload(%{
-        channel: channel,
-        conversation: conversation,
-        customer: customer,
-        thread: thread,
-        message: message
-      })
-      |> Slack.Client.send_message(access_token)
-      |> case do
-        # Just pass through in test/dev mode (not sure if there's a more idiomatic way to do this)
-        {:ok, nil} ->
-          nil
+      case validate_send_to_primary_channel(thread, is_first_message: is_first_message) do
+        :ok ->
+          send_to_primary_channel(%{
+            conversation: conversation,
+            message: message,
+            authorization: authorization,
+            thread: thread
+          })
 
-        {:ok, response} ->
-          # If no thread exists yet, start a new thread and kick off the first reply
-          if is_nil(thread) do
-            {:ok, thread} =
-              Slack.Helpers.create_new_slack_conversation_thread(conversation_id, response)
-
-            Slack.Client.send_message(
-              %{
-                "channel" => channel,
-                "text" => "(Send a message here to get started!)",
-                "thread_ts" => thread.slack_thread_ts
-              },
-              access_token
-            )
-          end
+        {:error, :conversation_exists_without_thread} ->
+          sync_conversation_messages_to_primary_channel(%{
+            conversation: conversation,
+            authorization: authorization,
+            thread: thread
+          })
 
         error ->
           Logger.error("Unable to send Slack message: #{inspect(error)}")
@@ -102,6 +83,87 @@ defmodule ChatApi.Slack.Notification do
       error ->
         Logger.info("Skipped sending Slack message: #{inspect(error)}")
     end
+  end
+
+  @spec send_to_primary_channel(%{
+          :authorization => SlackAuthorization.t(),
+          :conversation => Conversation.t(),
+          :message => Message.t(),
+          :thread => nil | SlackConversationThread.t()
+        }) :: nil | :ok | {:error, any} | {:ok, nil | Tesla.Env.t()}
+  def send_to_primary_channel(%{
+        conversation: %Conversation{id: conversation_id, customer: customer} = conversation,
+        message: message,
+        authorization:
+          %SlackAuthorization{access_token: access_token, channel: channel} = authorization,
+        thread: thread
+      }) do
+    %{
+      conversation: conversation,
+      message: message,
+      authorization: authorization,
+      thread: thread
+    }
+    |> Slack.Helpers.get_message_text()
+    |> Slack.Helpers.get_message_payload(%{
+      channel: channel,
+      conversation: conversation,
+      customer: customer,
+      thread: thread,
+      message: message
+    })
+    |> Slack.Client.send_message(access_token)
+    |> case do
+      # Just pass through in test/dev mode (not sure if there's a more idiomatic way to do this)
+      {:ok, nil} ->
+        nil
+
+      {:ok, response} ->
+        # If no thread exists yet, start a new thread and kick off the first reply
+        if is_nil(thread) do
+          {:ok, thread} =
+            Slack.Helpers.create_new_slack_conversation_thread(conversation_id, response)
+
+          Slack.Client.send_message(
+            %{
+              "channel" => channel,
+              "text" => "(Send a message here to get started!)",
+              "thread_ts" => thread.slack_thread_ts
+            },
+            access_token
+          )
+        end
+
+      error ->
+        Logger.error("Unable to send Slack message: #{inspect(error)}")
+    end
+  end
+
+  @spec sync_conversation_messages_to_primary_channel(%{
+          :authorization => SlackAuthorization.t(),
+          :conversation => Conversation.t(),
+          :thread => nil | SlackConversationThread.t()
+        }) :: :ok
+  def sync_conversation_messages_to_primary_channel(%{
+        conversation: %Conversation{id: conversation_id} = conversation,
+        authorization: authorization,
+        thread: thread
+      }) do
+    conversation_id
+    |> Conversations.get_conversation!()
+    |> Map.get(:messages, [])
+    |> Enum.sort_by(&{&1.inserted_at, &1.sent_at}, NaiveDateTime)
+    |> Enum.each(fn message ->
+      send_to_primary_channel(%{
+        conversation: conversation,
+        message: message,
+        authorization: authorization,
+        thread: thread
+      })
+
+      # TODO: how should we handle this?
+      Process.sleep(200)
+    end)
   end
 
   @spec notify_support_channel(Message.t()) :: :ok
@@ -169,10 +231,13 @@ defmodule ChatApi.Slack.Notification do
   # Otherwise, return :error (i.e. we don't want to start a new thread with a non-initial message)
   @spec validate_send_to_primary_channel(SlackConversationThread.t() | nil, [
           {:is_first_message, boolean}
-        ]) :: :error | :ok
+        ]) :: :ok | {:error, atom()}
+  def validate_send_to_primary_channel(nil, is_first_message: false),
+    do: {:error, :conversation_exists_without_thread}
+
   def validate_send_to_primary_channel(_thread, is_first_message: true), do: :ok
   def validate_send_to_primary_channel(%SlackConversationThread{}, _opts), do: :ok
-  def validate_send_to_primary_channel(_thread, _opts), do: :error
+  def validate_send_to_primary_channel(_thread, _opts), do: {:error, :unexpected_thread_state}
 
   # TODO: maybe these methods below belong in the Slack.Helpers module?
 

--- a/lib/chat_api/slack/notification.ex
+++ b/lib/chat_api/slack/notification.ex
@@ -51,15 +51,13 @@ defmodule ChatApi.Slack.Notification do
       ) do
     Logger.info("Calling ChatApi.Slack.Notification.notify_primary_channel")
     # TODO: handle getting all these fields in a separate function?
-    with %Conversation{} = conversation <-
-           Conversations.get_conversation_with!(conversation_id, :customer),
-         %SlackAuthorization{channel_id: channel_id} = authorization <-
+    with %SlackAuthorization{channel_id: channel_id} = authorization <-
            SlackAuthorizations.get_authorization_by_account(account_id, %{type: "reply"}),
-         is_first_message <-
-           Conversations.is_first_message?(conversation_id, message_id),
-         thread <-
-           SlackConversationThreads.get_thread_by_conversation_id(conversation_id, channel_id),
-         :ok <- validate_send_to_primary_channel(thread, is_first_message: is_first_message) do
+         %Conversation{} = conversation <-
+           Conversations.get_conversation_with!(conversation_id, :customer) do
+      is_first_message = Conversations.is_first_message?(conversation_id, message_id)
+      thread = SlackConversationThreads.get_thread_by_conversation_id(conversation_id, channel_id)
+
       case validate_send_to_primary_channel(thread, is_first_message: is_first_message) do
         :ok ->
           send_to_primary_channel(%{
@@ -72,8 +70,7 @@ defmodule ChatApi.Slack.Notification do
         {:error, :conversation_exists_without_thread} ->
           sync_conversation_messages_to_primary_channel(%{
             conversation: conversation,
-            authorization: authorization,
-            thread: thread
+            authorization: authorization
           })
 
         error ->
@@ -90,7 +87,7 @@ defmodule ChatApi.Slack.Notification do
           :conversation => Conversation.t(),
           :message => Message.t(),
           :thread => nil | SlackConversationThread.t()
-        }) :: nil | :ok | {:error, any} | {:ok, nil | Tesla.Env.t()}
+        }) :: {:error, any} | {:ok, nil | Tesla.Env.t()}
   def send_to_primary_channel(%{
         conversation: %Conversation{id: conversation_id, customer: customer} = conversation,
         message: message,
@@ -98,25 +95,26 @@ defmodule ChatApi.Slack.Notification do
           %SlackAuthorization{access_token: access_token, channel: channel} = authorization,
         thread: thread
       }) do
-    %{
-      conversation: conversation,
-      message: message,
-      authorization: authorization,
-      thread: thread
-    }
-    |> Slack.Helpers.get_message_text()
-    |> Slack.Helpers.get_message_payload(%{
-      channel: channel,
-      conversation: conversation,
-      customer: customer,
-      thread: thread,
-      message: message
-    })
-    |> Slack.Client.send_message(access_token)
-    |> case do
+    payload =
+      %{
+        conversation: conversation,
+        message: message,
+        authorization: authorization,
+        thread: thread
+      }
+      |> Slack.Helpers.get_message_text()
+      |> Slack.Helpers.get_message_payload(%{
+        channel: channel,
+        conversation: conversation,
+        customer: customer,
+        thread: thread,
+        message: message
+      })
+
+    case Slack.Client.send_message(payload, access_token) do
       # Just pass through in test/dev mode (not sure if there's a more idiomatic way to do this)
       {:ok, nil} ->
-        nil
+        {:ok, nil}
 
       {:ok, response} ->
         # If no thread exists yet, start a new thread and kick off the first reply
@@ -136,24 +134,43 @@ defmodule ChatApi.Slack.Notification do
 
       error ->
         Logger.error("Unable to send Slack message: #{inspect(error)}")
+
+        error
     end
   end
 
   @spec sync_conversation_messages_to_primary_channel(%{
           :authorization => SlackAuthorization.t(),
-          :conversation => Conversation.t(),
-          :thread => nil | SlackConversationThread.t()
+          :conversation => Conversation.t()
         }) :: :ok
   def sync_conversation_messages_to_primary_channel(%{
-        conversation: %Conversation{id: conversation_id} = conversation,
-        authorization: authorization,
-        thread: thread
+        conversation: %Conversation{} = conversation,
+        authorization: %SlackAuthorization{} = authorization
       }) do
-    conversation_id
-    |> Conversations.get_conversation!()
-    |> Map.get(:messages, [])
-    |> Enum.sort_by(&{&1.inserted_at, &1.sent_at}, NaiveDateTime)
-    |> Enum.each(fn message ->
+    # Retrieve and sort the conversation messages
+    [initial_message | followup_messages] =
+      conversation.id
+      |> Conversations.get_conversation!()
+      |> Map.get(:messages, [])
+      |> Enum.sort_by(& &1.inserted_at, NaiveDateTime)
+
+    # Send the initial messages to Slack to create a new thread
+    {:ok, _} =
+      send_to_primary_channel(%{
+        conversation: conversation,
+        message: initial_message,
+        authorization: authorization,
+        thread: nil
+      })
+
+    thread =
+      SlackConversationThreads.get_thread_by_conversation_id(
+        conversation.id,
+        authorization.channel_id
+      )
+
+    # Send each of the followup messages to the same thread
+    Enum.each(followup_messages, fn message ->
       send_to_primary_channel(%{
         conversation: conversation,
         message: message,

--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -271,7 +271,7 @@ defmodule ChatApi.SlackTest do
     end
 
     test "Notification.validate_send_to_primary_channel/2 returns :error if the message when the message is not an initial message and a thread does not exist" do
-      assert :error =
+      assert {:error, :conversation_exists_without_thread} =
                Slack.Notification.validate_send_to_primary_channel(nil, is_first_message: false)
     end
   end


### PR DESCRIPTION
### Description

Fix how messages are synced to Slack channel when integrations is added/changed

### Issue

https://github.com/papercups-io/papercups/issues/782

### Screenshots

TODO

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
