### PR TITLE
Include team ID in company Slack links when available

### DIFF
--- a/assets/src/components/companies/CompanyDetailsPage.tsx
+++ b/assets/src/components/companies/CompanyDetailsPage.tsx
@@ -9,6 +9,7 @@ import {sleep} from '../../utils';
 import Spinner from '../Spinner';
 import CustomersTableContainer from '../customers/CustomersTableContainer';
 import logger from '../../logger';
+import {generateSlackChannelUrl} from './support';
 
 const formatSlackChannel = (name: string) => {
   return name.startsWith('#') ? name : `#${name}`;
@@ -97,12 +98,11 @@ class CompanyDetailsPage extends React.Component<Props, State> {
       description,
       website_url: websiteUrl,
       external_id: externalId,
-      slack_channel_id: slackChannelId,
       slack_channel_name: slackChannelName,
-      slack_team_id: slackTeamId,
       slack_team_name: slackTeamName,
       id: companyId,
     } = company;
+    const slackChannelUrl = generateSlackChannelUrl(company);
 
     return (
       <Flex
@@ -184,16 +184,16 @@ class CompanyDetailsPage extends React.Component<Props, State> {
               </Box>
             </DetailsSectionCard>
 
-            {slackChannelId && slackChannelName && (
+            {slackChannelUrl && slackChannelName && (
               <DetailsSectionCard>
                 <Box>
                   <Text strong>Connected Slack Channel</Text>
                 </Box>
 
-                {slackTeamId && slackTeamName ? (
+                {slackTeamName ? (
                   <Text>
                     <a
-                      href={`https://slack.com/app_redirect?channel=${slackChannelId}&team=${slackTeamId}`}
+                      href={slackChannelUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
@@ -204,7 +204,7 @@ class CompanyDetailsPage extends React.Component<Props, State> {
                 ) : (
                   <Text>
                     <a
-                      href={`https://slack.com/app_redirect?channel=${slackChannelId}`}
+                      href={slackChannelUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                     >

--- a/assets/src/components/companies/support.ts
+++ b/assets/src/components/companies/support.ts
@@ -1,0 +1,16 @@
+import {Company} from '../../types';
+
+export const generateSlackChannelUrl = (company: Company) => {
+  const {
+    slack_channel_id: slackChannelId,
+    slack_team_id: slackTeamId,
+  } = company;
+
+  if (slackChannelId && slackTeamId) {
+    return `https://slack.com/app_redirect?channel=${slackChannelId}&team=${slackTeamId}`;
+  } else if (slackChannelId) {
+    return `https://slack.com/app_redirect?channel=${slackChannelId}`;
+  } else {
+    return null;
+  }
+};

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -41,6 +41,7 @@ import * as API from '../../api';
 import {Company, Conversation, Customer} from '../../types';
 import {download} from '../../utils';
 import logger from '../../logger';
+import {generateSlackChannelUrl} from '../companies/support';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -104,9 +105,9 @@ const CustomerCompanyDetails = ({customerId}: {customerId: string}) => {
     id: companyId,
     name = 'Unknown',
     website_url: websiteUrl,
-    slack_channel_id: slackChannelId,
     slack_channel_name: slackChannelName,
   } = company;
+  const slackChannelUrl = generateSlackChannelUrl(company);
 
   return (
     <DetailsSectionCard>
@@ -124,14 +125,10 @@ const CustomerCompanyDetails = ({customerId}: {customerId: string}) => {
           <LinkOutlined /> {websiteUrl || 'Unknown'}
         </Box>
       )}
-      {slackChannelId && slackChannelName && (
+      {slackChannelUrl && slackChannelName && (
         <Box mb={1}>
           <Image src="/slack.svg" alt="Slack" sx={{height: 16, mr: 1}} />
-          <a
-            href={`https://slack.com/app_redirect?channel=${slackChannelId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href={slackChannelUrl} target="_blank" rel="noopener noreferrer">
             {slackChannelName}
           </a>
         </Box>

--- a/assets/src/components/customers/CustomerDetailsSidebar.tsx
+++ b/assets/src/components/customers/CustomerDetailsSidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from '../icons';
 import {SidebarCustomerTags} from '../conversations/SidebarTagSection';
 import {BrowserSession, Company, Customer} from '../../types';
+import {generateSlackChannelUrl} from '../companies/support';
 
 // TODO: create date utility methods so we don't have to do this everywhere
 dayjs.extend(utc);
@@ -209,25 +210,9 @@ const CompanyDetailsSection = ({company}: {company?: Company}) => {
     id: companyId,
     name,
     website_url: websiteUrl,
-    slack_channel_id: slackChannelId,
     slack_channel_name: slackChannelName,
   } = company;
-
-  let slackPropertyValue;
-
-  if (slackChannelName && slackChannelId) {
-    slackPropertyValue = (
-      <a
-        href={`https://slack.com/app_redirect?channel=${slackChannelId}`}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {slackChannelName}
-      </a>
-    );
-  } else {
-    slackPropertyValue = <CustomerDetailsDefaultPropertyValue />;
-  }
+  const slackChannelUrl = generateSlackChannelUrl(company);
 
   return (
     <CustomerDetailsSection title={title}>
@@ -252,7 +237,15 @@ const CompanyDetailsSection = ({company}: {company?: Company}) => {
       <CustomerDetailsProperty
         icon={<LinkOutlined style={{color: colors.primary}} />}
         name="Slack Channel"
-        value={slackPropertyValue}
+        value={
+          slackChannelName && slackChannelUrl ? (
+            <a href={slackChannelUrl} target="_blank" rel="noopener noreferrer">
+              {slackChannelName}
+            </a>
+          ) : (
+            <CustomerDetailsDefaultPropertyValue />
+          )
+        }
       />
     </CustomerDetailsSection>
   );


### PR DESCRIPTION
### Description

Make Slack links more reliable by including team ID in query params when available.

### Issue

Related to #940 

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
