### PR TITLE
Expose more endpoints for API clients using personal API keys

### DIFF
--- a/lib/chat_api_web/controllers/reporting_controller.ex
+++ b/lib/chat_api_web/controllers/reporting_controller.ex
@@ -41,4 +41,16 @@ defmodule ChatApiWeb.ReportingController do
       }
     })
   end
+
+  def index(conn, params) do
+    conn
+    |> put_status(400)
+    |> json(%{
+      error: %{
+        status: 400,
+        message: "The following parameters are required: from_date, to_date",
+        received: Map.keys(params)
+      }
+    })
+  end
 end

--- a/lib/chat_api_web/controllers/user_controller.ex
+++ b/lib/chat_api_web/controllers/user_controller.ex
@@ -8,8 +8,8 @@ defmodule ChatApiWeb.UserController do
   action_fallback(ChatApiWeb.FallbackController)
 
   @spec index(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def index(conn, _params) do
-    users = ChatApi.Users.list_users_by_account(conn.assigns.current_user.account_id)
+  def index(conn, params) do
+    users = ChatApi.Users.list_users_by_account(conn.assigns.current_user.account_id, params)
 
     render(conn, "index.json", users: users)
   end

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -162,10 +162,18 @@ defmodule ChatApiWeb.Router do
 
     get("/me", SessionController, :me)
 
+    resources("/profile", UserProfileController, only: [:show, :update])
+    resources("/user_settings", UserSettingsController, only: [:show, :update])
     resources("/messages", MessageController, except: [:new, :edit])
     resources("/conversations", ConversationController, except: [:new, :edit])
     resources("/customers", CustomerController, except: [:new, :edit])
     resources("/users", UserController, only: [:index, :show])
+    resources("/tags", TagController, except: [:new, :edit])
+    resources("/issues", IssueController, except: [:new, :edit])
+    resources("/notes", NoteController, except: [:new, :edit])
+    resources("/companies", CompanyController, except: [:new, :edit])
+
+    get("/reporting", ReportingController, :index)
   end
 
   # Enables LiveDashboard only for development


### PR DESCRIPTION
### Description

Expose more endpoints for API clients using personal API keys. (This will offer more functionality for new "functions" feature)

Blocks: https://github.com/papercups-io/papercups-node/pull/2

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
