### PR TITLE
Include message metadata in push notification for deep linking

### DIFF
--- a/lib/workers/send_push_notifications.ex
+++ b/lib/workers/send_push_notifications.ex
@@ -52,7 +52,8 @@ defmodule ChatApi.Workers.SendPushNotifications do
             "customer_id" => message.customer_id,
             "message_id" => message.id,
             "user_id" => message.user_id,
-            "inserted_at" => message.inserted_at
+            "inserted_at" => message.inserted_at,
+            "url" => "messages/#{message.conversation_id}"
           },
           # TODO: how should we handle this?
           badge:

--- a/lib/workers/send_push_notifications.ex
+++ b/lib/workers/send_push_notifications.ex
@@ -46,6 +46,14 @@ defmodule ChatApi.Workers.SendPushNotifications do
           to: user.settings.expo_push_token,
           title: format_notification_title(message),
           body: body,
+          data: %{
+            "account_id" => message.account_id,
+            "conversation_id" => message.conversation_id,
+            "customer_id" => message.customer_id,
+            "message_id" => message.id,
+            "user_id" => message.user_id,
+            "inserted_at" => message.inserted_at
+          },
           # TODO: how should we handle this?
           badge:
             Conversations.count_conversations_where(account_id, %{


### PR DESCRIPTION
### Description

Include message metadata in push notification for deep linking

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
