### PR TITLE
Add support for @mentions in the dashboard

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -439,14 +439,29 @@ export const fetchAllConversations = async (
 };
 
 export const fetchMyConversations = async (
-  userId: number,
+  userId?: number,
   query = {},
   token = getAccessToken()
 ) => {
   return fetchConversations(
     {
       ...query,
-      assignee_id: userId,
+      assignee_id: userId || 'me',
+      status: 'open',
+    },
+    token
+  );
+};
+
+export const fetchMentionedConversations = async (
+  userId?: number,
+  query = {},
+  token = getAccessToken()
+) => {
+  return fetchConversations(
+    {
+      ...query,
+      mentioning: userId || 'me',
       status: 'open',
     },
     token

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -53,6 +53,7 @@ import {
 } from './conversations/ConversationsProvider';
 import AllConversations from './conversations/AllConversations';
 import MyConversations from './conversations/MyConversations';
+import MentionedConversations from './conversations/MentionedConversations';
 import PriorityConversations from './conversations/PriorityConversations';
 import ClosedConversations from './conversations/ClosedConversations';
 import ConversationsBySource from './conversations/ConversationsBySource';
@@ -304,6 +305,22 @@ const Dashboard = (props: RouteComponentProps) => {
                       <Box mr={2}>All conversations</Box>
                       <Badge
                         count={totalNumUnread}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
+                <Menu.Item key="mentions">
+                  <Link to="/conversations/mentions">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>Mentions</Box>
+                      <Badge
+                        count={getUnreadCount(inboxes.all.mentioned)}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -574,6 +591,10 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/functions/:id" component={LambdaDetailsPage} />
           <Route path="/functions" component={LambdasOverview} />
           <Route path="/conversations/all" component={AllConversations} />
+          <Route
+            path="/conversations/mentions"
+            component={MentionedConversations}
+          />
           <Route path="/conversations/me" component={MyConversations} />
           <Route
             path="/conversations/priority"

--- a/assets/src/components/common.tsx
+++ b/assets/src/components/common.tsx
@@ -12,6 +12,7 @@ import Input from 'antd/lib/input';
 import InputNumber from 'antd/lib/input-number';
 import Layout from 'antd/lib/layout';
 import List from 'antd/lib/list';
+import Mentions from 'antd/lib/mentions';
 import Menu from 'antd/lib/menu';
 import Modal from 'antd/lib/modal';
 import notification from 'antd/lib/notification';
@@ -201,6 +202,7 @@ export {
   InputNumber,
   List,
   MarkdownRenderer,
+  Mentions,
   Menu,
   Modal,
   notification,

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -3,8 +3,8 @@ import {Box, Flex} from 'theme-ui';
 import {
   colors,
   Button,
+  Mentions,
   Menu,
-  TextArea,
   Upload,
   UploadChangeParam,
   UploadFile,
@@ -13,6 +13,7 @@ import {
 import {Message, MessageType, User} from '../../types';
 import {InfoCircleOutlined, PaperClipOutlined} from '../icons';
 import {env} from '../../config';
+import * as API from '../../api';
 import {DashboardShortcutsRenderer} from './DashboardShortcutsModal';
 
 const {REACT_APP_FILE_UPLOADS_ENABLED} = env;
@@ -71,16 +72,25 @@ const ConversationFooter = ({
   const [message, setMessage] = React.useState<string>('');
   const [fileList, setFileList] = React.useState<Array<UploadFile>>([]);
   const [messageType, setMessageType] = React.useState<MessageType>('reply');
+  const [mentions, setMentions] = React.useState<Array<string>>([]);
+  const [mentionableUsers, setMentionableUsers] = React.useState<Array<User>>(
+    []
+  );
   const [isSendDisabled, setSendDisabled] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    API.fetchAccountUsers().then((users) => setMentionableUsers(users));
+  }, []);
 
   const isPrivateNote = messageType === 'note';
   const accountId = currentUser?.account_id;
   const shouldDisplayUploadButton = fileUploadsEnabled(accountId);
 
-  const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-    setMessage(e.target.value);
-
   const handleSetMessageType = ({key}: any) => setMessageType(key);
+
+  const handleSelectMentionOption = (option: any, prefix: string) => {
+    setMentions([...new Set([...mentions, option.value])]);
+  };
 
   const handleKeyDown = (e: any) => {
     const {key, metaKey} = e;
@@ -91,14 +101,32 @@ const ConversationFooter = ({
     }
   };
 
+  const findUserByMentionValue = (mention: string) => {
+    return mentionableUsers.find((user) => {
+      const {email, display_name, full_name} = user;
+      const value = display_name || full_name || email;
+
+      return mention === value;
+    });
+  };
+
   const handleSendMessage = (e?: any) => {
     e && e.preventDefault();
+
+    const mentionedUsers = mentions
+      .filter((mention) => message.includes(`@${mention}`))
+      .map((mention) => findUserByMentionValue(mention))
+      .filter((user: User | undefined): user is User => !!user);
 
     onSendMessage({
       body: message,
       type: messageType,
       private: isPrivateNote,
       file_ids: fileList.map((f) => f.response?.data?.id),
+      mentioned_user_ids: mentionedUsers.map((user) => user.id),
+      metadata: {
+        mentions: mentionedUsers,
+      },
     });
 
     setFileList([]);
@@ -188,7 +216,7 @@ const ConversationFooter = ({
 
             <Box mb={2}>
               {/* NB: we use the `key` prop to auto-focus the textarea when toggling `messageType` */}
-              <TextArea
+              <Mentions
                 key={messageType}
                 className="TextArea--transparent"
                 placeholder={
@@ -199,9 +227,22 @@ const ConversationFooter = ({
                 autoSize={{minRows: 2, maxRows: 4}}
                 autoFocus
                 value={message}
-                onKeyDown={handleKeyDown}
-                onChange={handleMessageChange}
-              />
+                split="**"
+                onPressEnter={handleKeyDown}
+                onChange={setMessage}
+                onSelect={handleSelectMentionOption}
+              >
+                {mentionableUsers.map((user) => {
+                  const {email, display_name, full_name} = user;
+                  const value = display_name || full_name || email;
+
+                  return (
+                    <Mentions.Option key={user.id} value={value}>
+                      {value}
+                    </Mentions.Option>
+                  );
+                })}
+              </Mentions>
             </Box>
             {shouldDisplayUploadButton ? (
               <Flex

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -113,13 +113,16 @@ const ConversationFooter = ({
   const handleSendMessage = (e?: any) => {
     e && e.preventDefault();
 
+    const formattedMessageBody = mentions.reduce((result, mention) => {
+      return result.replaceAll(`@${mention}`, `**@${mention}**`);
+    }, message);
     const mentionedUsers = mentions
       .filter((mention) => message.includes(`@${mention}`))
       .map((mention) => findUserByMentionValue(mention))
       .filter((user: User | undefined): user is User => !!user);
 
     onSendMessage({
-      body: message,
+      body: formattedMessageBody,
       type: messageType,
       private: isPrivateNote,
       file_ids: fileList.map((f) => f.response?.data?.id),
@@ -227,7 +230,6 @@ const ConversationFooter = ({
                 autoSize={{minRows: 2, maxRows: 4}}
                 autoFocus
                 value={message}
-                split="**"
                 onPressEnter={handleKeyDown}
                 onChange={setMessage}
                 onSelect={handleSelectMentionOption}

--- a/assets/src/components/conversations/ConversationItem.tsx
+++ b/assets/src/components/conversations/ConversationItem.tsx
@@ -6,6 +6,8 @@ import {colors, Badge, Text} from '../common';
 import {SmileTwoTone, StarFilled} from '../icons';
 import {formatRelativeTime} from '../../utils';
 import {Conversation, Message} from '../../types';
+import {useConversations} from './ConversationsProvider';
+import {isUnreadConversation} from './support';
 
 dayjs.extend(utc);
 
@@ -41,11 +43,13 @@ const ConversationItem = ({
   isCustomerOnline?: boolean;
   onSelectConversation: (id: string) => void;
 }) => {
+  const {currentUser} = useConversations();
   const formatted = formatConversation(conversation, messages);
-  const {id, priority, status, customer, date, preview, read} = formatted;
+  const {id, priority, status, customer, date, preview} = formatted;
   const {name, email} = customer;
   const isPriority = priority === 'priority';
   const isClosed = status === 'closed';
+  const isRead = !isUnreadConversation(conversation, currentUser);
 
   return (
     <Box
@@ -82,7 +86,7 @@ const ConversationItem = ({
           </Text>
         </Flex>
 
-        {read ? (
+        {isRead ? (
           isCustomerOnline ? (
             <Badge status="success" text="Online" />
           ) : (
@@ -99,7 +103,7 @@ const ConversationItem = ({
           textOverflow: 'ellipsis',
         }}
       >
-        {read ? (
+        {isRead ? (
           <Text type="secondary">{preview}</Text>
         ) : (
           <Text strong>{preview}</Text>

--- a/assets/src/components/conversations/MentionedConversations.tsx
+++ b/assets/src/components/conversations/MentionedConversations.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import ConversationsDashboard from './ConversationsDashboard';
+import {useConversations} from './ConversationsProvider';
+import * as API from '../../api';
+
+const MentionedConversations = () => {
+  const {
+    loading,
+    currentUser,
+    account,
+    messagesByConversation = {},
+    inboxes,
+    onSetConversations,
+    onSelectConversation,
+    onUpdateConversation,
+    onDeleteConversation,
+    onSendMessage,
+  } = useConversations();
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const {id: userId} = currentUser;
+  const fetcher = (query = {}) =>
+    API.fetchMentionedConversations(userId, query);
+
+  return (
+    <ConversationsDashboard
+      loading={loading}
+      title="Assigned to me"
+      account={account}
+      conversationIds={inboxes.all.mentioned}
+      messagesByConversation={messagesByConversation}
+      fetcher={fetcher}
+      onRetrieveConversations={onSetConversations}
+      onSelectConversation={onSelectConversation}
+      onUpdateConversation={onUpdateConversation}
+      onDeleteConversation={onDeleteConversation}
+      onSendMessage={onSendMessage}
+    />
+  );
+};
+
+export default MentionedConversations;

--- a/assets/src/components/conversations/MentionedConversations.tsx
+++ b/assets/src/components/conversations/MentionedConversations.tsx
@@ -28,7 +28,7 @@ const MentionedConversations = () => {
   return (
     <ConversationsDashboard
       loading={loading}
-      title="Assigned to me"
+      title="Mentions"
       account={account}
       conversationIds={inboxes.all.mentioned}
       messagesByConversation={messagesByConversation}

--- a/assets/src/components/conversations/support.ts
+++ b/assets/src/components/conversations/support.ts
@@ -1,5 +1,5 @@
 import {colors} from '../common';
-import {Account, Message} from '../../types';
+import {Account, Conversation, Message, User} from '../../types';
 
 const {primary, gold, red, green, purple, magenta} = colors;
 
@@ -20,6 +20,21 @@ export const isBotMessage = (message: Message) => {
 
 export const isAgentMessage = (message: Message) => {
   return !isBotMessage(message) && !!message.user_id;
+};
+
+export const isUnreadConversation = (
+  conversation: Conversation,
+  currentUser: User | null
+) => {
+  if (!conversation.read) {
+    return true;
+  }
+
+  const {mentions = []} = conversation;
+
+  return mentions.some((mention) => {
+    return mention.user_id === currentUser?.id && !mention.seen_at;
+  });
 };
 
 export const getSenderIdentifier = (

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -82,8 +82,11 @@ export type Message = {
   conversation_id: string;
   user_id?: number;
   user?: User;
-  file_ids?: string[];
-  attachments?: Attachment[];
+  file_ids?: Array<string>;
+  attachments?: Array<Attachment>;
+  mentioned_user_ids?: Array<number>;
+  mentions?: Array<any>;
+  metadata?: any;
 };
 
 export type FileUpload = {
@@ -115,6 +118,7 @@ export type Conversation = {
   status?: string;
   assignee_id?: number;
   tags?: Array<Tag>;
+  mentions?: Array<any>;
 };
 
 export type CustomerNote = {

--- a/lib/chat_api/conversations/conversation.ex
+++ b/lib/chat_api/conversations/conversation.ex
@@ -6,6 +6,7 @@ defmodule ChatApi.Conversations.Conversation do
     Accounts.Account,
     Customers.Customer,
     Issues.ConversationIssue,
+    Mentions.Mention,
     Messages.Message,
     Tags.ConversationTag,
     Users.User
@@ -51,11 +52,13 @@ defmodule ChatApi.Conversations.Conversation do
     field(:last_activity_at, :utc_datetime)
     field(:metadata, :map)
 
-    has_many(:messages, Message)
     belongs_to(:assignee, User, foreign_key: :assignee_id, references: :id, type: :integer)
     belongs_to(:account, Account)
     belongs_to(:customer, Customer)
+    has_many(:messages, Message)
 
+    has_many(:mentions, Mention)
+    has_many(:mentioned_users, through: [:mentions, :user])
     has_many(:conversation_tags, ConversationTag)
     has_many(:tags, through: [:conversation_tags, :tag])
     has_many(:conversation_issues, ConversationIssue)

--- a/lib/chat_api/emails.ex
+++ b/lib/chat_api/emails.ex
@@ -79,6 +79,24 @@ defmodule ChatApi.Emails do
     |> deliver()
   end
 
+  @spec send_mention_notification_email(keyword()) :: deliver_result()
+  def send_mention_notification_email(
+        sender: sender,
+        recipient: recipient,
+        account: account,
+        messages: messages
+      ) do
+    Email.mention_notification(
+      to: recipient.email,
+      from: format_sender_name(sender, account),
+      reply_to: sender.email,
+      company: account.company_name,
+      messages: messages,
+      user: recipient
+    )
+    |> deliver()
+  end
+
   @spec send_user_invitation_email(User.t(), Account.t(), binary(), binary()) :: deliver_result()
   def send_user_invitation_email(user, account, to_address, invitation_token) do
     Email.user_invitation(%{

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -9,7 +9,7 @@ defmodule ChatApi.Emails.Email do
   @type t :: Swoosh.Email.t()
 
   @from_address System.get_env("FROM_ADDRESS") || ""
-  @backend_url System.get_env("BACKEND_URL") || ""
+  @backend_url System.get_env("BACKEND_URL", "app.papercups.io")
 
   defstruct to_address: nil, message: nil
 
@@ -210,7 +210,7 @@ defmodule ChatApi.Emails.Email do
   # TODO: figure out a better way to create templates for these
   defp mention_notification_text(messages, from: from, to: _user, company: company) do
     conversation_id = messages |> List.first() |> Map.get(:conversation_id)
-    dashboard_link = "https://#{@backend_url}/conversations/#{conversation_id}"
+    dashboard_link = "#{get_app_domain()}/conversations/mentions?cid=#{conversation_id}"
 
     """
     Hi there!
@@ -232,7 +232,7 @@ defmodule ChatApi.Emails.Email do
 
   defp mention_notification_html(messages, from: from, to: _user, company: company) do
     conversation_id = messages |> List.first() |> Map.get(:conversation_id)
-    dashboard_link = "https://#{@backend_url}/conversations/#{conversation_id}"
+    dashboard_link = "#{get_app_domain()}/conversations/mentions?cid=#{conversation_id}"
 
     """
     <p>Hi there!</p>

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -190,6 +190,55 @@ defmodule ChatApi.Emails.Email do
     end
   end
 
+  def mention_notification(
+        to: to,
+        from: from,
+        reply_to: reply_to,
+        company: company,
+        messages: messages,
+        user: user
+      ) do
+    new()
+    |> to(to)
+    |> from({from, @from_address})
+    |> reply_to(reply_to)
+    |> subject("You were mentioned in a message on Papercups!")
+    |> html_body(mention_notification_html(messages, from: from, to: user, company: company))
+    |> text_body(mention_notification_text(messages, from: from, to: user, company: company))
+  end
+
+  # TODO: figure out a better way to create templates for these
+  defp mention_notification_text(messages, from: from, to: user, company: company) do
+    """
+    Hi there!
+
+    You were mentioned in a message on Papercups:
+
+    #{
+      Enum.map(messages, fn msg ->
+        format_sender(msg, company) <> ": " <> msg.body <> "\n"
+      end)
+    }
+
+    Best,
+    #{from}
+    """
+  end
+
+  defp mention_notification_html(messages, from: from, to: user, company: company) do
+    """
+    <p>Hi there!</p>
+    <p> You were mentioned in a message on Papercups:</p>
+    <hr />
+    #{Enum.map(messages, fn msg -> format_message_html(msg, company) end)}
+    <hr />
+    <p>
+    Best,<br />
+    #{from}
+    </p>
+    """
+  end
+
   # TODO: use env variables instead, come up with a better message
   def welcome(to_address) do
     new()

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -208,7 +208,10 @@ defmodule ChatApi.Emails.Email do
   end
 
   # TODO: figure out a better way to create templates for these
-  defp mention_notification_text(messages, from: from, to: user, company: company) do
+  defp mention_notification_text(messages, from: from, to: _user, company: company) do
+    conversation_id = messages |> List.first() |> Map.get(:conversation_id)
+    dashboard_link = "https://#{@backend_url}/conversations/#{conversation_id}"
+
     """
     Hi there!
 
@@ -220,18 +223,26 @@ defmodule ChatApi.Emails.Email do
       end)
     }
 
+    View in the dashboard at #{dashboard_link}
+
     Best,
     #{from}
     """
   end
 
-  defp mention_notification_html(messages, from: from, to: user, company: company) do
+  defp mention_notification_html(messages, from: from, to: _user, company: company) do
+    conversation_id = messages |> List.first() |> Map.get(:conversation_id)
+    dashboard_link = "https://#{@backend_url}/conversations/#{conversation_id}"
+
     """
     <p>Hi there!</p>
-    <p> You were mentioned in a message on Papercups:</p>
+    <p>You were mentioned in a message on Papercups:</p>
     <hr />
     #{Enum.map(messages, fn msg -> format_message_html(msg, company) end)}
     <hr />
+    <p>
+    (View in the <a href="#{dashboard_link}">dashboard</a>)
+    </p>
     <p>
     Best,<br />
     #{from}

--- a/lib/chat_api/mentions.ex
+++ b/lib/chat_api/mentions.ex
@@ -13,6 +13,7 @@ defmodule ChatApi.Mentions do
     Mention
     |> where(account_id: ^account_id)
     |> where(^filter_where(filters))
+    |> preload(:user)
     |> Repo.all()
   end
 
@@ -52,16 +53,19 @@ defmodule ChatApi.Mentions do
     end)
     |> Enum.reduce(dynamic(true), fn
       {:account_id, value}, dynamic ->
-        dynamic([r], ^dynamic and r.account_id == ^value)
+        dynamic([m], ^dynamic and m.account_id == ^value)
 
       {:user_id, value}, dynamic ->
-        dynamic([r], ^dynamic and r.user_id == ^value)
+        dynamic([m], ^dynamic and m.user_id == ^value)
 
       {:conversation_id, value}, dynamic ->
-        dynamic([r], ^dynamic and r.conversation_id == ^value)
+        dynamic([m], ^dynamic and m.conversation_id == ^value)
 
       {:message_id, value}, dynamic ->
-        dynamic([r], ^dynamic and r.message_id == ^value)
+        dynamic([m], ^dynamic and m.message_id == ^value)
+
+      {:seen_at, nil}, dynamic ->
+        dynamic([m], ^dynamic and is_nil(m.seen_at))
 
       {_, _}, dynamic ->
         # Not a where parameter

--- a/lib/chat_api/mentions.ex
+++ b/lib/chat_api/mentions.ex
@@ -1,0 +1,71 @@
+defmodule ChatApi.Mentions do
+  @moduledoc """
+  The Mentions context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.Mentions.Mention
+
+  @spec list_mentions(binary(), map()) :: [Mention.t()]
+  def list_mentions(account_id, filters \\ %{}) do
+    Mention
+    |> where(account_id: ^account_id)
+    |> where(^filter_where(filters))
+    |> Repo.all()
+  end
+
+  @spec get_mention!(binary()) :: Mention.t()
+  def get_mention!(id), do: Repo.get!(Mention, id)
+
+  @spec create_mention(map()) :: {:ok, Mention.t()} | {:error, Ecto.Changeset.t()}
+  def create_mention(attrs \\ %{}) do
+    %Mention{}
+    |> Mention.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_mention(Mention.t(), map()) :: {:ok, Mention.t()} | {:error, Ecto.Changeset.t()}
+  def update_mention(%Mention{} = mention, attrs) do
+    mention
+    |> Mention.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_mention(Mention.t()) :: {:ok, Mention.t()} | {:error, Ecto.Changeset.t()}
+  def delete_mention(%Mention{} = mention) do
+    Repo.delete(mention)
+  end
+
+  @spec change_mention(Mention.t(), map()) :: Ecto.Changeset.t()
+  def change_mention(%Mention{} = mention, attrs \\ %{}) do
+    Mention.changeset(mention, attrs)
+  end
+
+  @spec filter_where(map()) :: %Ecto.Query.DynamicExpr{}
+  def filter_where(params) do
+    params
+    |> Map.new(fn
+      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
+      {k, v} when is_atom(k) -> {k, v}
+    end)
+    |> Enum.reduce(dynamic(true), fn
+      {:account_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.account_id == ^value)
+
+      {:user_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.user_id == ^value)
+
+      {:conversation_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.conversation_id == ^value)
+
+      {:message_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.message_id == ^value)
+
+      {_, _}, dynamic ->
+        # Not a where parameter
+        dynamic
+    end)
+  end
+end

--- a/lib/chat_api/mentions/mention.ex
+++ b/lib/chat_api/mentions/mention.ex
@@ -1,0 +1,44 @@
+defmodule ChatApi.Mentions.Mention do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Conversations.Conversation
+  alias ChatApi.Messages.Message
+  alias ChatApi.Users.User
+
+  @type t :: %__MODULE__{
+          seen_at: DateTime.t() | nil,
+          # Relations
+          account_id: binary(),
+          account: any(),
+          conversation_id: binary(),
+          conversation: any(),
+          message_id: binary(),
+          message: any(),
+          user_id: any(),
+          user: any(),
+          # Timestamps
+          inserted_at: any(),
+          updated_at: any()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "mentions" do
+    field(:seen_at, :utc_datetime)
+
+    belongs_to(:account, Account)
+    belongs_to(:conversation, Conversation)
+    belongs_to(:message, Message)
+    belongs_to(:user, User, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(mention, attrs) do
+    mention
+    |> cast(attrs, [:seen_at])
+    |> validate_required([:seen_at])
+  end
+end

--- a/lib/chat_api/messages/helpers.ex
+++ b/lib/chat_api/messages/helpers.ex
@@ -156,7 +156,6 @@ defmodule ChatApi.Messages.Helpers do
     updates
     |> build_first_reply_updates(message)
     |> build_message_type_updates(message)
-    |> build_metadata_updates(message)
   end
 
   @spec is_first_agent_reply?(Message.t()) :: boolean()
@@ -186,24 +185,6 @@ defmodule ChatApi.Messages.Helpers do
       # Bot messages should be considered unread by default
       :bot -> Map.merge(updates, %{read: false})
       _ -> updates
-    end
-  end
-
-  @spec build_metadata_updates(map(), Message.t()) :: map()
-  defp build_metadata_updates(updates, %Message{} = message) do
-    case message.metadata do
-      %{"mentions" => new_mentions} when is_list(new_mentions) ->
-        existing_metadata = Map.get(updates, :metadata, %{})
-        existing_mentions = Map.get(existing_metadata, "mentions", [])
-        updated_mentions = Enum.uniq_by(existing_mentions ++ new_mentions, & &1["id"])
-        # TODO: if new mentions are added, send email alert to the user(s) who are mentioned?
-
-        Map.merge(updates, %{
-          metadata: Map.merge(existing_metadata, %{"mentions" => updated_mentions})
-        })
-
-      _ ->
-        updates
     end
   end
 

--- a/lib/chat_api/messages/message.ex
+++ b/lib/chat_api/messages/message.ex
@@ -6,6 +6,7 @@ defmodule ChatApi.Messages.Message do
   alias ChatApi.Accounts.Account
   alias ChatApi.Customers.Customer
   alias ChatApi.Users.User
+  alias ChatApi.Mentions.Mention
   alias ChatApi.Messages.MessageFile
 
   @type t :: %__MODULE__{
@@ -48,6 +49,8 @@ defmodule ChatApi.Messages.Message do
     belongs_to(:customer, Customer)
     belongs_to(:user, User, type: :integer)
 
+    has_many(:mentions, Mention)
+    has_many(:mentioned_users, through: [:mentions, :user])
     has_many(:message_files, MessageFile)
     has_many(:attachments, through: [:message_files, :file])
 

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -153,6 +153,39 @@ defmodule ChatApi.Messages.Notification do
     message
   end
 
+  def notify(
+        %Message{
+          id: message_id,
+          account_id: account_id,
+          conversation_id: conversation_id,
+          user_id: _user_id
+        } = message,
+        :mentions,
+        _opts
+      ) do
+    Logger.info("Sending message notification: :mentions (message #{inspect(message.id)})")
+
+    account_id
+    |> ChatApi.Mentions.list_mentions(%{
+      message_id: message_id,
+      conversation_id: conversation_id,
+      seen_at: nil
+    })
+    |> Enum.filter(& &1.user.has_valid_email)
+    # TODO: should we avoid sending notifications if users @mention themselves?
+    # |> Enum.reject(& &1.user_id == user_id)
+    |> Enum.each(fn mention ->
+      %{
+        message: Helpers.format(message),
+        user: ChatApiWeb.UserView.render("user.json", user: mention.user)
+      }
+      |> ChatApi.Workers.SendMentionNotification.new()
+      |> Oban.insert()
+    end)
+
+    message
+  end
+
   def notify(%Message{private: false} = message, :gmail, _opts) do
     Logger.info("Sending message notification: :gmail (message #{inspect(message.id)})")
 

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -158,7 +158,7 @@ defmodule ChatApi.Messages.Notification do
           id: message_id,
           account_id: account_id,
           conversation_id: conversation_id,
-          user_id: _user_id
+          user_id: user_id
         } = message,
         :mentions,
         _opts
@@ -171,9 +171,9 @@ defmodule ChatApi.Messages.Notification do
       conversation_id: conversation_id,
       seen_at: nil
     })
-    |> Enum.filter(& &1.user.has_valid_email)
-    # TODO: should we avoid sending notifications if users @mention themselves?
-    # |> Enum.reject(& &1.user_id == user_id)
+    |> Stream.filter(& &1.user.has_valid_email)
+    # Avoid sending notifications if users @mention themselves?
+    |> Stream.reject(&(&1.user_id == user_id))
     |> Enum.each(fn mention ->
       %{
         message: Helpers.format(message),

--- a/lib/chat_api/users.ex
+++ b/lib/chat_api/users.ex
@@ -20,7 +20,7 @@ defmodule ChatApi.Users do
     User |> where(account_id: ^account_id, email: ^email) |> Repo.one()
   end
 
-  @spec list_users_by_account(binary()) :: [User.t()]
+  @spec list_users_by_account(binary(), map()) :: [User.t()]
   def list_users_by_account(account_id, filters \\ %{}) do
     User
     |> where(account_id: ^account_id)

--- a/lib/chat_api/users/user.ex
+++ b/lib/chat_api/users/user.ex
@@ -5,6 +5,7 @@ defmodule ChatApi.Users.User do
 
   alias ChatApi.Conversations.Conversation
   alias ChatApi.Messages.Message
+  alias ChatApi.Mentions.Mention
   alias ChatApi.Accounts.Account
   alias ChatApi.Users.{UserProfile, UserSettings}
 
@@ -41,6 +42,10 @@ defmodule ChatApi.Users.User do
     belongs_to(:account, Account, type: :binary_id)
     has_one(:profile, UserProfile)
     has_one(:settings, UserSettings)
+
+    has_many(:mentions, Mention)
+    has_many(:mentioned_conversations, through: [:mentions, :conversation])
+    has_many(:mentioned_messages, through: [:mentions, :message])
 
     pow_user_fields()
 

--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -124,6 +124,7 @@ defmodule ChatApiWeb.NotificationChannel do
     message
     |> Messages.Notification.notify(:slack)
     |> Messages.Notification.notify(:webhooks)
+    |> Messages.Notification.notify(:mentions)
   end
 
   defp broadcast_new_message(message, socket) do
@@ -136,6 +137,7 @@ defmodule ChatApiWeb.NotificationChannel do
     |> Messages.Notification.notify(:slack_company_channel)
     |> Messages.Notification.notify(:mattermost)
     |> Messages.Notification.notify(:webhooks)
+    |> Messages.Notification.notify(:mentions)
     |> Messages.Notification.notify(:conversation_reply_email)
     |> Messages.Notification.notify(:gmail)
     |> Messages.Notification.notify(:sms)

--- a/lib/chat_api_web/controllers/conversation_controller.ex
+++ b/lib/chat_api_web/controllers/conversation_controller.ex
@@ -74,11 +74,12 @@ defmodule ChatApiWeb.ConversationController do
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, params) do
     with %{account_id: account_id} <- conn.assigns.current_user,
+         filters <- format_filter_options(params, conn.assigns.current_user),
          pagination_options <- format_pagination_options(params),
          %{entries: conversations, metadata: pagination} <-
            Conversations.list_conversations_by_account_paginated(
              account_id,
-             params,
+             filters,
              pagination_options
            ) do
       render(conn, "index.json", conversations: conversations, pagination: pagination)
@@ -319,6 +320,23 @@ defmodule ChatApiWeb.ConversationController do
   end
 
   defp maybe_create_message(_conn, _conversation, _), do: :ok
+
+  defp format_filter_options(params, current_user) do
+    Enum.reduce(
+      params,
+      %{},
+      fn
+        {"assignee_id", "me"}, acc ->
+          Map.merge(acc, %{"assignee_id" => current_user.id})
+
+        {"mentioning", "me"}, acc ->
+          Map.merge(acc, %{"mentioning" => current_user.id})
+
+        {k, v}, acc ->
+          Map.merge(acc, %{k => v})
+      end
+    )
+  end
 
   defp format_pagination_options(params) do
     Enum.reduce(

--- a/lib/chat_api_web/views/conversation_view.ex
+++ b/lib/chat_api_web/views/conversation_view.ex
@@ -1,6 +1,13 @@
 defmodule ChatApiWeb.ConversationView do
   use ChatApiWeb, :view
-  alias ChatApiWeb.{ConversationView, MessageView, CustomerView, TagView}
+
+  alias ChatApiWeb.{
+    ConversationView,
+    MentionView,
+    MessageView,
+    CustomerView,
+    TagView
+  }
 
   def render("index.json", %{conversations: conversations, pagination: pagination}) do
     %{
@@ -65,7 +72,8 @@ defmodule ChatApiWeb.ConversationView do
       metadata: conversation.metadata,
       customer: render_one(conversation.customer, CustomerView, "customer.json"),
       messages: render_many(conversation.messages, MessageView, "expanded.json"),
-      tags: render_tags(conversation.tags)
+      tags: render_tags(conversation.tags),
+      mentions: render_mentions(conversation.mentions)
     }
   end
 
@@ -74,4 +82,10 @@ defmodule ChatApiWeb.ConversationView do
   end
 
   defp render_tags(_tags), do: []
+
+  defp render_mentions([_ | _] = mentions) do
+    render_many(mentions, MentionView, "mention.json")
+  end
+
+  defp render_mentions(_mentions), do: []
 end

--- a/lib/chat_api_web/views/mention_view.ex
+++ b/lib/chat_api_web/views/mention_view.ex
@@ -1,0 +1,26 @@
+defmodule ChatApiWeb.MentionView do
+  use ChatApiWeb, :view
+  alias ChatApiWeb.{MentionView, UserView}
+
+  def render("index.json", %{mentions: mentions}) do
+    %{data: render_many(mentions, MentionView, "user.json")}
+  end
+
+  def render("show.json", %{mention: mention}) do
+    %{data: render_one(mention, MentionView, "mention.json")}
+  end
+
+  def render("mention.json", %{mention: mention}) do
+    %{
+      id: mention.id,
+      object: "mention",
+      account_id: mention.account_id,
+      created_at: mention.inserted_at,
+      seen_at: mention.seen_at,
+      conversation_id: mention.conversation_id,
+      message_id: mention.message_id,
+      user_id: mention.user_id,
+      user: render_one(mention.user, UserView, "user.json")
+    }
+  end
+end

--- a/lib/chat_api_web/views/user_view.ex
+++ b/lib/chat_api_web/views/user_view.ex
@@ -21,6 +21,7 @@ defmodule ChatApiWeb.UserView do
           email: user.email,
           created_at: user.inserted_at,
           disabled_at: user.disabled_at,
+          archived_at: user.archived_at,
           full_name: profile.full_name,
           display_name: profile.display_name,
           profile_photo_url: profile.profile_photo_url,
@@ -34,6 +35,7 @@ defmodule ChatApiWeb.UserView do
           email: user.email,
           created_at: user.inserted_at,
           disabled_at: user.disabled_at,
+          archived_at: user.archived_at,
           role: user.role
         }
     end

--- a/lib/workers/send_conversation_reply_email.ex
+++ b/lib/workers/send_conversation_reply_email.ex
@@ -120,7 +120,7 @@ defmodule ChatApi.Workers.SendConversationReplyEmail do
       account_reply_emails_enabled?(account_id)
   end
 
-  def enabled(_), do: false
+  def enabled?(_), do: false
 
   @spec account_reply_emails_enabled?(binary()) :: boolean()
   def account_reply_emails_enabled?(account_id) do

--- a/lib/workers/send_mention_notification.ex
+++ b/lib/workers/send_mention_notification.ex
@@ -1,0 +1,112 @@
+defmodule ChatApi.Workers.SendMentionNotification do
+  @moduledoc false
+
+  use Oban.Worker, queue: :mailers
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias ChatApi.{Accounts, Users}
+  alias ChatApi.Messages
+  alias ChatApi.Messages.Message
+  alias ChatApi.Users.User
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{args: %{"message" => message, "user" => user}}) do
+    if enabled?() && should_send_email?(user) do
+      Logger.info("Checking if we need to send reply email: #{inspect(message)}")
+
+      send_email(message, user)
+    else
+      Logger.info(
+        "Skipping @mention notification email: #{inspect(message)} (user: #{inspect(user)})"
+      )
+    end
+
+    :ok
+  end
+
+  @spec send_email(map()) :: :ok | :skipped | :error
+  def send_email(%{"user_id" => nil, "user" => nil}, _), do: :skipped
+
+  def send_email(
+        %{
+          "seen_at" => nil,
+          "user_id" => sender_id,
+          "account_id" => account_id,
+          "customer_id" => nil,
+          "conversation_id" => conversation_id
+        } = _message,
+        %{"id" => recipient_id, "email" => _email} = _user
+      ) do
+    Logger.info("Sending @mention notification email!")
+
+    email =
+      ChatApi.Emails.send_mention_notification_email(
+        sender: Users.get_user_info(sender_id),
+        recipient: Users.get_user_info(recipient_id),
+        account: Accounts.get_account!(account_id),
+        messages: get_recent_messages(conversation_id, account_id)
+      )
+
+    case email do
+      {:ok, result} ->
+        Logger.info("Sent @mention notification email! #{inspect(result)}")
+
+      {:error, reason} ->
+        Logger.error("Failed to send @mention notification email! #{inspect(reason)}")
+
+      {:warning, reason} ->
+        Logger.warn(reason)
+    end
+  end
+
+  def send_email(_params), do: :error
+
+  @spec get_recent_messages(binary(), binary()) :: [Message.t()]
+  def get_recent_messages(conversation_id, account_id) do
+    conversation_id
+    |> Messages.list_by_conversation(
+      %{
+        "account_id" => account_id,
+        "private" => false
+      },
+      limit: 5
+    )
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Check that the user has a valid email before sending
+  """
+  @spec should_send_email?(User.t()) :: boolean()
+  def should_send_email?(%{
+        "email" => email,
+        "disabled_at" => nil,
+        "archived_at" => nil
+      }),
+      do: ChatApi.Emails.Helpers.valid_format?(email)
+
+  def should_send_email?(_), do: false
+
+  @spec enabled?() :: boolean()
+  def enabled?() do
+    has_valid_email_domain?() && mention_notification_emails_enabled?()
+  end
+
+  @spec has_valid_email_domain? :: boolean()
+  def has_valid_email_domain?() do
+    System.get_env("DOMAIN") == "mail.heypapercups.io"
+  end
+
+  @spec mention_notification_emails_enabled? :: boolean()
+  def mention_notification_emails_enabled?() do
+    # Should be enabled by default, unless the MENTION_NOTIFICATION_EMAILS_DISABLED is set
+    case System.get_env("MENTION_NOTIFICATION_EMAILS_DISABLED") do
+      x when x == "1" or x == "true" -> false
+      _ -> true
+    end
+  end
+end

--- a/priv/repo/migrations/20210720202019_create_mentions.exs
+++ b/priv/repo/migrations/20210720202019_create_mentions.exs
@@ -7,7 +7,12 @@ defmodule ChatApi.Repo.Migrations.CreateMentions do
       add(:seen_at, :utc_datetime)
 
       add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
-      add(:conversation_id, references(:conversations, null: false, type: :uuid, on_delete: :delete_all))
+
+      add(
+        :conversation_id,
+        references(:conversations, null: false, type: :uuid, on_delete: :delete_all)
+      )
+
       add(:message_id, references(:messages, null: false, type: :uuid, on_delete: :delete_all))
       add(:user_id, references(:users, type: :integer))
 

--- a/priv/repo/migrations/20210720202019_create_mentions.exs
+++ b/priv/repo/migrations/20210720202019_create_mentions.exs
@@ -1,0 +1,22 @@
+defmodule ChatApi.Repo.Migrations.CreateMentions do
+  use Ecto.Migration
+
+  def change do
+    create table(:mentions, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:seen_at, :utc_datetime)
+
+      add(:account_id, references(:accounts, null: false, type: :uuid, on_delete: :delete_all))
+      add(:conversation_id, references(:conversations, null: false, type: :uuid, on_delete: :delete_all))
+      add(:message_id, references(:messages, null: false, type: :uuid, on_delete: :delete_all))
+      add(:user_id, references(:users, type: :integer))
+
+      timestamps()
+    end
+
+    create index(:mentions, [:account_id])
+    create index(:mentions, [:user_id])
+    create index(:mentions, [:conversation_id])
+    create index(:mentions, [:message_id])
+  end
+end

--- a/test/chat_api/emails_test.exs
+++ b/test/chat_api/emails_test.exs
@@ -28,7 +28,7 @@ defmodule ChatApi.EmailsTest do
       assert email.text_body == "New message from an anonymous user: some message body"
 
       assert email.html_body ==
-               "New message from an anonymous user:<br /><b>some message body</b><br /><br /><a href=\"https:///conversations/#{
+               "New message from an anonymous user:<br /><b>some message body</b><br /><br /><a href=\"https://app.papercups.io/conversations/#{
                  conversation_id
                }\">View in dashboard</a>"
     end
@@ -50,7 +50,7 @@ defmodule ChatApi.EmailsTest do
       assert email.text_body == "New message from Test User: some message body"
 
       assert email.html_body ==
-               "New message from Test User:<br /><b>some message body</b><br /><br /><a href=\"https:///conversations/#{
+               "New message from Test User:<br /><b>some message body</b><br /><br /><a href=\"https://app.papercups.io/conversations/#{
                  conversation_id
                }\">View in dashboard</a>"
     end
@@ -72,7 +72,7 @@ defmodule ChatApi.EmailsTest do
       assert email.text_body == "New message from customer@customer.com: some message body"
 
       assert email.html_body ==
-               "New message from customer@customer.com:<br /><b>some message body</b><br /><br /><a href=\"https:///conversations/#{
+               "New message from customer@customer.com:<br /><b>some message body</b><br /><br /><a href=\"https://app.papercups.io/conversations/#{
                  conversation_id
                }\">View in dashboard</a>"
     end
@@ -97,7 +97,7 @@ defmodule ChatApi.EmailsTest do
                "New message from Test User (customer@customer.com): some message body"
 
       assert email.html_body ==
-               "New message from Test User (customer@customer.com):<br /><b>some message body</b><br /><br /><a href=\"https:///conversations/#{
+               "New message from Test User (customer@customer.com):<br /><b>some message body</b><br /><br /><a href=\"https://app.papercups.io/conversations/#{
                  conversation_id
                }\">View in dashboard</a>"
     end

--- a/test/chat_api/mentions_test.exs
+++ b/test/chat_api/mentions_test.exs
@@ -1,0 +1,78 @@
+defmodule ChatApi.MentionsTest do
+  use ChatApi.DataCase
+  import ChatApi.Factory
+  alias ChatApi.Mentions
+
+  describe "mentions" do
+    alias ChatApi.Mentions.Mention
+
+    @valid_attrs %{seen_at: ~U[2021-01-06 10:00:00Z]}
+    @update_attrs %{seen_at: ~U[2021-02-06 10:00:00Z]}
+    @invalid_attrs %{account_id: nil, conversation_id: nil, message_id: nil}
+
+    setup do
+      account = insert(:account)
+      mention = insert(:mention, account: account)
+
+      {:ok, account: account, mention: mention}
+    end
+
+    test "list_mentions/1 returns all mentions for the given account", %{
+      account: account,
+      mention: mention
+    } do
+      mention_ids = Mentions.list_mentions(account.id) |> Enum.map(& &1.id)
+
+      assert mention_ids == [mention.id]
+    end
+
+    test "get_mention!/1 returns the mention with given id", %{mention: mention} do
+      result = Mentions.get_mention!(mention.id)
+
+      assert mention.id == result.id
+      assert mention.seen_at == result.seen_at
+      assert mention.conversation_id == result.conversation_id
+      assert mention.message_id == result.message_id
+      assert mention.user_id == result.user_id
+    end
+
+    test "create_mention/1 with valid data creates a mention" do
+      assert {:ok, %Mention{} = mention} =
+               Mentions.create_mention(params_with_assocs(:mention, Map.to_list(@valid_attrs)))
+
+      assert mention.seen_at == @valid_attrs.seen_at
+    end
+
+    test "create_mention/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Mentions.create_mention(@invalid_attrs)
+    end
+
+    test "update_mention/2 with valid data updates the mention", %{mention: mention} do
+      assert {:ok, %Mention{} = mention} = Mentions.update_mention(mention, @update_attrs)
+
+      assert mention.seen_at == @update_attrs.seen_at
+    end
+
+    test "update_mention/2 with invalid data returns error changeset", %{mention: mention} do
+      assert {:error, %Ecto.Changeset{}} = Mentions.update_mention(mention, @invalid_attrs)
+
+      current = Mentions.get_mention!(mention.id)
+
+      assert mention.id == current.id
+      assert mention.seen_at == current.seen_at
+      assert mention.account_id == current.account_id
+      assert mention.conversation_id == current.conversation_id
+      assert mention.message_id == current.message_id
+      assert mention.user_id == current.user_id
+    end
+
+    test "delete_mention/1 deletes the mention", %{mention: mention} do
+      assert {:ok, %Mention{}} = Mentions.delete_mention(mention)
+      assert_raise Ecto.NoResultsError, fn -> Mentions.get_mention!(mention.id) end
+    end
+
+    test "change_mention/1 returns a mention changeset", %{mention: mention} do
+      assert %Ecto.Changeset{} = Mentions.change_mention(mention)
+    end
+  end
+end

--- a/test/chat_api/messages_test.exs
+++ b/test/chat_api/messages_test.exs
@@ -174,7 +174,7 @@ defmodule ChatApi.MessagesTest do
       assert customer.email == c.email
     end
 
-    test "build_conversation_updates/1 builds the conversation updates for a created message" do
+    test "build_conversation_updates/2 builds the conversation updates for a created message" do
       account = insert(:account)
       agent = insert(:user, account: account)
       customer = insert(:customer, account: account)
@@ -185,30 +185,31 @@ defmodule ChatApi.MessagesTest do
 
       # No conversation updates are necessary on the first customer message
       assert %{read: false} =
-               Messages.Helpers.build_conversation_updates(initial_customer_message)
+               Messages.Helpers.build_conversation_updates(%{}, initial_customer_message)
 
       first_agent_reply = insert(:message, conversation: conversation, user: agent, customer: nil)
       agent_id = agent.id
 
       # After the first reply, auto-assign the responder and mark the conversation as "read"
       assert %{assignee_id: ^agent_id, read: true} =
-               Messages.Helpers.build_conversation_updates(first_agent_reply)
+               Messages.Helpers.build_conversation_updates(%{}, first_agent_reply)
 
       first_customer_reply =
         insert(:message, conversation: conversation, customer: customer, user: nil)
 
-      assert %{read: false} = Messages.Helpers.build_conversation_updates(first_customer_reply)
+      assert %{read: false} =
+               Messages.Helpers.build_conversation_updates(%{}, first_customer_reply)
 
       second_agent_reply =
         insert(:message, conversation: conversation, user: agent, customer: nil)
 
       # On subsequent replies, just mark the conversation as "read"
-      assert %{read: true} = Messages.Helpers.build_conversation_updates(second_agent_reply)
+      assert %{read: true} = Messages.Helpers.build_conversation_updates(%{}, second_agent_reply)
 
       second_customer_reply =
         insert(:message, conversation: conversation, customer: customer, user: nil)
 
-      assert %{} = Messages.Helpers.build_conversation_updates(second_customer_reply)
+      assert %{} = Messages.Helpers.build_conversation_updates(%{}, second_customer_reply)
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -117,6 +117,15 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def mention_factory do
+    %ChatApi.Mentions.Mention{
+      account: build(:account),
+      conversation: build(:conversation),
+      message: build(:message),
+      user: build(:user)
+    }
+  end
+
   def issue_factory do
     %ChatApi.Issues.Issue{
       title: sequence("some title"),


### PR DESCRIPTION
### Description

This PR adds support for @ mentions in the dashboard:
- [x] Agent can @ mention anyone on the team
- [x] Agent can view conversations where they have been @ mentioned
- [x] Agent will receive email notification when they are @ mentioned
- [x] UX cleanup

### Issue

Handles https://github.com/papercups-io/papercups/issues/910

### Screenshots

**Demo:**
![at-mention-dashboard](https://user-images.githubusercontent.com/5264279/126420797-cdcbd439-a5fe-4b38-beec-fb895c41ff17.gif)

**Dashboard:**
<img width="1573" alt="Screen Shot 2021-07-20 at 7 25 47 PM" src="https://user-images.githubusercontent.com/5264279/126420788-12d7c1fc-d815-4d09-9abd-27be8b88093e.png">

**Email notification:**
<img width="658" alt="Screen Shot 2021-07-20 at 7 24 58 PM" src="https://user-images.githubusercontent.com/5264279/126420795-c4161326-931e-479c-9476-4753ef2b9b29.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
