### PR TITLE
Include private messages in @ mention notifications

### DIFF
--- a/lib/workers/send_mention_notification.ex
+++ b/lib/workers/send_mention_notification.ex
@@ -68,13 +68,7 @@ defmodule ChatApi.Workers.SendMentionNotification do
   @spec get_recent_messages(binary(), binary()) :: [Message.t()]
   def get_recent_messages(conversation_id, account_id) do
     conversation_id
-    |> Messages.list_by_conversation(
-      %{
-        "account_id" => account_id,
-        "private" => false
-      },
-      limit: 5
-    )
+    |> Messages.list_by_conversation(%{"account_id" => account_id}, limit: 5)
     |> Enum.reverse()
   end
 


### PR DESCRIPTION
### Description

Include private messages in @ mention notifications (since these are only sent internally within a team)

### Issue

#910 

### Screenshots

<img width="739" alt="Screen Shot 2021-07-23 at 9 39 50 AM" src="https://user-images.githubusercontent.com/5264279/126814140-e5b96b35-79e1-4703-91fe-81a13a53f06e.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
