### PR TITLE
Allow to store sensitive configs in files

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -17,17 +17,42 @@ socket_options =
 pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")
 
 if config_env() === :prod do
-  database_url =
-    System.get_env("DATABASE_URL") ||
-      raise """
-      environment variable DATABASE_URL is missing.
-      For example: ecto://USER:PASS@HOST/DATABASE
-      """
+  database_url = if System.get_env("DATABASE_URL") === nil do
+                   database_user =
+                     System.get_env("DATABASE_USER") ||
+                       raise """
+                       environment variable DATABASE_USER is missing.
+                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+                       """
+                   database_password =
+                     (System.get_env("DATABASE_PASSWORD_FILE") && File.read!(System.get_env("DATABASE_PASSWORD_FILE"))) ||
+                     System.get_env("DATABASE_PASSWORD") ||
+                       raise """
+                       environment variables DATABASE_PASSWORD or DATABASE_PASSWORD_FILE are missing.
+                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+                       """
+                   database_host =
+                     System.get_env("DATABASE_HOST") ||
+                       raise """
+                       environment variable DATABASE_HOST is missing.
+                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+                       """
+                   database =
+                     System.get_env("DATABASE") ||
+                       raise """
+                       environment variable DATABASE is missing.
+                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+                       """
+                   "ecto://#{database_user}:#{URI.encode_www_form(database_password)}@#{database_host}/#{database}"
+                 else
+                   System.get_env("DATABASE_URL")
+                 end
 
   secret_key_base =
+    (System.get_env("SECRET_KEY_BASE_FILE") && File.read!(System.get_env("SECRET_KEY_BASE_FILE"))) ||
     System.get_env("SECRET_KEY_BASE") ||
       raise """
-      environment variable SECRET_KEY_BASE is missing.
+      environment variables SECRET_KEY_BASE or SECRET_KEY_BASE_FILE are missing.
       You can generate one by calling: mix phx.gen.secret
       """
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -17,40 +17,46 @@ socket_options =
 pool_size = String.to_integer(System.get_env("POOL_SIZE") || "10")
 
 if config_env() === :prod do
-  database_url = if System.get_env("DATABASE_URL") === nil do
-                   database_user =
-                     System.get_env("DATABASE_USER") ||
-                       raise """
-                       environment variable DATABASE_USER is missing.
-                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
-                       """
-                   database_password =
-                     (System.get_env("DATABASE_PASSWORD_FILE") && File.read!(System.get_env("DATABASE_PASSWORD_FILE"))) ||
-                     System.get_env("DATABASE_PASSWORD") ||
-                       raise """
-                       environment variables DATABASE_PASSWORD or DATABASE_PASSWORD_FILE are missing.
-                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
-                       """
-                   database_host =
-                     System.get_env("DATABASE_HOST") ||
-                       raise """
-                       environment variable DATABASE_HOST is missing.
-                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
-                       """
-                   database =
-                     System.get_env("DATABASE") ||
-                       raise """
-                       environment variable DATABASE is missing.
-                       Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
-                       """
-                   "ecto://#{database_user}:#{URI.encode_www_form(database_password)}@#{database_host}/#{database}"
-                 else
-                   System.get_env("DATABASE_URL")
-                 end
+  database_url =
+    if System.get_env("DATABASE_URL") === nil do
+      database_user =
+        System.get_env("DATABASE_USER") ||
+          raise """
+          environment variable DATABASE_USER is missing.
+          Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+          """
+
+      database_password =
+        (System.get_env("DATABASE_PASSWORD_FILE") &&
+           File.read!(System.get_env("DATABASE_PASSWORD_FILE"))) ||
+          System.get_env("DATABASE_PASSWORD") ||
+          raise """
+          environment variables DATABASE_PASSWORD or DATABASE_PASSWORD_FILE are missing.
+          Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+          """
+
+      database_host =
+        System.get_env("DATABASE_HOST") ||
+          raise """
+          environment variable DATABASE_HOST is missing.
+          Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+          """
+
+      database =
+        System.get_env("DATABASE") ||
+          raise """
+          environment variable DATABASE is missing.
+          Alternatively, you can use the DATABASE_URL variable (for example: ecto://USER:PASS@HOST/DATABASE).
+          """
+
+      "ecto://#{database_user}:#{URI.encode_www_form(database_password)}@#{database_host}/#{database}"
+    else
+      System.get_env("DATABASE_URL")
+    end
 
   secret_key_base =
     (System.get_env("SECRET_KEY_BASE_FILE") && File.read!(System.get_env("SECRET_KEY_BASE_FILE"))) ||
-    System.get_env("SECRET_KEY_BASE") ||
+      System.get_env("SECRET_KEY_BASE") ||
       raise """
       environment variables SECRET_KEY_BASE or SECRET_KEY_BASE_FILE are missing.
       You can generate one by calling: mix phx.gen.secret

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -144,7 +144,9 @@ case mailer_adapter do
       relay: System.get_env("SMTP_HOST_ADDR", "mail"),
       port: System.get_env("SMTP_HOST_PORT", "25"),
       username: System.get_env("SMTP_USER_NAME"),
-      password: System.get_env("SMTP_USER_PWD"),
+      password:
+        (System.get_env("SMTP_USER_PWD_FILE") && File.read!(System.get_env("SMTP_USER_PWD_FILE"))) ||
+          System.get_env("SMTP_USER_PWD"),
       ssl: System.get_env("SMTP_HOST_SSL_ENABLED") || false,
       tls: :if_available,
       retries: System.get_env("SMTP_RETRIES") || 2,


### PR DESCRIPTION
### Description

This allows to store sensitive configs (namely the secret key base and the database password) in a file (e.g. via Docker secrets).

The database can now be configured via DATABASE_USER, DATABASE_PASSWORD/DATABASE_PASSWORD_FILE, DATABASE_HOST and DATABASE variable as an alternative to the DATABASE_URL variable (which still has priority).

The database password is encoded to prevent errors, like https://elixirforum.com/t/problems-with-url-in-a-configuration-for-ecto/4057.

Since I'm not very familiar with Elixir this might require some tweaking. However, it's working for me.

### Issue

None

### Screenshots

Not relevant

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
