### PR TITLE
Fix Slack file attachments

### DIFF
--- a/lib/chat_api/github/helpers.ex
+++ b/lib/chat_api/github/helpers.ex
@@ -8,7 +8,9 @@ defmodule ChatApi.Github.Helpers do
 
   @github_issue_regex ~r/https?:\/\/github\.com\/(?:[^\/\s]+\/)+(?:issues\/\d+)/
 
-  @spec extract_github_issue_links(binary()) :: [String.t()]
+  @spec extract_github_issue_links(binary() | nil) :: [String.t()]
+  def extract_github_issue_links(nil), do: []
+
   def extract_github_issue_links(str) do
     @github_issue_regex
     |> Regex.scan(str)

--- a/lib/chat_api/slack/event.ex
+++ b/lib/chat_api/slack/event.ex
@@ -47,6 +47,17 @@ defmodule ChatApi.Slack.Event do
     handle_event(event)
   end
 
+  def handle_payload(%{
+        "event" => event,
+        "team_id" => team,
+        "is_ext_shared_channel" => false
+      }) do
+    # If the "team" field is missing from the "event", add the payload "team_id"
+    event
+    |> Map.merge(%{"team" => team})
+    |> handle_event()
+  end
+
   def handle_payload(%{"event" => event}), do: handle_event(event)
   def handle_payload(_), do: nil
 

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -309,15 +309,6 @@ defmodule ChatApiWeb.SlackController do
     end
   end
 
-  @spec handle_webhook_event(map()) :: any()
-  defp handle_webhook_event(event) do
-    # TODO: figure out a better way to handle this in tests
-    case Application.get_env(:chat_api, :environment) do
-      :test -> Slack.Event.handle_event(event)
-      _ -> Task.start(fn -> Slack.Event.handle_event(event) end)
-    end
-  end
-
   # TODO: maybe it would make more sense to put these in the Slack.Notification module
   @spec send_private_channel_instructions(:reply | :support, binary()) :: any()
   defp send_private_channel_instructions(:reply, webhook_url) do

--- a/lib/chat_api_web/controllers/slack_controller.ex
+++ b/lib/chat_api_web/controllers/slack_controller.ex
@@ -198,12 +198,8 @@ defmodule ChatApiWeb.SlackController do
     Logger.debug("Payload from Slack webhook: #{inspect(payload)}")
 
     case payload do
-      %{"event" => _event, "is_ext_shared_channel" => true} ->
+      %{"event" => _event} ->
         handle_webhook_payload(payload)
-        send_resp(conn, 200, "")
-
-      %{"event" => event} ->
-        handle_webhook_event(event)
         send_resp(conn, 200, "")
 
       %{"challenge" => challenge} ->

--- a/test/chat_api/github_test.exs
+++ b/test/chat_api/github_test.exs
@@ -119,6 +119,7 @@ defmodule ChatApi.GithubTest do
 
   describe "helpers" do
     test "Github.Helpers.extract_github_issue_links/1 handles strings without GitHub issue links" do
+      assert [] = Github.Helpers.extract_github_issue_links(nil)
       assert [] = Github.Helpers.extract_github_issue_links("")
       assert [] = Github.Helpers.extract_github_issue_links("hello world")
 


### PR DESCRIPTION
### Description

Fix file attachments being sent through Slack

### Screenshots

**In dashboard:**
<img width="640" alt="Screen Shot 2021-08-10 at 9 28 07 AM" src="https://user-images.githubusercontent.com/5264279/128875460-97dc75be-8178-40ca-863a-760cd1303afb.png">

**In widget:**
<img width="400" alt="Screen Shot 2021-08-10 at 9 28 17 AM" src="https://user-images.githubusercontent.com/5264279/128875458-adc42b36-23d8-4db2-a102-d12b8c36058d.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
