### PR TITLE
Only trigger functions on customer message events

### DIFF
--- a/assets/src/components/lambdas/LambdaDetailsPage.tsx
+++ b/assets/src/components/lambdas/LambdaDetailsPage.tsx
@@ -294,7 +294,7 @@ class LambdaDetailsPage extends React.Component<Props, State> {
         <Box>
           <Button
             block
-            disabled={deploying}
+            loading={deploying}
             type="primary"
             onClick={this.handleDeployLambda}
           >
@@ -474,11 +474,13 @@ class LambdaDetailsPage extends React.Component<Props, State> {
                   >
                     <Button
                       block
-                      disabled={deploying || !this.papercups}
-                      loading={isExecuting}
+                      disabled={!this.papercups}
+                      loading={deploying || isExecuting}
                       onClick={this.handleSendTestMessage}
                     >
-                      Run with test event
+                      {deploying || isExecuting
+                        ? 'Running...'
+                        : 'Run with test event'}
                     </Button>
                   </Box>
                 );

--- a/assets/src/components/lambdas/LambdaDetailsPage.tsx
+++ b/assets/src/components/lambdas/LambdaDetailsPage.tsx
@@ -276,6 +276,14 @@ class LambdaDetailsPage extends React.Component<Props, State> {
     });
 
     this.setState({apiExplorerOutput: output});
+
+    if (output && output.errorMessage) {
+      notification.error({
+        message: `Error running function.`,
+        description: output.errorMessage,
+        duration: null,
+      });
+    }
   };
 
   handleMessageSent = (fn: (data: any) => void) => (payload = {}) => {

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -93,8 +93,12 @@ defmodule ChatApi.Messages.Notification do
       }
 
       EventSubscriptions.notify_event_subscriptions(account_id, event)
-      # NB: We treat custom lambdas as webhook event handler
-      Lambdas.notify_active_lambdas(account_id, event)
+
+      # NB: We treat custom lambdas as webhook event handlers for customer messages
+      case Helpers.get_message_type(message) do
+        :customer -> Lambdas.notify_active_lambdas(account_id, event)
+        _ -> nil
+      end
     end)
 
     message


### PR DESCRIPTION
### Description

- Only trigger lambdas on customer message events
- General UX improvements on function details page

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
