### PR TITLE
Set Sentry user context for backend error events

### DIFF
--- a/lib/chat_api_web/channels/notification_channel.ex
+++ b/lib/chat_api_web/channels/notification_channel.ex
@@ -146,8 +146,14 @@ defmodule ChatApiWeb.NotificationChannel do
   @spec authorized?(any(), binary()) :: boolean()
   defp authorized?(socket, account_id) do
     with %{current_user: current_user} <- socket.assigns,
-         %{account_id: acct} <- current_user do
-      acct == account_id
+         %{id: user_id, account_id: current_account_id, email: email} <- current_user do
+      Sentry.Context.set_user_context(%{
+        id: user_id,
+        email: email,
+        account_id: current_account_id
+      })
+
+      current_account_id == account_id
     else
       _ -> false
     end

--- a/lib/chat_api_web/channels/user_socket.ex
+++ b/lib/chat_api_web/channels/user_socket.ex
@@ -51,6 +51,12 @@ defmodule ChatApiWeb.UserSocket do
 
     with {:ok, token} <- Pow.Plug.verify_token(conn, salt, signed_token, config),
          {user, _metadata} <- Pow.Store.CredentialsCache.get(store_config, token) do
+      Sentry.Context.set_user_context(%{
+        id: user.id,
+        email: user.email,
+        account_id: user.account_id
+      })
+
       user
     else
       _any -> nil


### PR DESCRIPTION
### Description

Sets Sentry user context for backend error events, so we can associate error events with users/accounts more easily.

### Screenshots

<img width="995" alt="Screen Shot 2021-08-05 at 2 54 36 PM" src="https://user-images.githubusercontent.com/5264279/128405653-d7d1db45-5ff5-442d-801c-0dd9609767a6.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
