### PR TITLE
Include SES received header in forwarding email addresses to check

### DIFF
--- a/lib/chat_api/forwarding_addresses.ex
+++ b/lib/chat_api/forwarding_addresses.ex
@@ -50,6 +50,24 @@ defmodule ChatApi.ForwardingAddresses do
     end
   end
 
+  @spec find_by_source_email(binary()) :: ForwardingAddress.t() | nil
+  def find_by_source_email(email) do
+    ForwardingAddress
+    |> where(source_email_address: ^email)
+    |> Repo.one()
+  end
+
+  @spec find_account_by_source_address(binary()) :: Account.t() | nil
+  def find_account_by_source_address(email) do
+    case find_by_source_email(email) do
+      %ForwardingAddress{account_id: account_id} ->
+        Accounts.get_account!(account_id)
+
+      nil ->
+        nil
+    end
+  end
+
   @spec create_forwarding_address(map()) ::
           {:ok, ForwardingAddress.t()} | {:error, Ecto.Changeset.t()}
   def create_forwarding_address(attrs \\ %{}) do

--- a/lib/chat_api_web/controllers/ses_controller.ex
+++ b/lib/chat_api_web/controllers/ses_controller.ex
@@ -16,7 +16,8 @@ defmodule ChatApiWeb.SesController do
       ses_message_id: ses_message_id,
       from_address: from_address,
       to_addresses: to_addresses,
-      forwarded_to: payload["forwarded_to"]
+      forwarded_to: payload["forwarded_to"],
+      received_by: parse_received_by_headers(payload)
     }
     |> ChatApi.Workers.ProcessSesEvent.new()
     |> Oban.insert()
@@ -30,4 +31,31 @@ defmodule ChatApiWeb.SesController do
 
     send_resp(conn, 200, "")
   end
+
+  @email_regex ~r/(?<user>[a-zA-Z0-9_.-]+)@(?<domain>[a-zA-Z0-9_.-]+\.[a-zA-Z0-9_.-]+)/
+
+  def parse_received_by_headers(headers) when is_list(headers) do
+    headers
+    |> Enum.filter(fn header ->
+      key = header |> Map.get("name", "") |> String.downcase()
+      value = header |> Map.get("value", "") |> String.downcase()
+
+      key == "received" && Regex.match?(@email_regex, value)
+    end)
+    |> Enum.map(fn header ->
+      value = header |> Map.get("value", "") |> String.downcase()
+
+      case Regex.scan(@email_regex, value) do
+        [[email | _]] -> email
+        _ -> nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  def parse_received_by_headers(%{"mail" => %{"headers" => headers}}),
+    do: parse_received_by_headers(headers)
+
+  def parse_received_by_headers(_), do: []
 end

--- a/test/workers/process_ses_event_test.exs
+++ b/test/workers/process_ses_event_test.exs
@@ -58,7 +58,8 @@ defmodule ChatApi.ProcessSesEventText do
             ses_message_id: "ses_message_id",
             from_address: "customer@example.co",
             to_addresses: ["support@me.com"],
-            forwarded_to: "company@chat.papercups.io"
+            forwarded_to: "company@chat.papercups.io",
+            received_by: []
           })
 
         message = ChatApi.Messages.get_message!(message.id)
@@ -117,7 +118,8 @@ defmodule ChatApi.ProcessSesEventText do
             ses_message_id: "ses_message_id",
             from_address: customer.email,
             to_addresses: ["reply+#{conversation.id}@chat.papercups.io"],
-            forwarded_to: nil
+            forwarded_to: nil,
+            received_by: []
           })
 
         message = ChatApi.Messages.get_message!(message.id)
@@ -135,7 +137,8 @@ defmodule ChatApi.ProcessSesEventText do
         ses_message_id: "ses_message_id",
         from_address: customer.email,
         to_addresses: ["random@chat.papercups.io"],
-        forwarded_to: nil
+        forwarded_to: nil,
+        received_by: []
       })
     end
   end


### PR DESCRIPTION
### Description

Include SES received header in forwarding email addresses to check (to fix bug with group forwarding)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
