### PR TITLE
Make appsignal optional

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -168,6 +168,7 @@ if System.get_env("APPSIGNAL_API_KEY") do
     push_api_key: System.get_env("APPSIGNAL_API_KEY"),
     env: Mix.env(),
     active: true
+end
 
 case System.get_env("PAPERCUPS_STRIPE_SECRET") do
   "sk_" <> _rest = api_key ->

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -161,7 +161,7 @@ config :ex_aws,
     region: region
   ]
 
-if System.get_env("APPSIGNAL_API_KEY")
+if System.get_env("APPSIGNAL_API_KEY") do
   config :appsignal, :config,
     otp_app: :chat_api,
     name: "chat_api",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -161,12 +161,13 @@ config :ex_aws,
     region: region
   ]
 
-config :appsignal, :config,
-  otp_app: :chat_api,
-  name: "chat_api",
-  push_api_key: System.get_env("APPSIGNAL_API_KEY"),
-  env: Mix.env(),
-  active: true
+if System.get_env("APPSIGNAL_API_KEY")
+  config :appsignal, :config,
+    otp_app: :chat_api,
+    name: "chat_api",
+    push_api_key: System.get_env("APPSIGNAL_API_KEY"),
+    env: Mix.env(),
+    active: true
 
 case System.get_env("PAPERCUPS_STRIPE_SECRET") do
   "sk_" <> _rest = api_key ->


### PR DESCRIPTION
### Description

Added an if statement to add appsignal config only if APPSIGNAL_API_KEY env variable is present 

### Issue

https://github.com/papercups-io/papercups/issues/900

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
