### PR TITLE
Improve how we format email messages in Slack

### DIFF
--- a/test/chat_api/slack_test.exs
+++ b/test/chat_api/slack_test.exs
@@ -345,6 +345,43 @@ defmodule ChatApi.SlackTest do
              end) =~ "Unrecognized message format"
     end
 
+    test "Helpers.get_message_text/1 handles email messages differently",
+         %{
+           account: account,
+           authorization: authorization,
+           customer: customer
+         } do
+      conversation =
+        insert(:conversation,
+          account: account,
+          customer: customer,
+          source: "email",
+          subject: "Test subject line"
+        )
+
+      message =
+        insert(:message,
+          account: account,
+          conversation: conversation,
+          customer: customer,
+          source: "email",
+          body: "Test email message"
+        )
+
+      assert Slack.Helpers.get_message_text(%{
+               conversation: conversation,
+               message: message,
+               authorization: authorization,
+               thread: nil
+             }) =~
+               """
+               > :email: From: *#{customer.email}*
+               > Subject: *Test subject line*
+
+               Test email message
+               """
+    end
+
     test "Helpers.get_message_payload/2 returns payload for initial slack thread",
          %{customer: customer, conversation: conversation, thread: thread} do
       text = "Hello world"


### PR DESCRIPTION
### Description

This PR improves how we format email messages in Slack

### Issue

Fixes https://github.com/papercups-io/papercups/issues/945

### Screenshots

**Before:**
<img width="664" alt="Screen Shot 2021-08-31 at 12 34 03 PM" src="https://user-images.githubusercontent.com/5264279/131541709-76d8538f-91f6-45c3-acf2-a27104666681.png">

**After:**
<img width="667" alt="Screen Shot 2021-08-31 at 12 33 54 PM" src="https://user-images.githubusercontent.com/5264279/131541738-a4281525-f464-45e8-8183-53c0d137e3d6.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
