### PR TITLE
Display more metadata (e.g. source, email subject line) in non-chat messages

### DIFF
--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -45,6 +45,10 @@ body {
   color: #fff;
 }
 
+.Text--white.ant-typography-secondary {
+  color: rgba(250, 250, 250, 0.8);
+}
+
 .Text--white > h1,
 .Text--white > h2,
 .Text--white > h3,

--- a/assets/src/components/conversations/ChatMessage.tsx
+++ b/assets/src/components/conversations/ChatMessage.tsx
@@ -93,7 +93,6 @@ const ChatMessage = ({
   shouldDisplayTimestamp,
 }: Props) => {
   const {
-    body,
     sent_at,
     created_at,
     seen_at,
@@ -115,10 +114,8 @@ const ChatMessage = ({
         <Flex sx={{justifyContent: 'flex-end'}}>
           <ChatMessageBox
             className={isPrivate ? '' : 'Text--white'}
-            content={body}
+            message={message}
             sx={{
-              px: 3,
-              py: 2,
               background: isPrivate ? colors.note : colors.primary,
             }}
             attachmentTextColor={isPrivate ? colors.text : colors.white}
@@ -152,10 +149,8 @@ const ChatMessage = ({
           color={color}
         />
         <ChatMessageBox
-          content={body}
+          message={message}
           sx={{
-            px: 3,
-            py: 2,
             background: isPrivate ? colors.note : 'rgb(245, 245, 245)',
             maxWidth: '80%',
           }}

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -1,8 +1,32 @@
 import React from 'react';
-import {Box} from 'theme-ui';
-import {MarkdownRenderer} from '../common';
-import {Attachment} from '../../types';
+import {Box, Flex} from 'theme-ui';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import {MarkdownRenderer, Text} from '../common';
+import {Attachment, Message, MessageSource} from '../../types';
 import {PaperClipOutlined} from '../icons';
+
+dayjs.extend(utc);
+
+const getMessageSourceDetails = (source?: MessageSource) => {
+  switch (source) {
+    case 'email':
+      return ['email', '/gmail.svg'];
+    case 'slack':
+      return ['Slack', '/slack.svg'];
+    case 'mattermost':
+      return ['Mattermost', '/mattermost.svg'];
+    case 'sms':
+      return ['SMS', '/twilio.svg'];
+    case 'api':
+      return ['API', '/logo.svg'];
+    case 'sandbox':
+      return ['sandbox', '/logo.svg'];
+    case 'chat':
+    default:
+      return [];
+  }
+};
 
 const ChatMessageAttachment = ({
   attachment,
@@ -31,7 +55,7 @@ const ChatMessageAttachment = ({
 
 type Props = {
   className?: string;
-  content: string;
+  message: Message;
   sx?: Record<any, any>;
   attachments?: Attachment[];
   attachmentTextColor?: string;
@@ -39,12 +63,18 @@ type Props = {
 
 const ChatMessageBox = ({
   className,
-  content,
+  message,
   sx,
   attachments = [],
   attachmentTextColor,
 }: Props) => {
+  const {body, source, created_at, metadata = {}} = message;
+  const createdAt = dayjs.utc(created_at).local().format('ddd, MMM D h:mm A');
+  const subject = metadata?.gmail_subject ?? null;
+  const [formattedSource, sourceIcon] = getMessageSourceDetails(source);
   const parsedSx = Object.assign(sx, {
+    px: 3,
+    py: 2,
     borderRadius: 4,
     p: {
       mb: 0,
@@ -58,7 +88,15 @@ const ChatMessageBox = ({
 
   return (
     <Box sx={parsedSx}>
-      <MarkdownRenderer className={className} source={content} />
+      {subject && (
+        <Box pb={1} mb={2} sx={{borderBottom: '1px solid rgba(0,0,0,.06)'}}>
+          <Text className={className} type="secondary" style={{fontSize: 12}}>
+            {subject}
+          </Text>
+        </Box>
+      )}
+
+      <MarkdownRenderer className={className} source={body} />
 
       {attachments && attachments.length > 0 && (
         <Box mt={2} className={className}>
@@ -72,6 +110,39 @@ const ChatMessageBox = ({
             );
           })}
         </Box>
+      )}
+
+      {formattedSource && (
+        <Flex
+          pt={1}
+          mt={2}
+          sx={{
+            borderTop: '1px solid rgba(0,0,0,.06)',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            className={className}
+            type="secondary"
+            style={{fontSize: 12, marginRight: 32}}
+          >
+            {createdAt}
+          </Text>
+
+          <Flex sx={{alignItems: 'center'}}>
+            {sourceIcon && (
+              <img
+                src={sourceIcon}
+                alt={source}
+                style={{height: 12, marginRight: 4}}
+              />
+            )}
+            <Text className={className} type="secondary" style={{fontSize: 12}}>
+              Sent via {formattedSource}
+            </Text>
+          </Flex>
+        </Flex>
       )}
     </Box>
   );

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -67,12 +67,21 @@ export type Company = {
   updated_at: string;
 };
 
-export type MessageType = 'reply' | 'note';
+export type MessageType = 'reply' | 'note' | 'bot';
+export type MessageSource =
+  | 'chat'
+  | 'slack'
+  | 'mattermost'
+  | 'email'
+  | 'sms'
+  | 'api'
+  | 'sandbox';
 
 export type Message = {
   id: string;
   body: string;
-  type?: 'reply' | 'note' | 'bot';
+  type?: MessageType;
+  source?: MessageSource;
   private?: boolean;
   created_at: string;
   sent_at?: string;


### PR DESCRIPTION
### Description

Display more metadata (e.g. source, email subject line) in non-chat (e.g. Slack, email, SMS) messages

### Issue

https://github.com/papercups-io/papercups/issues/914
https://github.com/papercups-io/papercups/issues/915

### Screenshots

**Email message with subject line:**
<img width="827" alt="Screen Shot 2021-07-21 at 2 42 55 PM" src="https://user-images.githubusercontent.com/5264279/126564253-0a5a33bf-ccb3-4b33-8eb0-4f52bb51687f.png">

**Slack message:**
<img width="826" alt="Screen Shot 2021-07-21 at 2 43 20 PM" src="https://user-images.githubusercontent.com/5264279/126564260-97341660-f597-4b54-834a-9f7bbd4c2fc9.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
