### PR TITLE
Set up APIs for sending one-off notifications (Slack/Gmail/Twilio)

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -672,6 +672,25 @@ export const sendUserInvitationEmail = async (
     .then((res) => res.body.data);
 };
 
+export const sendSlackNotification = async (
+  params: {
+    text: string;
+    type?: 'reply' | 'support';
+    channel?: string;
+  },
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/slack/notify`)
+    .send(params)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const fetchSlackAuthorization = async (
   type = 'reply',
   token = getAccessToken()
@@ -824,6 +843,21 @@ export const deleteTwilioAuthorization = async (
   return request
     .delete(`/api/twilio/authorizations/${authorizationId}`)
     .set('Authorization', token);
+};
+
+export const sendTwilioSms = async (
+  params: {to: string; body: string},
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/twilio/send`)
+    .send(params)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
 };
 
 export const fetchGoogleAuthorization = async (

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -90,6 +90,7 @@ defmodule ChatApiWeb.Router do
     get("/reporting", ReportingController, :index)
 
     get("/slack/oauth", SlackController, :oauth)
+    post("/slack/notify", SlackController, :notify)
     get("/slack/authorization", SlackController, :authorization)
     post("/slack/authorizations/:id/settings", SlackController, :update_settings)
     delete("/slack/authorizations/:id", SlackController, :delete)
@@ -98,6 +99,7 @@ defmodule ChatApiWeb.Router do
     get("/mattermost/channels", MattermostController, :channels)
     get("/mattermost/authorization", MattermostController, :authorization)
     delete("/mattermost/authorizations/:id", MattermostController, :delete)
+    post("/twilio/send", TwilioController, :send)
     post("/twilio/auth", TwilioController, :auth)
     get("/twilio/authorization", TwilioController, :authorization)
     delete("/twilio/authorizations/:id", TwilioController, :delete)
@@ -174,6 +176,9 @@ defmodule ChatApiWeb.Router do
     resources("/companies", CompanyController, except: [:new, :edit])
 
     get("/reporting", ReportingController, :index)
+    post("/slack/notify", SlackController, :notify)
+    post("/twilio/send", TwilioController, :send)
+    post("/gmail/send", GmailController, :send)
   end
 
   # Enables LiveDashboard only for development


### PR DESCRIPTION
### Description

This PR sets up APIs for sending one-off notifications (via Slack/Gmail/Twilio).

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
