### PR TITLE
Use sanitized email html if text body is null

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2876,6 +2876,15 @@
         "@types/react": "*"
       }
     },
+    "@types/sanitize-html": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.3.2.tgz",
+      "integrity": "sha512-DnmoXsiqG2/RoSf6/lD3Hrs+TCM8ILtzNuuSjmOtRaP/ud9Sy3M3ctwD+SB50EIDs5GzVFF1dJk2Fq/ID/PNCQ==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^6.0.0"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -6571,6 +6580,21 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        }
+      }
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
@@ -8746,6 +8770,44 @@
         }
       }
     },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        }
+      }
+    },
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -10325,6 +10387,11 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
+    },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -11514,6 +11581,11 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12248,6 +12320,11 @@
         "json-parse-better-errors": "^1.0.1",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "4.0.0",
@@ -15233,6 +15310,47 @@
         "walker": "~1.0.5"
       }
     },
+    "sanitize-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+          "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
     "sanitize.css": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
@@ -15812,6 +15930,11 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -17540,7 +17663,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/assets/package.json
+++ b/assets/package.json
@@ -53,6 +53,7 @@
     "remark-breaks": "^2.0.0",
     "rrweb": "^0.9.7",
     "rrweb-player": "^0.6.2",
+    "sanitize-html": "^2.4.0",
     "superagent": "^5.3.1",
     "theme-ui": "^0.3.1",
     "typescript": "~3.9.7"
@@ -99,6 +100,7 @@
   "proxy": "http://localhost:4000",
   "devDependencies": {
     "@types/jszip": "^3.4.1",
+    "@types/sanitize-html": "^2.3.2",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5"

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -103,9 +103,7 @@ const ChatMessageBox = ({
 
       {rawEmailHtml ? (
         // TODO: not sure the best way to handle this yet, but I think this is fine for now ¯\_(ツ)_/¯
-        <div
-          dangerouslySetInnerHTML={{__html: sanitizeHtml(rawEmailHtml)}}
-        ></div>
+        <div dangerouslySetInnerHTML={{__html: sanitizeHtml(rawEmailHtml)}} />
       ) : (
         <MarkdownRenderer className={className} source={body} />
       )}

--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import sanitizeHtml from 'sanitize-html';
+
 import {MarkdownRenderer, Text} from '../common';
 import {Attachment, Message, MessageSource} from '../../types';
 import {PaperClipOutlined} from '../icons';
@@ -70,7 +72,10 @@ const ChatMessageBox = ({
 }: Props) => {
   const {body, source, created_at, metadata = {}} = message;
   const createdAt = dayjs.utc(created_at).local().format('ddd, MMM D h:mm A');
+  // TODO: pull this from the conversation, or use the `message.subject` field instead
   const subject = metadata?.gmail_subject ?? metadata?.ses_subject ?? null;
+  // TODO: add a `content_type` field to messages, which can be `text` or `html`
+  const rawEmailHtml = metadata?.ses_html;
   const [formattedSource, sourceIcon] = getMessageSourceDetails(source);
   const parsedSx = Object.assign(sx, {
     px: 3,
@@ -96,7 +101,14 @@ const ChatMessageBox = ({
         </Box>
       )}
 
-      <MarkdownRenderer className={className} source={body} />
+      {rawEmailHtml ? (
+        // TODO: not sure the best way to handle this yet, but I think this is fine for now ¯\_(ツ)_/¯
+        <div
+          dangerouslySetInnerHTML={{__html: sanitizeHtml(rawEmailHtml)}}
+        ></div>
+      ) : (
+        <MarkdownRenderer className={className} source={body} />
+      )}
 
       {attachments && attachments.length > 0 && (
         <Box mt={2} className={className}>

--- a/lib/chat_api/aws.ex
+++ b/lib/chat_api/aws.ex
@@ -294,7 +294,13 @@ defmodule ChatApi.Aws do
       ses_in_reply_to: format_metadata_email_field(message.in_reply_to),
       ses_references: message.references
     }
+    |> maybe_merge_raw_html(message)
   end
+
+  def maybe_merge_raw_html(metadata, %{formatted_text: nil, html: html}) when is_binary(html),
+    do: Map.merge(metadata, %{ses_html: html})
+
+  def maybe_merge_raw_html(metadata, _), do: metadata
 
   # Lambda
 


### PR DESCRIPTION
### Description

Use sanitized email html if text body is null. Fixes some SES emails (e.g. Gmail verification) from showing up blank in the dashboard.

### Screenshots

<img width="874" alt="Screen Shot 2021-09-03 at 5 09 00 PM" src="https://user-images.githubusercontent.com/5264279/132065590-c1db20ef-cc36-466b-8b50-2ef4c1e62e38.png">

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
