### PR TITLE
Render image in dashboard

### DIFF
--- a/assets/src/components/conversations/ChatMessageBox.tsx
+++ b/assets/src/components/conversations/ChatMessageBox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import {MarkdownRenderer, Text} from '../common';
+import {colors, MarkdownRenderer, Text} from '../common';
 import {Attachment, Message, MessageSource} from '../../types';
 import {PaperClipOutlined} from '../icons';
 
@@ -36,20 +36,42 @@ const ChatMessageAttachment = ({
   color?: string;
 }) => {
   const {id, filename, file_url: fileUrl} = attachment;
+  const isImage =
+    filename.includes('.png') ||
+    filename.includes('jpeg') ||
+    filename.includes('.jpg');
 
   return (
-    <Box key={id}>
-      <PaperClipOutlined />{' '}
-      <a
-        href={fileUrl}
-        style={{
-          color,
-          textDecoration: 'underline',
-        }}
-      >
-        {filename}
-      </a>
-    </Box>
+    <Flex
+      sx={{
+        flexDirection: 'column',
+        backgroundColor: '#F5F5F5',
+        borderRadius: 3,
+      }}
+    >
+      {isImage && (
+        <img
+          src={fileUrl}
+          alt="display image"
+          style={{height: '100%', borderRadius: 3}}
+        />
+      )}
+      <Box>
+        <Flex pb={2} pt={2} pr={3}>
+          <a
+            href={fileUrl}
+            style={{
+              textDecoration: 'underline',
+              color: colors.primary,
+              backgroundColor: '#F5F5F5',
+              border: 'none',
+            }}
+          >
+            <PaperClipOutlined style={{color: '#7E7E7E'}} /> {filename}
+          </a>
+        </Flex>
+      </Box>
+    </Flex>
   );
 };
 
@@ -87,17 +109,60 @@ const ChatMessageBox = ({
   });
 
   return (
-    <Box sx={parsedSx}>
-      {subject && (
-        <Box pb={1} mb={2} sx={{borderBottom: '1px solid rgba(0,0,0,.06)'}}>
-          <Text className={className} type="secondary" style={{fontSize: 12}}>
-            {subject}
-          </Text>
+    <Box>
+      {body && (
+        <Box sx={parsedSx}>
+          {subject && (
+            <Box pb={1} mb={2} sx={{borderBottom: '1px solid rgba(0,0,0,.06)'}}>
+              <Text
+                className={className}
+                type="secondary"
+                style={{fontSize: 12}}
+              >
+                {subject}
+              </Text>
+            </Box>
+          )}
+          <MarkdownRenderer className={className} source={body} />
+
+          {formattedSource && (
+            <Flex
+              pt={1}
+              mt={2}
+              sx={{
+                borderTop: '1px solid rgba(0,0,0,.06)',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Text
+                className={className}
+                type="secondary"
+                style={{fontSize: 12, marginRight: 32}}
+              >
+                {createdAt}
+              </Text>
+
+              <Flex sx={{alignItems: 'center'}}>
+                {sourceIcon && (
+                  <img
+                    src={sourceIcon}
+                    alt={source}
+                    style={{height: 12, marginRight: 4}}
+                  />
+                )}
+                <Text
+                  className={className}
+                  type="secondary"
+                  style={{fontSize: 12}}
+                >
+                  Sent via {formattedSource}
+                </Text>
+              </Flex>
+            </Flex>
+          )}
         </Box>
       )}
-
-      <MarkdownRenderer className={className} source={body} />
-
       {attachments && attachments.length > 0 && (
         <Box mt={2} className={className}>
           {attachments.map((attachment) => {
@@ -110,39 +175,6 @@ const ChatMessageBox = ({
             );
           })}
         </Box>
-      )}
-
-      {formattedSource && (
-        <Flex
-          pt={1}
-          mt={2}
-          sx={{
-            borderTop: '1px solid rgba(0,0,0,.06)',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <Text
-            className={className}
-            type="secondary"
-            style={{fontSize: 12, marginRight: 32}}
-          >
-            {createdAt}
-          </Text>
-
-          <Flex sx={{alignItems: 'center'}}>
-            {sourceIcon && (
-              <img
-                src={sourceIcon}
-                alt={source}
-                style={{height: 12, marginRight: 4}}
-              />
-            )}
-            <Text className={className} type="secondary" style={{fontSize: 12}}>
-              Sent via {formattedSource}
-            </Text>
-          </Flex>
-        </Flex>
       )}
     </Box>
   );


### PR DESCRIPTION
### Description

- Removed empty text box when sending attachment without a message
- moved attachment outside of ChatMessage box to make it look better

### Screenshots
<img width="1437" alt="Screen Shot 2021-09-03 at 6 47 41 PM" src="https://user-images.githubusercontent.com/81601997/132072022-a2f6f4f4-f2d4-44ad-9a15-74c57bb52ebc.png">

<img width="1434" alt="Screen Shot 2021-09-03 at 6 48 25 PM" src="https://user-images.githubusercontent.com/81601997/132072055-42ee4a0d-0272-46dd-b65c-8dc3ea9ab26a.png">

_For frontend updates, please include a screenshot._

## Checklist

- [ x] Everything passes when running `mix test`
- [ x] Ran `mix format`
- [ x] No frontend compilation warnings
