### PR TITLE
Support for only sending email alerts on new conversations (i.e. first message only)

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -17,6 +17,7 @@ import {
   WidgetSettings,
   CannedResponse,
   SlackAuthorization,
+  UserSettings,
 } from './types';
 
 // TODO: handle this on the server instead
@@ -377,7 +378,9 @@ export const updateUserProfile = async (
     .then((res) => res.body.data);
 };
 
-export const fetchUserSettings = async (token = getAccessToken()) => {
+export const fetchUserSettings = async (
+  token = getAccessToken()
+): Promise<UserSettings> => {
   if (!token) {
     throw new Error('Invalid token!');
   }

--- a/assets/src/components/settings/UserProfile.tsx
+++ b/assets/src/components/settings/UserProfile.tsx
@@ -11,6 +11,7 @@ import {
   Divider,
   Input,
   Paragraph,
+  Text,
   Title,
 } from '../common';
 import * as API from '../../api';
@@ -24,6 +25,7 @@ type State = {
   displayName: string;
   profilePhotoUrl: string;
   shouldEmailOnNewMessages: boolean;
+  shouldEmailOnNewConversations: boolean;
   personalGmailAuthorization: any | null;
   isLoading: boolean;
   isEditing: boolean;
@@ -38,6 +40,7 @@ class UserProfile extends React.Component<Props, State> {
     displayName: '',
     profilePhotoUrl: '',
     shouldEmailOnNewMessages: false,
+    shouldEmailOnNewConversations: false,
     personalGmailAuthorization: null,
     isLoading: true,
     isEditing: false,
@@ -125,11 +128,13 @@ class UserProfile extends React.Component<Props, State> {
     if (settings) {
       this.setState({
         shouldEmailOnNewMessages: settings.email_alert_on_new_message,
+        shouldEmailOnNewConversations: settings.email_alert_on_new_conversation,
       });
     } else {
       // NB: this also handles resetting these values if the optimistic update fails
       this.setState({
         shouldEmailOnNewMessages: false,
+        shouldEmailOnNewConversations: false,
       });
     }
   };
@@ -192,7 +197,7 @@ class UserProfile extends React.Component<Props, State> {
       .then(() => this.setState({isEditing: false}));
   };
 
-  handleToggleEmailAlertSetting = async (e: any) => {
+  handleEmailAlertOnNewMessage = async (e: any) => {
     const shouldEmailOnNewMessages = e.target.checked;
 
     // Optimistic update
@@ -200,6 +205,21 @@ class UserProfile extends React.Component<Props, State> {
 
     return API.updateUserSettings({
       email_alert_on_new_message: shouldEmailOnNewMessages,
+    }).catch((err) => {
+      logger.error('Failed to update settings!', err);
+      // Reset if fails to actually update
+      return this.fetchLatestSettings();
+    });
+  };
+
+  handleEmailAlertOnNewConversation = async (e: any) => {
+    const shouldEmailOnNewConversations = e.target.checked;
+
+    // Optimistic update
+    this.setState({shouldEmailOnNewConversations});
+
+    return API.updateUserSettings({
+      email_alert_on_new_conversation: shouldEmailOnNewConversations,
     }).catch((err) => {
       logger.error('Failed to update settings!', err);
       // Reset if fails to actually update
@@ -220,6 +240,7 @@ class UserProfile extends React.Component<Props, State> {
       profilePhotoUrl,
       personalGmailAuthorization,
       shouldEmailOnNewMessages,
+      shouldEmailOnNewConversations,
       isEditing,
     } = this.state;
 
@@ -332,12 +353,28 @@ class UserProfile extends React.Component<Props, State> {
           </Paragraph>
         </Box>
 
-        <Checkbox
-          checked={shouldEmailOnNewMessages}
-          onChange={this.handleToggleEmailAlertSetting}
-        >
-          Send email alert on new messages
-        </Checkbox>
+        <Box mb={3}>
+          <Checkbox
+            checked={shouldEmailOnNewConversations}
+            onChange={this.handleEmailAlertOnNewConversation}
+          >
+            <Text>
+              Send email alert on <Text strong>new conversations</Text> (initial
+              message only)
+            </Text>
+          </Checkbox>
+        </Box>
+
+        <Box mb={3}>
+          <Checkbox
+            checked={shouldEmailOnNewMessages}
+            onChange={this.handleEmailAlertOnNewMessage}
+          >
+            <Text>
+              Send email alert on <Text strong>all new messages</Text>
+            </Text>
+          </Checkbox>
+        </Box>
 
         <Divider />
 

--- a/assets/src/types.ts
+++ b/assets/src/types.ts
@@ -37,6 +37,15 @@ export type User = {
   account_id: string;
 };
 
+export type UserSettings = {
+  id: string;
+  object: 'user_settings';
+  user_id: number;
+  email_alert_on_new_message: boolean;
+  email_alert_on_new_conversation: boolean;
+  expo_push_token?: string | null;
+};
+
 export type Customer = {
   id: string;
   email?: string;

--- a/lib/chat_api/conversations.ex
+++ b/lib/chat_api/conversations.ex
@@ -489,6 +489,9 @@ defmodule ChatApi.Conversations do
     end
   end
 
+  def is_first_message?(%Message{conversation_id: conversation_id, id: message_id}),
+    do: is_first_message?(conversation_id, message_id)
+
   @spec count_agent_replies(binary()) :: number()
   def count_agent_replies(conversation_id) do
     Message

--- a/lib/chat_api/users/user_settings.ex
+++ b/lib/chat_api/users/user_settings.ex
@@ -6,6 +6,7 @@ defmodule ChatApi.Users.UserSettings do
 
   @type t :: %__MODULE__{
           email_alert_on_new_message: boolean(),
+          email_alert_on_new_conversation: boolean(),
           expo_push_token: String.t() | nil,
           # Foreign keys
           user_id: integer(),
@@ -18,6 +19,7 @@ defmodule ChatApi.Users.UserSettings do
   @foreign_key_type :binary_id
   schema "user_settings" do
     field(:email_alert_on_new_message, :boolean, default: false)
+    field(:email_alert_on_new_conversation, :boolean, default: false)
     field(:expo_push_token, :string)
 
     belongs_to(:user, User, type: :integer)
@@ -28,7 +30,12 @@ defmodule ChatApi.Users.UserSettings do
   @doc false
   def changeset(user_settings, attrs) do
     user_settings
-    |> cast(attrs, [:user_id, :email_alert_on_new_message, :expo_push_token])
+    |> cast(attrs, [
+      :user_id,
+      :email_alert_on_new_message,
+      :email_alert_on_new_conversation,
+      :expo_push_token
+    ])
     |> validate_required([:user_id])
   end
 end

--- a/lib/chat_api_web/views/user_settings_view.ex
+++ b/lib/chat_api_web/views/user_settings_view.ex
@@ -16,6 +16,7 @@ defmodule ChatApiWeb.UserSettingsView do
       object: "user_settings",
       user_id: user_settings.user_id,
       email_alert_on_new_message: user_settings.email_alert_on_new_message,
+      email_alert_on_new_conversation: user_settings.email_alert_on_new_conversation,
       expo_push_token: user_settings.expo_push_token
     }
   end

--- a/priv/repo/migrations/20210901153347_add_email_alert_on_new_conversation_to_user_settings.exs
+++ b/priv/repo/migrations/20210901153347_add_email_alert_on_new_conversation_to_user_settings.exs
@@ -1,0 +1,9 @@
+defmodule ChatApi.Repo.Migrations.AddEmailAlertOnNewConversationToUserSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_settings) do
+      add(:email_alert_on_new_conversation, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
### Description

This PR adds basic support for only sending email alerts on new conversations (i.e. first message only).

### Issue

#951 

### Screenshots

<img width="680" alt="Screen Shot 2021-09-01 at 12 09 01 PM" src="https://user-images.githubusercontent.com/5264279/131705807-a4ad8037-16a5-41b0-9d22-1e6823fdff95.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
