### PR TITLE
Add basic text search to conversations UI

### DIFF
--- a/assets/src/App.css
+++ b/assets/src/App.css
@@ -119,3 +119,25 @@ a.RelatedCustomerConversation--link:hover {
 .GettingStartedCode .ant-tabs-nav .ant-tabs-tab {
   border-color: #d9d9d9;
 }
+
+.ConversationsSearchInput {
+  border-top: 1px solid rgb(240, 240, 240);
+  border-right: none;
+  border-bottom: none;
+  border-left: none;
+}
+
+.ConversationsSearchInput:hover,
+.ConversationsSearchInput:active,
+.ConversationsSearchInput:focus {
+  border-color: rgb(240, 240, 240);
+}
+
+.ConversationsSearchInput.ant-input-affix-wrapper:focus,
+.ant-input-affix-wrapper-focused {
+  box-shadow: rgb(0 0 0 / 10%) 0px 0px 4px;
+}
+
+.ConversationsSearchInput .ant-input-search-icon::before {
+  border-left: 1px solid rgb(240, 240, 240);
+}

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -418,6 +418,19 @@ export type ConversationsListResponse = {
   previous: string | null;
 };
 
+export const countUnreadConversations = async (
+  token = getAccessToken()
+): Promise<any> => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/conversations/unread`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
 export const fetchConversations = async (
   query = {},
   token = getAccessToken()
@@ -489,6 +502,27 @@ export const fetchClosedConversations = async (
   token = getAccessToken()
 ) => {
   return fetchConversations({...query, status: 'closed'}, token);
+};
+
+export const fetchUnreadConversations = async (
+  query = {},
+  token = getAccessToken()
+) => {
+  return fetchConversations({...query, status: 'open', read: false}, token);
+};
+
+export const fetchUnassignedConversations = async (
+  query = {},
+  token = getAccessToken()
+) => {
+  return fetchConversations(
+    {
+      ...query,
+      status: 'open',
+      assignee_id: null,
+    },
+    token
+  );
 };
 
 export const fetchConversation = async (

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -55,6 +55,8 @@ import AllConversations from './conversations/AllConversations';
 import MyConversations from './conversations/MyConversations';
 import MentionedConversations from './conversations/MentionedConversations';
 import PriorityConversations from './conversations/PriorityConversations';
+import UnreadConversations from './conversations/UnreadConversations';
+import UnassignedConversations from './conversations/UnassignedConversations';
 import ClosedConversations from './conversations/ClosedConversations';
 import ConversationsBySource from './conversations/ConversationsBySource';
 import IntegrationsOverview from './integrations/IntegrationsOverview';
@@ -233,7 +235,7 @@ const Dashboard = (props: RouteComponentProps) => {
   const {account, currentUser, inboxes, getUnreadCount} = useConversations();
 
   const [section, key] = getSectionKey(pathname);
-  const totalNumUnread = getUnreadCount(inboxes.all.open);
+  const totalNumUnread = getUnreadCount('open', inboxes.all.open);
   const shouldDisplayBilling = hasValidStripeKey();
 
   const logout = () => auth.logout().then(() => props.history.push('/login'));
@@ -310,6 +312,41 @@ const Dashboard = (props: RouteComponentProps) => {
                     </Flex>
                   </Link>
                 </Menu.Item>
+                <Menu.Item key="unread">
+                  <Link to="/conversations/unread">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>All unread</Box>
+                      <Badge
+                        count={getUnreadCount('unread', inboxes.all.unread)}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
+                <Menu.Item key="unassigned">
+                  <Link to="/conversations/unassigned">
+                    <Flex
+                      sx={{
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Box mr={2}>Unassigned</Box>
+                      <Badge
+                        count={getUnreadCount(
+                          'unassigned',
+                          inboxes.all.unassigned
+                        )}
+                        style={{borderColor: '#FF4D4F'}}
+                      />
+                    </Flex>
+                  </Link>
+                </Menu.Item>
                 <Menu.Item key="mentions">
                   <Link to="/conversations/mentions">
                     <Flex
@@ -320,7 +357,10 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Mentions</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.all.mentioned)}
+                        count={getUnreadCount(
+                          'mentioned',
+                          inboxes.all.mentioned
+                        )}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -336,7 +376,7 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Assigned to me</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.all.assigned)}
+                        count={getUnreadCount('assigned', inboxes.all.assigned)}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -352,7 +392,7 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Prioritized</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.all.priority)}
+                        count={getUnreadCount('priority', inboxes.all.priority)}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -377,7 +417,10 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Live chat</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.bySource['chat'] ?? [])}
+                        count={getUnreadCount(
+                          'chat',
+                          inboxes.bySource['chat'] ?? []
+                        )}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -393,7 +436,10 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Email</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.bySource['email'] ?? [])}
+                        count={getUnreadCount(
+                          'email',
+                          inboxes.bySource['email'] ?? []
+                        )}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -409,7 +455,10 @@ const Dashboard = (props: RouteComponentProps) => {
                     >
                       <Box mr={2}>Slack</Box>
                       <Badge
-                        count={getUnreadCount(inboxes.bySource['slack'] ?? [])}
+                        count={getUnreadCount(
+                          'slack',
+                          inboxes.bySource['slack'] ?? []
+                        )}
                         style={{borderColor: '#FF4D4F'}}
                       />
                     </Flex>
@@ -599,6 +648,11 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route path="/functions/:id" component={LambdaDetailsPage} />
           <Route path="/functions" component={LambdasOverview} />
           <Route path="/conversations/all" component={AllConversations} />
+          <Route path="/conversations/unread" component={UnreadConversations} />
+          <Route
+            path="/conversations/unassigned"
+            component={UnassignedConversations}
+          />
           <Route
             path="/conversations/mentions"
             component={MentionedConversations}

--- a/assets/src/components/conversations/ConversationsDashboard.tsx
+++ b/assets/src/components/conversations/ConversationsDashboard.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import {Box} from 'theme-ui';
 import qs from 'query-string';
-import {
-  colors,
-  Divider,
-  Input,
-  Layout,
-  notification,
-  Sider,
-  Title,
-} from '../common';
+import {colors, Input, Layout, notification, Sider, Title} from '../common';
 import {sleep} from '../../utils';
 import {ConversationsListResponse, PaginationOptions} from '../../api';
 import {Account, Conversation, Message} from '../../types';

--- a/assets/src/components/conversations/ConversationsPreviewList.tsx
+++ b/assets/src/components/conversations/ConversationsPreviewList.tsx
@@ -5,7 +5,7 @@ import ConversationItem from './ConversationItem';
 import ConversationClosing from './ConversationClosing';
 import {getColorByUuid} from './support';
 import {Conversation} from '../../types';
-import {isScrolledIntoView} from '../../utils';
+import {isScrolledIntoView, sleep} from '../../utils';
 import {useConversations} from './ConversationsProvider';
 
 const ConversationsPreviewList = ({
@@ -51,7 +51,10 @@ const ConversationsPreviewList = ({
 
   const handleLoadMoreConversations = async () => {
     setFetchingMore(true);
+
     await onLoadMoreConversations();
+    await sleep(1000);
+
     setFetchingMore(false);
   };
 

--- a/assets/src/components/conversations/UnassignedConversations.tsx
+++ b/assets/src/components/conversations/UnassignedConversations.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {useConversations} from './ConversationsProvider';
+import ConversationsDashboard from './ConversationsDashboard';
+import * as API from '../../api';
+
+const UnassignedConversations = () => {
+  const {
+    loading,
+    currentUser,
+    account,
+    inboxes,
+    messagesByConversation = {},
+    onSetConversations,
+    onSelectConversation,
+    onUpdateConversation,
+    onDeleteConversation,
+    onSendMessage,
+  } = useConversations();
+
+  if (!currentUser) {
+    return null;
+  }
+
+  return (
+    <ConversationsDashboard
+      loading={loading}
+      title="Unassigned"
+      account={account}
+      conversationIds={inboxes.all.unassigned}
+      messagesByConversation={messagesByConversation}
+      fetcher={API.fetchUnassignedConversations}
+      onRetrieveConversations={onSetConversations}
+      onSelectConversation={onSelectConversation}
+      onUpdateConversation={onUpdateConversation}
+      onDeleteConversation={onDeleteConversation}
+      onSendMessage={onSendMessage}
+    />
+  );
+};
+
+export default UnassignedConversations;

--- a/assets/src/components/conversations/UnreadConversations.tsx
+++ b/assets/src/components/conversations/UnreadConversations.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {useConversations} from './ConversationsProvider';
+import ConversationsDashboard from './ConversationsDashboard';
+import * as API from '../../api';
+
+const UnreadConversations = () => {
+  const {
+    loading,
+    currentUser,
+    account,
+    inboxes,
+    messagesByConversation = {},
+    onSetConversations,
+    onSelectConversation,
+    onUpdateConversation,
+    onDeleteConversation,
+    onSendMessage,
+  } = useConversations();
+
+  if (!currentUser) {
+    return null;
+  }
+
+  return (
+    <ConversationsDashboard
+      loading={loading}
+      title="All unread"
+      account={account}
+      conversationIds={inboxes.all.unread}
+      messagesByConversation={messagesByConversation}
+      fetcher={API.fetchUnreadConversations}
+      onRetrieveConversations={onSetConversations}
+      onSelectConversation={onSelectConversation}
+      onUpdateConversation={onUpdateConversation}
+      onDeleteConversation={onDeleteConversation}
+      onSendMessage={onSendMessage}
+    />
+  );
+};
+
+export default UnreadConversations;

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -21,6 +21,7 @@ defmodule ChatApi.Conversations do
     |> where([c], is_nil(c.archived_at))
     |> filter_by_tag(filters)
     |> filter_by_mention(filters)
+    |> filter_by_text(filters)
     |> order_by_most_recent_message()
     |> preload([
       :customer,
@@ -28,6 +29,19 @@ defmodule ChatApi.Conversations do
       messages: [:attachments, :customer, user: :profile]
     ])
     |> Repo.all()
+  end
+
+  @spec count_conversations_where(binary(), map()) :: [Conversation.t()]
+  def count_conversations_where(account_id, filters \\ %{}) do
+    Conversation
+    |> select([c], count(c.id, :distinct))
+    |> where(account_id: ^account_id)
+    |> where(^filter_where(filters))
+    |> where([c], is_nil(c.archived_at))
+    |> filter_by_tag(filters)
+    |> filter_by_mention(filters)
+    |> filter_by_text(filters)
+    |> Repo.one()
   end
 
   @spec list_conversations_by_account_paginated(binary(), map(), Keyword.t()) ::
@@ -43,6 +57,7 @@ defmodule ChatApi.Conversations do
     |> where([c], is_nil(c.archived_at))
     |> filter_by_tag(filters)
     |> filter_by_mention(filters)
+    |> filter_by_text(filters)
     |> order_by(desc: :last_activity_at, desc: :id)
     |> preload([
       :customer,
@@ -531,16 +546,53 @@ defmodule ChatApi.Conversations do
   def filter_by_tag(query, _filters), do: query
 
   @spec filter_by_mention(Ecto.Query.t(), map()) :: Ecto.Query.t()
-  def filter_by_mention(query, %{"mentioning" => user_id}) when not is_nil(user_id) do
-    # TODO: should we do a `distinct` query at the top level? we mainly do it here because conversations
-    # can have multiple `mentions` of the same person (i.e. multiple messages with the same mentioned user)
+  def filter_by_mention(query, %{"mentioning" => user_id, "has_seen_mention" => has_seen_mention})
+      when not is_nil(user_id) and has_seen_mention in ["true", true] do
     query
-    |> distinct([c], c.id)
-    |> join(:left, [c], m in assoc(c, :mentions), as: :mentions)
+    |> filter_by_mention(%{"mentioning" => user_id})
+    |> where([_c, mentions: m], not is_nil(m.seen_at))
+  end
+
+  def filter_by_mention(query, %{"mentioning" => user_id, "has_seen_mention" => has_seen_mention})
+      when not is_nil(user_id) and has_seen_mention in ["false", false] do
+    query
+    |> filter_by_mention(%{"mentioning" => user_id})
+    |> where([_c, mentions: m], is_nil(m.seen_at))
+  end
+
+  def filter_by_mention(query, %{"mentioning" => user_id}) when is_binary(user_id) do
+    case Integer.parse(user_id) do
+      {parsed, _} -> filter_by_mention(query, %{"mentioning" => parsed})
+      :error -> query
+    end
+  end
+
+  def filter_by_mention(query, %{"mentioning" => user_id}) when is_integer(user_id) do
+    query
+    |> join(
+      :left_lateral,
+      [c],
+      f in fragment(
+        "SELECT * FROM mentions WHERE conversation_id = ? LIMIT 1",
+        c.id
+      ),
+      as: :mentions
+    )
     |> where([c, mentions: m], m.user_id == ^user_id and m.conversation_id == c.id)
   end
 
   def filter_by_mention(query, _filters), do: query
+
+  @spec filter_by_text(Ecto.Query.t(), map()) :: Ecto.Query.t()
+  def filter_by_text(query, %{"q" => text}) when not is_nil(text) do
+    body = "%#{text}%"
+
+    query
+    |> join(:left, [c], m in assoc(c, :messages), as: :messages)
+    |> where([_c, messages: m], ilike(m.body, ^body))
+  end
+
+  def filter_by_text(query, _filters), do: query
 
   @spec mark_activity(String.t()) ::
           {:ok, Conversation.t()} | {:error, Ecto.Changeset.t()}
@@ -572,22 +624,34 @@ defmodule ChatApi.Conversations do
   defp filter_where(attrs) do
     Enum.reduce(attrs, dynamic(true), fn
       {"status", value}, dynamic ->
-        dynamic([p], ^dynamic and p.status == ^value)
+        dynamic([c], ^dynamic and c.status == ^value)
 
       {"priority", value}, dynamic ->
-        dynamic([p], ^dynamic and p.priority == ^value)
+        dynamic([c], ^dynamic and c.priority == ^value)
+
+      {"read", "true"}, dynamic ->
+        dynamic([c], ^dynamic and c.read == true)
+
+      {"read", "false"}, dynamic ->
+        dynamic([c], ^dynamic and c.read == false)
+
+      {"read", value}, dynamic ->
+        dynamic([p], ^dynamic and p.read == ^value)
+
+      {"assignee_id", missing}, dynamic when missing in [nil, ""] ->
+        dynamic([c], ^dynamic and is_nil(c.assignee_id))
 
       {"assignee_id", value}, dynamic ->
-        dynamic([p], ^dynamic and p.assignee_id == ^value)
+        dynamic([c], ^dynamic and c.assignee_id == ^value)
 
       {"customer_id", value}, dynamic ->
-        dynamic([p], ^dynamic and p.customer_id == ^value)
+        dynamic([c], ^dynamic and c.customer_id == ^value)
 
       {"account_id", value}, dynamic ->
-        dynamic([p], ^dynamic and p.account_id == ^value)
+        dynamic([c], ^dynamic and c.account_id == ^value)
 
       {"source", value}, dynamic ->
-        dynamic([p], ^dynamic and p.source == ^value)
+        dynamic([c], ^dynamic and c.source == ^value)
 
       {_, _}, dynamic ->
         # Not a where parameter

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -588,7 +588,16 @@ defmodule ChatApi.Conversations do
     body = "%#{text}%"
 
     query
-    |> join(:left, [c], m in assoc(c, :messages), as: :messages)
+    |> join(
+      :left_lateral,
+      [c],
+      f in fragment(
+        "SELECT body FROM messages WHERE conversation_id = ? AND body LIKE ? LIMIT 1",
+        c.id,
+        ^body
+      ),
+      as: :messages
+    )
     |> where([_c, messages: m], ilike(m.body, ^body))
   end
 

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -126,6 +126,7 @@ defmodule ChatApiWeb.Router do
     post("/payment_methods", PaymentMethodController, :create)
     get("/payment_methods", PaymentMethodController, :show)
     get("/browser_sessions/count", BrowserSessionController, :count)
+    get("/conversations/unread", ConversationController, :unread)
 
     resources("/users", UserController, only: [:index, :show, :delete])
     resources("/user_invitations", UserInvitationController, except: [:new, :edit])

--- a/priv/repo/migrations/20210729175737_add_slack_team_to_companies.exs
+++ b/priv/repo/migrations/20210729175737_add_slack_team_to_companies.exs
@@ -2,7 +2,7 @@ defmodule ChatApi.Repo.Migrations.AddSlackTeamToCompanies do
   use Ecto.Migration
   import Ecto.Query, warn: false
   require Logger
-  alias ChatApi.{Companies, Repo, SlackAuthorizations, SlackConversationThreads}
+  alias ChatApi.{Repo, SlackAuthorizations}
   alias ChatApi.Companies.Company
   alias ChatApi.SlackAuthorizations.SlackAuthorization
   alias ChatApi.SlackConversationThreads.SlackConversationThread


### PR DESCRIPTION
### Description

This PR adds:
- [x] Basic text search to conversations UI
- [x] New inboxes for "unread" and "unassigned" conversations
- [x] Fixes how we count unread messages with pagination (logic moved to server)

(Note that for this initial version, we're just using a `like` query)

### Issue

Related to https://github.com/papercups-io/papercups/issues/333

### Screenshots

![text-search-convo](https://user-images.githubusercontent.com/5264279/128368406-6bf4aa97-a7b3-4577-852d-3b6bdd1a676b.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
