### PR TITLE
Minor s3 refactor

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -147,7 +147,6 @@ config :ex_aws,
   secret_access_key: aws_secret_key,
   s3: [
     scheme: "https://",
-    host: bucket_name <> ".s3.amazonaws.com",
     region: region
   ]
 

--- a/lib/chat_api/aws.ex
+++ b/lib/chat_api/aws.ex
@@ -48,7 +48,7 @@ defmodule ChatApi.Aws do
 
   @spec get_file_url(binary(), binary()) :: binary()
   def get_file_url(identifier, bucket) do
-    "https://#{bucket}.s3.amazonaws.com/#{bucket}/#{identifier}"
+    "https://#{bucket}.s3.amazonaws.com/#{identifier}"
   end
 
   @spec get_file_url(binary()) :: binary() | nil

--- a/test/chat_api/aws_test.exs
+++ b/test/chat_api/aws_test.exs
@@ -45,7 +45,7 @@ defmodule ChatApi.AwsTest do
       bucket = "papercups"
 
       assert Aws.get_file_url(filename, bucket) ==
-               "https://papercups.s3.amazonaws.com/papercups/test-file.jpg"
+               "https://papercups.s3.amazonaws.com/test-file.jpg"
     end
   end
 end


### PR DESCRIPTION
Support multiple s3 buckets and remove extra nested folder. Old files should work like before since we save the file path for s3 files in the db 