### PR TITLE
Set up UX for using canned responses

### DIFF
--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -21,7 +21,11 @@ body {
 .TextArea--transparent,
 .TextArea--transparent:hover,
 .TextArea--transparent:focus,
-.TextArea--transparent:active {
+.TextArea--transparent:active,
+.TextArea--transparent > textarea,
+.TextArea--transparent > textarea:hover,
+.TextArea--transparent > textarea:focus,
+.TextArea--transparent > textarea:active {
   background: transparent;
   border: none;
   box-shadow: none;

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -15,6 +15,7 @@ import {
   Tag,
   User,
   WidgetSettings,
+  CannedResponse,
 } from './types';
 
 // TODO: handle this on the server instead
@@ -1676,6 +1677,62 @@ export const getOnboardingStatus = async (
 
   return request
     .get(`/api/onboarding_status`)
+    .set('Authorization', token)
+    .then((res) => res.body);
+};
+
+export const fetchCannedResponses = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/canned_responses`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const createCannedResponse = async (
+  params: Partial<CannedResponse>,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/canned_responses`)
+    .send({canned_response: params})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const updateCannedResponse = async (
+  id: string,
+  updates: Partial<CannedResponse>,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .put(`/api/canned_responses/${id}`)
+    .send({canned_response: updates})
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const deleteCannedResponse = async (
+  id: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/canned_responses/${id}`)
     .set('Authorization', token)
     .then((res) => res.body);
 };

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -86,6 +86,7 @@ import EventSubscriptionsPage from './developers/EventSubscriptionsPage';
 import EmailTemplateBuilder from './developers/EmailTemplateBuilder';
 import LambdaDetailsPage from './lambdas/LambdaDetailsPage';
 import LambdasOverview from './lambdas/LambdasOverview';
+import CannedResponsesOverview from './canned-responses/CannedResponsesOverview';
 
 const {
   REACT_APP_ADMIN_ACCOUNT_ID = 'eb504736-0f20-4978-98ff-1a82ae60b266',
@@ -497,6 +498,9 @@ const Dashboard = (props: RouteComponentProps) => {
                 <Menu.Item key="chat-widget">
                   <Link to="/settings/chat-widget">Chat widget</Link>
                 </Menu.Item>
+                <Menu.Item key="saved-replies">
+                  <Link to="/settings/saved-replies">Saved replies</Link>
+                </Menu.Item>
                 {shouldDisplayBilling && (
                   <Menu.Item key="billing">
                     <Link to="/settings/billing">Billing</Link>
@@ -545,10 +549,15 @@ const Dashboard = (props: RouteComponentProps) => {
           />
           <Redirect from="/account*" to="/settings*" />
           <Redirect from="/billing" to="/settings/billing" />
+          <Redirect from="/saved-replies" to="/settings/saved-replies" />
 
           <Route path="/settings/account" component={AccountOverview} />
           <Route path="/settings/team" component={TeamOverview} />
           <Route path="/settings/profile" component={UserProfile} />
+          <Route
+            path="/settings/saved-replies"
+            component={CannedResponsesOverview}
+          />
           <Route path="/settings/chat-widget" component={ChatWidgetSettings} />
           {shouldDisplayBilling && (
             <Route path="/settings/billing" component={BillingOverview} />

--- a/assets/src/components/canned-responses/CannedResponsesOverview.tsx
+++ b/assets/src/components/canned-responses/CannedResponsesOverview.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {
+  Button,
+  Container,
+  Input,
+  Paragraph,
+  Popconfirm,
+  Table,
+  Text,
+  Title,
+} from '../common';
+import * as API from '../../api';
+import {CannedResponse} from '../../types';
+import logger from '../../logger';
+import {NewCannedResponseModalButton} from './NewCannedResponseModal';
+
+const CannedResponsesTable = ({
+  loading,
+  cannedResponses,
+  onDeleteCannedResponse,
+}: {
+  loading?: boolean;
+  cannedResponses: Array<CannedResponse>;
+  onDeleteCannedResponse: (id: string) => void;
+}) => {
+  const data = cannedResponses
+    .map((cannedResponse) => {
+      return {key: cannedResponse.id, ...cannedResponse};
+    })
+    .sort((a, b) => {
+      return +new Date(b.updated_at) - +new Date(a.updated_at);
+    });
+
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      render: (value: string) => {
+        return <Text code>/{value}</Text>;
+      },
+    },
+    {
+      title: 'Content',
+      dataIndex: 'content',
+      key: 'content',
+      render: (value: string) => {
+        return value;
+      },
+    },
+    {
+      title: '',
+      dataIndex: 'action',
+      key: 'action',
+      render: (value: string, record: CannedResponse) => {
+        return (
+          <Flex mx={-1} sx={{justifyContent: 'flex-end'}}>
+            {/* 
+            TODO: implement me!
+
+            <Box mx={1}>
+              <Button>Edit</Button>
+            </Box> 
+            */}
+
+            <Box mx={1}>
+              <Popconfirm
+                title="Are you sure you want to delete this API key?"
+                okText="Yes"
+                cancelText="No"
+                placement="topLeft"
+                onConfirm={() => onDeleteCannedResponse(record.id)}
+              >
+                <Button danger>Delete</Button>
+              </Popconfirm>
+            </Box>
+          </Flex>
+        );
+      },
+    },
+  ];
+
+  return <Table loading={loading} dataSource={data} columns={columns} />;
+};
+
+type Props = {};
+type State = {
+  filterQuery: string;
+  filteredCannedResponses: Array<CannedResponse>;
+  isNewCannedResponseModalVisible: boolean;
+  loading: boolean;
+  cannedResponses: Array<CannedResponse>;
+};
+
+const filterCannedResponsesByQuery = (
+  cannedResponses: Array<CannedResponse>,
+  query?: string
+): Array<CannedResponse> => {
+  if (!query || !query.length) {
+    return cannedResponses;
+  }
+
+  return cannedResponses.filter((cannedResponse) => {
+    const {id, name, content} = cannedResponse;
+
+    const words = [id, name, content]
+      .filter((str) => str && String(str).trim().length > 0)
+      .join(' ')
+      .replace('_', ' ')
+      .split(' ')
+      .map((str) => str.toLowerCase());
+
+    const queries = query.split(' ').map((str) => str.toLowerCase());
+
+    return queries.every((q) => {
+      return words.some((word) => word.indexOf(q) !== -1);
+    });
+  });
+};
+
+class CannedResponsesOverview extends React.Component<Props, State> {
+  state: State = {
+    filteredCannedResponses: [],
+    filterQuery: '',
+    isNewCannedResponseModalVisible: false,
+    loading: true,
+    cannedResponses: [],
+  };
+
+  async componentDidMount() {
+    await this.handleRefreshCannedResponses();
+  }
+
+  handleSearchCannedResponses = (filterQuery: string) => {
+    const {cannedResponses = []} = this.state;
+
+    if (!filterQuery?.length) {
+      this.setState({
+        filterQuery: '',
+        filteredCannedResponses: cannedResponses,
+      });
+    }
+
+    this.setState({
+      filterQuery,
+      filteredCannedResponses: filterCannedResponsesByQuery(
+        cannedResponses,
+        filterQuery
+      ),
+    });
+  };
+
+  handleRefreshCannedResponses = async () => {
+    try {
+      const {filterQuery} = this.state;
+      const cannedResponses = await API.fetchCannedResponses();
+
+      this.setState({
+        filteredCannedResponses: filterCannedResponsesByQuery(
+          cannedResponses,
+          filterQuery
+        ),
+        loading: false,
+        cannedResponses,
+      });
+    } catch (err) {
+      logger.error('Error loading canned responses!', err);
+
+      this.setState({loading: false});
+    }
+  };
+
+  handleDeleteCannedResponse = async (id: string) => {
+    try {
+      this.setState({loading: true});
+
+      await API.deleteCannedResponse(id);
+      await this.handleRefreshCannedResponses();
+    } catch (err) {
+      logger.error('Error deleting canned responses!', err);
+
+      this.setState({loading: false});
+    }
+  };
+
+  render() {
+    const {loading, filteredCannedResponses = []} = this.state;
+
+    return (
+      <Container>
+        <Flex sx={{justifyContent: 'space-between', alignItems: 'center'}}>
+          <Title level={3}>Saved replies</Title>
+
+          <NewCannedResponseModalButton
+            onSuccess={this.handleRefreshCannedResponses}
+          >
+            New
+          </NewCannedResponseModalButton>
+        </Flex>
+
+        <Box mb={4}>
+          <Paragraph>
+            Use saved replies to respond more quickly to common questions.
+          </Paragraph>
+        </Box>
+
+        <Box mb={3}>
+          <Input.Search
+            placeholder="Search saved replies..."
+            allowClear
+            onSearch={this.handleSearchCannedResponses}
+            style={{width: 400}}
+          />
+        </Box>
+
+        <Box my={4}>
+          <CannedResponsesTable
+            loading={loading}
+            cannedResponses={filteredCannedResponses}
+            onDeleteCannedResponse={this.handleDeleteCannedResponse}
+          />
+        </Box>
+      </Container>
+    );
+  }
+}
+
+export default CannedResponsesOverview;

--- a/assets/src/components/canned-responses/NewCannedResponseModal.tsx
+++ b/assets/src/components/canned-responses/NewCannedResponseModal.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {Box} from 'theme-ui';
+import {ButtonProps} from 'antd/lib/button';
+import {Button, Input, Modal, Text, TextArea} from '../common';
+import {PlusOutlined} from '../icons';
+import * as API from '../../api';
+import logger from '../../logger';
+import {formatServerError} from '../../utils';
+
+const NewCannedResponseModal = ({
+  visible,
+  onSuccess,
+  onCancel,
+}: {
+  visible: boolean;
+  onSuccess: (params: any) => void;
+  onCancel: () => void;
+}) => {
+  const [name, setName] = React.useState('');
+  const [content, setContent] = React.useState('');
+  const [error, setErrorMessage] = React.useState<string | null>(null);
+  const [isSaving, setIsSaving] = React.useState(false);
+
+  const handleChangeName = (e: any) => setName(e.target.value);
+  const handleChangeContent = (e: any) => setContent(e.target.value);
+  const resetInputFields = () => {
+    setName('');
+    setContent('');
+    setErrorMessage(null);
+  };
+
+  const handleCancelCannedResponse = () => {
+    onCancel();
+    resetInputFields();
+  };
+
+  const handleCreateCannedResponse = async () => {
+    setIsSaving(true);
+
+    return API.createCannedResponse({name: name.replace('/', ''), content})
+      .then((result) => {
+        onSuccess(result);
+        resetInputFields();
+      })
+      .catch((err) => {
+        logger.error('Error creating saved reply:', err);
+        const errorMessage = formatServerError(err);
+        setErrorMessage(errorMessage);
+      })
+      .finally(() => setIsSaving(false));
+  };
+
+  return (
+    <Modal
+      title="Create new saved reply"
+      visible={visible}
+      width={400}
+      onOk={handleCreateCannedResponse}
+      onCancel={handleCancelCannedResponse}
+      footer={[
+        <Button key="cancel" onClick={handleCancelCannedResponse}>
+          Cancel
+        </Button>,
+        <Button
+          key="submit"
+          type="primary"
+          loading={isSaving}
+          onClick={handleCreateCannedResponse}
+        >
+          Save
+        </Button>,
+      ]}
+    >
+      <Box>
+        <Box mb={3}>
+          <label htmlFor="name">Name</label>
+          <Input
+            id="name"
+            type="text"
+            value={name}
+            placeholder="demo"
+            autoFocus
+            onChange={handleChangeName}
+          />
+        </Box>
+        <Box mb={3}>
+          <label htmlFor="content">Content</label>
+          <TextArea
+            id="content"
+            value={content}
+            placeholder="Check out our demo at https://example.com/demo"
+            onChange={handleChangeContent}
+          />
+        </Box>
+
+        {error && (
+          <Box mb={-3}>
+            <Text type="danger">{error}</Text>
+          </Box>
+        )}
+      </Box>
+    </Modal>
+  );
+};
+
+export const NewCannedResponseModalButton = ({
+  onSuccess,
+  ...rest
+}: {
+  onSuccess: (data?: any) => void;
+} & ButtonProps) => {
+  const [isModalOpen, setModalOpen] = React.useState(false);
+
+  const handleOpenModal = () => setModalOpen(true);
+  const handleCloseModal = () => setModalOpen(false);
+  const handleSuccess = () => {
+    onSuccess();
+    handleCloseModal();
+  };
+
+  return (
+    <>
+      <Button
+        type="primary"
+        icon={<PlusOutlined />}
+        onClick={handleOpenModal}
+        {...rest}
+      />
+
+      <NewCannedResponseModal
+        visible={isModalOpen}
+        onSuccess={handleSuccess}
+        onCancel={handleCloseModal}
+      />
+    </>
+  );
+};
+
+export default NewCannedResponseModal;

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import {
   colors,

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Link} from 'react-router-dom';
 import {Box, Flex} from 'theme-ui';
 import {
   colors,
@@ -311,13 +312,32 @@ const ConversationFooter = ({
                 className="TextArea--transparent"
                 placeholder={
                   isPrivateNote
-                    ? 'Type a private note here'
-                    : 'Type your reply here'
+                    ? 'Type @ to mention a teammate and they will be notified.'
+                    : 'Type / to use a saved reply.'
                 }
                 autoSize={{minRows: 2, maxRows: 4}}
                 autoFocus
                 prefix={['@', '#', '/']}
                 value={message}
+                notFoundContent={
+                  <Box py={1}>
+                    {prefix === '@' ? (
+                      <Text type="secondary">Teammate not found.</Text>
+                    ) : (
+                      <Text type="secondary">
+                        Not found. Create a new saved reply{' '}
+                        <a
+                          href="/saved-replies"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          here
+                        </a>
+                        .
+                      </Text>
+                    )}
+                  </Box>
+                }
                 onPressEnter={handleKeyDown}
                 onChange={setMessage}
                 onSelect={handleSelectMentionOption}

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -8,6 +8,7 @@ import {
   Upload,
   UploadChangeParam,
   UploadFile,
+  Text,
   Tooltip,
 } from '../common';
 import {Message, MessageType, User} from '../../types';
@@ -69,17 +70,25 @@ const ConversationFooter = ({
   onSendMessage: (message: Partial<Message>) => void;
   currentUser?: User | null;
 }) => {
+  const textAreaEl = React.useRef<any>(null);
   const [message, setMessage] = React.useState<string>('');
   const [fileList, setFileList] = React.useState<Array<UploadFile>>([]);
   const [messageType, setMessageType] = React.useState<MessageType>('reply');
+  const [cannedResponses, setCannedResponses] = React.useState<Array<any>>([]);
   const [mentions, setMentions] = React.useState<Array<string>>([]);
   const [mentionableUsers, setMentionableUsers] = React.useState<Array<User>>(
     []
   );
+  const [prefix, setMentionPrefix] = React.useState<string>('@');
   const [isSendDisabled, setSendDisabled] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    API.fetchAccountUsers().then((users) => setMentionableUsers(users));
+    Promise.all([API.fetchAccountUsers(), API.fetchCannedResponses()]).then(
+      ([users, responses]) => {
+        setMentionableUsers(users);
+        setCannedResponses(responses);
+      }
+    );
   }, []);
 
   const isPrivateNote = messageType === 'note';
@@ -88,9 +97,50 @@ const ConversationFooter = ({
 
   const handleSetMessageType = ({key}: any) => setMessageType(key);
 
-  const handleSelectMentionOption = (option: any, prefix: string) => {
-    setMentions([...new Set([...mentions, option.value])]);
+  const getPrefixIndex = (index: number) => {
+    for (let i = index; i >= 0; i--) {
+      if (message[i] === '/' || message[i] === '#') {
+        return i;
+      }
+    }
+
+    return -1;
   };
+
+  const handleSelectMentionOption = (option: any, prefix: string) => {
+    switch (prefix) {
+      case '@':
+        return setMentions([...new Set([...mentions, option.value])]);
+      case '#':
+      case '/':
+        const el = textAreaEl.current?.textarea;
+        const y = el?.selectionStart ?? -1;
+        const x = getPrefixIndex(y);
+        const response = cannedResponses.find((r) => r.name === option.value);
+
+        if (el && x !== -1 && y !== -1 && response && response.content) {
+          const update = [
+            message.slice(0, x),
+            response.content,
+            message.slice(y),
+          ].join('');
+          const newCursorIndex = x + response.content.length;
+
+          setMessage(update);
+          // Slight hack to get the cursor to move to the correct spot
+          setTimeout(() => {
+            el.selectionStart = newCursorIndex;
+          }, 0);
+        }
+
+        return null;
+      default:
+        return null;
+    }
+  };
+
+  const handleSearchMentions = (str: string, prefix: string) =>
+    setMentionPrefix(prefix);
 
   const handleKeyDown = (e: any) => {
     const {key, metaKey} = e;
@@ -147,6 +197,42 @@ const ConversationFooter = ({
     // Enable send button again when the server has responded
     if (file && file.response) {
       setSendDisabled(false);
+    }
+  };
+
+  const getMentionOptions = () => {
+    switch (prefix) {
+      case '@':
+        return mentionableUsers.map(({id, email, display_name, full_name}) => {
+          const value = display_name || full_name || email;
+
+          return (
+            <Mentions.Option key={id} value={value}>
+              <Box>
+                <Text>{value}</Text>
+              </Box>
+              <Box>
+                <Text type="secondary">{email}</Text>
+              </Box>
+            </Mentions.Option>
+          );
+        });
+      case '#':
+      case '/':
+        return cannedResponses.map(({name, content}) => {
+          return (
+            <Mentions.Option key={name} value={name}>
+              <Box>
+                <Text>{name}</Text>
+              </Box>
+              <Box>
+                <Text type="secondary">{content}</Text>
+              </Box>
+            </Mentions.Option>
+          );
+        });
+      default:
+        return [];
     }
   };
 
@@ -221,6 +307,7 @@ const ConversationFooter = ({
               {/* NB: we use the `key` prop to auto-focus the textarea when toggling `messageType` */}
               <Mentions
                 key={messageType}
+                ref={textAreaEl}
                 className="TextArea--transparent"
                 placeholder={
                   isPrivateNote
@@ -229,21 +316,14 @@ const ConversationFooter = ({
                 }
                 autoSize={{minRows: 2, maxRows: 4}}
                 autoFocus
+                prefix={['@', '#', '/']}
                 value={message}
                 onPressEnter={handleKeyDown}
                 onChange={setMessage}
                 onSelect={handleSelectMentionOption}
+                onSearch={handleSearchMentions}
               >
-                {mentionableUsers.map((user) => {
-                  const {email, display_name, full_name} = user;
-                  const value = display_name || full_name || email;
-
-                  return (
-                    <Mentions.Option key={user.id} value={value}>
-                      {value}
-                    </Mentions.Option>
-                  );
-                })}
+                {getMentionOptions()}
               </Mentions>
             </Box>
             {shouldDisplayUploadButton ? (

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -17,6 +17,14 @@ export type AccountSettings = {
   max_num_conversation_reminders?: number | null;
 };
 
+export type CannedResponse = {
+  id: string;
+  name: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export type User = {
   id: number;
   email: string;

--- a/lib/chat_api/canned_responses.ex
+++ b/lib/chat_api/canned_responses.ex
@@ -8,11 +8,6 @@ defmodule ChatApi.CannedResponses do
 
   alias ChatApi.CannedResponses.CannedResponse
 
-  @spec list_canned_responses() :: [CannedResponse.t()]
-  def list_canned_responses do
-    Repo.all(CannedResponse)
-  end
-
   @spec list_canned_responses(binary()) :: [CannedResponse.t()]
   def list_canned_responses(account_id) do
     CannedResponse |> where(account_id: ^account_id) |> Repo.all()

--- a/lib/chat_api_web/controllers/canned_response_controller.ex
+++ b/lib/chat_api_web/controllers/canned_response_controller.ex
@@ -4,9 +4,9 @@ defmodule ChatApiWeb.CannedResponseController do
   alias ChatApi.CannedResponses
   alias ChatApi.CannedResponses.CannedResponse
 
-  action_fallback ChatApiWeb.FallbackController
+  action_fallback(ChatApiWeb.FallbackController)
 
-  plug :authorize when action in [:show, :update, :delete]
+  plug(:authorize when action in [:show, :update, :delete])
 
   defp authorize(conn, _) do
     id = conn.path_params["id"]


### PR DESCRIPTION
### Description

Set up UX for using canned responses/saved replies

### Issue

Fixes https://github.com/papercups-io/papercups/issues/655

### Screenshots

**Create new canned response:**
![saved-reply-create](https://user-images.githubusercontent.com/5264279/126712989-65d5e393-1a6c-490c-bbb7-62017f8cf095.gif)

**Use canned response:**
![saved-reply-ux](https://user-images.githubusercontent.com/5264279/126712981-0a4585fe-ce89-4918-8b88-f2949b1270a1.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
