### PR TITLE
Simplify dashboard nav for non-admin users

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -244,6 +244,7 @@ const Dashboard = (props: RouteComponentProps) => {
   const {unread} = useConversations();
   const [account, setAccount] = React.useState<Account | null>(null);
   const {currentUser} = auth;
+  const isAdminUser = currentUser?.role === 'admin';
 
   React.useEffect(() => {
     // TODO: figure out a better way to handle this
@@ -301,13 +302,16 @@ const Dashboard = (props: RouteComponentProps) => {
         <Flex sx={{flexDirection: 'column', height: '100%'}}>
           <Box py={3} sx={{flex: 1}}>
             <Menu selectedKeys={[section, key]} mode="inline" theme="dark">
-              <Menu.Item
-                key="getting-started"
-                icon={<GlobalOutlined />}
-                title="Getting started"
-              >
-                <Link to="/getting-started">Getting started</Link>
-              </Menu.Item>
+              {isAdminUser && (
+                <Menu.Item
+                  key="getting-started"
+                  icon={<GlobalOutlined />}
+                  title="Getting started"
+                >
+                  <Link to="/getting-started">Getting started</Link>
+                </Menu.Item>
+              )}
+
               <Menu.Item
                 danger={shouldHighlightInbox}
                 key="conversations"
@@ -317,13 +321,15 @@ const Dashboard = (props: RouteComponentProps) => {
                 <Link to="/conversations/all">Inbox ({totalNumUnread})</Link>
               </Menu.Item>
 
-              <Menu.Item
-                title="Integrations"
-                icon={<ApiOutlined />}
-                key="integrations"
-              >
-                <Link to="/integrations">Integrations</Link>
-              </Menu.Item>
+              {isAdminUser && (
+                <Menu.Item
+                  title="Integrations"
+                  icon={<ApiOutlined />}
+                  key="integrations"
+                >
+                  <Link to="/integrations">Integrations</Link>
+                </Menu.Item>
+              )}
 
               <Menu.SubMenu
                 key="customers"
@@ -355,63 +361,82 @@ const Dashboard = (props: RouteComponentProps) => {
                 <Link to="/reporting">Reporting</Link>
               </Menu.Item>
 
-              <Menu.SubMenu
-                key="developers"
-                icon={<CodeOutlined />}
-                title="Developers"
-              >
-                <Menu.Item key="personal-api-keys">
-                  <Link to="/developers/personal-api-keys">API keys</Link>
-                </Menu.Item>
-                <Menu.Item key="event-subscriptions">
-                  <Link to="/developers/event-subscriptions">
-                    Event subscriptions
-                  </Link>
-                </Menu.Item>
-                <Menu.Item key="functions">
-                  <Link to="/functions">Functions</Link>
-                </Menu.Item>
-              </Menu.SubMenu>
-
-              <Menu.SubMenu
-                key="sessions"
-                icon={<VideoCameraOutlined />}
-                title="Sessions"
-              >
-                <Menu.Item key="list">
-                  <Link to="/sessions/list">Live sessions</Link>
-                </Menu.Item>
-                <Menu.Item key="setup">
-                  <Link to="/sessions/setup">Set up Storytime</Link>
-                </Menu.Item>
-              </Menu.SubMenu>
-
-              <Menu.SubMenu
-                key="settings"
-                icon={<SettingOutlined />}
-                title="Settings"
-              >
-                <Menu.Item key="account">
-                  <Link to="/settings/account">Account</Link>
-                </Menu.Item>
-                <Menu.Item key="team">
-                  <Link to="/settings/team">My team</Link>
-                </Menu.Item>
-                <Menu.Item key="profile">
-                  <Link to="/settings/profile">My profile</Link>
-                </Menu.Item>
-                <Menu.Item key="inboxes" title="Inboxes">
-                  <Link to="/inboxes">Inboxes</Link>
-                </Menu.Item>
-                <Menu.Item key="saved-replies">
-                  <Link to="/settings/saved-replies">Saved replies</Link>
-                </Menu.Item>
-                {shouldDisplayBilling && (
-                  <Menu.Item key="billing">
-                    <Link to="/settings/billing">Billing</Link>
+              {isAdminUser && (
+                <Menu.SubMenu
+                  key="developers"
+                  icon={<CodeOutlined />}
+                  title="Developers"
+                >
+                  <Menu.Item key="personal-api-keys">
+                    <Link to="/developers/personal-api-keys">API keys</Link>
                   </Menu.Item>
-                )}
-              </Menu.SubMenu>
+                  <Menu.Item key="event-subscriptions">
+                    <Link to="/developers/event-subscriptions">
+                      Event subscriptions
+                    </Link>
+                  </Menu.Item>
+                  <Menu.Item key="functions">
+                    <Link to="/functions">Functions</Link>
+                  </Menu.Item>
+                </Menu.SubMenu>
+              )}
+
+              {isAdminUser && (
+                <Menu.SubMenu
+                  key="sessions"
+                  icon={<VideoCameraOutlined />}
+                  title="Sessions"
+                >
+                  <Menu.Item key="list">
+                    <Link to="/sessions/list">Live sessions</Link>
+                  </Menu.Item>
+                  <Menu.Item key="setup">
+                    <Link to="/sessions/setup">Set up Storytime</Link>
+                  </Menu.Item>
+                </Menu.SubMenu>
+              )}
+
+              {isAdminUser ? (
+                <Menu.SubMenu
+                  key="settings"
+                  icon={<SettingOutlined />}
+                  title="Settings"
+                >
+                  <Menu.Item key="account">
+                    <Link to="/settings/account">Account</Link>
+                  </Menu.Item>
+                  <Menu.Item key="team">
+                    <Link to="/settings/team">My team</Link>
+                  </Menu.Item>
+                  <Menu.Item key="profile">
+                    <Link to="/settings/profile">My profile</Link>
+                  </Menu.Item>
+                  <Menu.Item key="inboxes" title="Inboxes">
+                    <Link to="/inboxes">Inboxes</Link>
+                  </Menu.Item>
+                  <Menu.Item key="saved-replies">
+                    <Link to="/settings/saved-replies">Saved replies</Link>
+                  </Menu.Item>
+                  {shouldDisplayBilling && (
+                    <Menu.Item key="billing">
+                      <Link to="/settings/billing">Billing</Link>
+                    </Menu.Item>
+                  )}
+                </Menu.SubMenu>
+              ) : (
+                <Menu.SubMenu
+                  key="settings"
+                  icon={<SettingOutlined />}
+                  title="Settings"
+                >
+                  <Menu.Item key="profile">
+                    <Link to="/settings/profile">My profile</Link>
+                  </Menu.Item>
+                  <Menu.Item key="saved-replies">
+                    <Link to="/settings/saved-replies">Saved replies</Link>
+                  </Menu.Item>
+                </Menu.SubMenu>
+              )}
             </Menu>
           </Box>
 

--- a/assets/src/components/inboxes/InboxesDashboard.tsx
+++ b/assets/src/components/inboxes/InboxesDashboard.tsx
@@ -15,6 +15,7 @@ import {PlusOutlined, SettingOutlined} from '../icons';
 import {INBOXES_DASHBOARD_SIDER_WIDTH} from '../../utils';
 import * as API from '../../api';
 import {Inbox} from '../../types';
+import {useAuth} from '../auth/AuthProvider';
 import {useConversations} from '../conversations/ConversationsProvider';
 import ConversationsDashboard from '../conversations/ConversationsDashboard';
 import ChatWidgetSettings from '../settings/ChatWidgetSettings';
@@ -73,11 +74,13 @@ export const NewInboxModalMenuItem = ({
 
 const InboxesDashboard = (props: RouteComponentProps) => {
   const {pathname} = useLocation();
+  const {currentUser} = useAuth();
   const {unread} = useConversations();
   const [inboxes, setCustomInboxes] = React.useState<Array<Inbox>>([]);
 
   const [section, key] = getSectionKey(pathname);
   const totalNumUnread = unread.conversations.open || 0;
+  const isAdminUser = currentUser?.role === 'admin';
 
   React.useEffect(() => {
     API.fetchInboxes().then((inboxes) => setCustomInboxes(inboxes));
@@ -237,22 +240,26 @@ const InboxesDashboard = (props: RouteComponentProps) => {
                 })}
               </Menu.SubMenu>
 
-              <NewInboxModalMenuItem
-                key="add-inbox"
-                icon={<PlusOutlined />}
-                title="Add inbox"
-                onSuccess={handleInboxCreated}
-              >
-                Add inbox
-              </NewInboxModalMenuItem>
+              {isAdminUser && (
+                <NewInboxModalMenuItem
+                  key="add-inbox"
+                  icon={<PlusOutlined />}
+                  title="Add inbox"
+                  onSuccess={handleInboxCreated}
+                >
+                  Add inbox
+                </NewInboxModalMenuItem>
+              )}
 
-              <Menu.Item
-                key="inbox-settings"
-                icon={<SettingOutlined />}
-                title="Inbox settings"
-              >
-                <Link to="/inboxes">Configure inboxes</Link>
-              </Menu.Item>
+              {isAdminUser && (
+                <Menu.Item
+                  key="inbox-settings"
+                  icon={<SettingOutlined />}
+                  title="Inbox settings"
+                >
+                  <Link to="/inboxes">Configure inboxes</Link>
+                </Menu.Item>
+              )}
             </Menu>
           </Box>
         </Flex>


### PR DESCRIPTION
### Description

Non-admin users should not be touching integrations and other admin-level settings.

### Screenshots

**Simplified side nav**:
<img width="1361" alt="Screen Shot 2021-09-28 at 12 19 27 PM" src="https://user-images.githubusercontent.com/5264279/135126509-d79730b2-9278-442f-95fb-6757d183654c.png">


## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
