### PR TITLE
Set NODE env variable at build for Redis adapter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: POOL_SIZE=2 mix ecto.migrate
-web: mix phx.server
+web: NODE=$(mix phx.gen.secret) mix phx.server

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -4,4 +4,4 @@ set -e
 POOL_SIZE=2 mix ecto.setup
 mix deps.compile certifi
 echo "Run: mix phx.swagger.generate to generate swagger docs"
-mix phx.server
+NODE=$(mix phx.gen.secret) mix phx.server


### PR DESCRIPTION
### Description

Set NODE env variable at build for Redis adapter

### Issue

Redis adapter is still flakey... the heroku `DYNO` env variable may be unreliable

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
