### PR TITLE
Include conversation source details in initial Slack message

### DIFF
--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -351,6 +351,7 @@ defmodule ChatApi.SlackTest do
       customer_email = "*Email:*\n#{customer.email}"
       conversation_id = conversation.id
       channel = thread.slack_channel
+      message = insert(:message, customer: customer, user: nil)
 
       assert %{
                "blocks" => [
@@ -368,13 +369,13 @@ defmodule ChatApi.SlackTest do
                        "text" => ^customer_email
                      },
                      %{
-                       "text" => "*URL:*\nN/A"
+                       "text" => "*Source:*\n:speech_balloon: Chat"
                      },
                      %{
-                       "text" => "*Browser:*\nN/A"
+                       "text" => "*Last seen URL:*\nN/A"
                      },
                      %{
-                       "text" => "*OS:*\nN/A"
+                       "text" => "*Device:*\nN/A"
                      },
                      %{
                        "text" => "*Timezone:*\nN/A"
@@ -402,6 +403,7 @@ defmodule ChatApi.SlackTest do
                  channel: channel,
                  conversation: conversation,
                  customer: customer,
+                 message: message,
                  thread: nil
                })
     end


### PR DESCRIPTION
### Description

Include conversation source details in initial Slack message (e.g. email vs chat vs SMS). Also includes email subject line if available.

### Issue

https://github.com/papercups-io/papercups/issues/914
https://github.com/papercups-io/papercups/issues/915

### Screenshots

<img width="669" alt="Screen Shot 2021-07-22 at 11 09 52 AM" src="https://user-images.githubusercontent.com/5264279/126688049-a92ae482-d69f-493f-833c-a7aa52da8eaa.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
