### PR TITLE
Set up HubSpot integration

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1081,6 +1081,30 @@ export const sendGmailNotification = async (
     .then((res) => res.body.data);
 };
 
+export const fetchHubspotAuthorization = async (token = getAccessToken()) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/hubspot/authorization`)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const deleteHubspotAuthorization = async (
+  authorizationId: string,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .delete(`/api/hubspot/authorizations/${authorizationId}`)
+    .set('Authorization', token);
+};
+
 export const fetchEventSubscriptions = async (token = getAccessToken()) => {
   if (!token) {
     throw new Error('Invalid token!');
@@ -1280,6 +1304,21 @@ export const authorizeGithubIntegration = async (
 
   return request
     .get(`/api/github/oauth`)
+    .query(query)
+    .set('Authorization', token)
+    .then((res) => res.body);
+};
+
+export const authorizeHubspotIntegration = async (
+  query: Record<string, any>,
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/hubspot/oauth`)
     .query(query)
     .set('Authorization', token)
     .then((res) => res.body);

--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -1092,6 +1092,45 @@ export const fetchHubspotAuthorization = async (token = getAccessToken()) => {
     .then((res) => res.body.data);
 };
 
+export const createHubspotContact = async (
+  params = {},
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .post(`/api/hubspot/contacts`)
+    .send(params)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const fetchHubspotContacts = async (
+  query = {},
+  token = getAccessToken()
+) => {
+  if (!token) {
+    throw new Error('Invalid token!');
+  }
+
+  return request
+    .get(`/api/hubspot/contacts`)
+    .query(query)
+    .set('Authorization', token)
+    .then((res) => res.body.data);
+};
+
+export const fetchHubspotContactByEmail = async (
+  email: string,
+  token = getAccessToken()
+) => {
+  return fetchHubspotContacts({email}, token).then(
+    ([result]) => result || null
+  );
+};
+
 export const deleteHubspotAuthorization = async (
   authorizationId: string,
   token = getAccessToken()

--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -66,6 +66,7 @@ import GoogleIntegrationDetails from './integrations/GoogleIntegrationDetails';
 import MattermostIntegrationDetails from './integrations/MattermostIntegrationDetails';
 import TwilioIntegrationDetails from './integrations/TwilioIntegrationDetails';
 import GithubIntegrationDetails from './integrations/GithubIntegrationDetails';
+import HubspotIntegrationDetails from './integrations/HubspotIntegrationDetails';
 import BillingOverview from './billing/BillingOverview';
 import CustomersPage from './customers/CustomersPage';
 import CustomerDetailsPage from './customers/CustomerDetailsPage';
@@ -544,6 +545,10 @@ const Dashboard = (props: RouteComponentProps) => {
           <Route
             path="/integrations/github"
             component={GithubIntegrationDetails}
+          />
+          <Route
+            path="/integrations/hubspot"
+            component={HubspotIntegrationDetails}
           />
           <Route path="/integrations/:type" component={IntegrationsOverview} />
           <Route path="/integrations" component={IntegrationsOverview} />

--- a/assets/src/components/conversations/ConversationDetailsSidebar.tsx
+++ b/assets/src/components/conversations/ConversationDetailsSidebar.tsx
@@ -80,6 +80,118 @@ const CustomerActiveSessions = ({customerId}: {customerId: string}) => {
   );
 };
 
+const CustomerHubspotInfo = ({customer}: {customer: Customer}) => {
+  const [status, setStatus] = React.useState<
+    'loading' | 'adding' | 'success' | 'error'
+  >('loading');
+  const [authorization, setHubspotAuthorization] = React.useState<any>(null);
+  const [hubspotContactInfo, setHubspotContactInfo] = React.useState<any>(null);
+  const {email} = customer;
+
+  React.useEffect(() => {
+    if (!email) {
+      return;
+    }
+
+    setStatus('loading');
+
+    API.fetchHubspotAuthorization()
+      .then((auth) => {
+        setHubspotAuthorization(auth);
+
+        if (auth) {
+          return API.fetchHubspotContactByEmail(email);
+        } else {
+          return null;
+        }
+      })
+      .then((contact) => setHubspotContactInfo(contact))
+      .catch((err) => logger.error('Error retrieving HubSpot contact:', err))
+      .then(() => setStatus('success'));
+  }, [email]);
+
+  function handleCreateHubspotContact() {
+    const {name, email, phone} = customer;
+
+    if (!email) {
+      return;
+    }
+
+    setStatus('adding');
+
+    const [firstName, lastName] = (name || '').split(' ');
+    const payload = {
+      email,
+      phone,
+      first_name: firstName,
+      last_name: lastName,
+    };
+
+    return API.createHubspotContact(payload)
+      .then((contact) => {
+        setHubspotContactInfo(contact);
+
+        const url = contact?.hubspot_profile_url;
+
+        notification.success({
+          message: `Successfully added to HubSpot.`,
+          description: url ? (
+            <Text>
+              Click{' '}
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                here
+              </a>{' '}
+              to view in HubSpot.
+            </Text>
+          ) : null,
+        });
+      })
+
+      .catch((err) =>
+        logger.error('Error creating/retrieving HubSpot contact:', err)
+      )
+      .then(() => setStatus('success'));
+  }
+
+  if (!email) {
+    return null;
+  }
+
+  const url = hubspotContactInfo?.hubspot_profile_url;
+
+  if (!url && !authorization) {
+    return null;
+  }
+
+  return (
+    <DetailsSectionCard>
+      <Flex mb={2} sx={{}}>
+        <img
+          src="/hubspot.svg"
+          alt="HubSpot"
+          style={{maxHeight: 20, maxWidth: 20, marginRight: 4}}
+        />
+
+        <Text strong>HubSpot</Text>
+      </Flex>
+      {url ? (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          <Button block>View HubSpot profile</Button>
+        </a>
+      ) : (
+        <Button
+          block
+          disabled={status === 'loading'}
+          loading={status === 'adding'}
+          onClick={handleCreateHubspotContact}
+        >
+          {status === 'loading' ? 'Loading...' : 'Add to HubSpot'}
+        </Button>
+      )}
+    </DetailsSectionCard>
+  );
+};
+
 const CustomerCompanyDetails = ({customerId}: {customerId: string}) => {
   const [loading, setLoading] = React.useState(false);
   const [company, setCompany] = React.useState<Company | null>(null);
@@ -341,6 +453,8 @@ export const CustomerDetails = ({
       </DetailsSectionCard>
 
       <CustomerCompanyDetails customerId={customerId} />
+
+      <CustomerHubspotInfo customer={customer} />
 
       <DetailsSectionCard>
         <Box mb={2}>

--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -65,8 +65,8 @@ class ConversationModal extends React.Component<Props> {
     const title = `Conversation with ${identifer}`;
     const href =
       status === 'closed'
-        ? `/conversations/closed?cid=${id}`
-        : `/conversations/all?cid=${id}`;
+        ? `/conversations/closed/${id}`
+        : `/conversations/all/${id}`;
 
     return (
       <Modal

--- a/assets/src/components/conversations/NotificationsProvider.tsx
+++ b/assets/src/components/conversations/NotificationsProvider.tsx
@@ -40,12 +40,9 @@ export const useNotifications = () => useContext(NotificationsContext);
 
 type Props = {
   socket: Socket;
-  // TODO: get ridof these?
   onNewMessage?: (message: Message) => void;
   onNewConversation?: (id: string) => void;
   onConversationUpdated?: (id: string, updates: Partial<Conversation>) => void;
-  // onPresenceInit?: (presence: PhoenixPresence) => void;
-  // onPresenceDiff?: (diff: PresenceDiff) => void;
 } & React.PropsWithChildren<{}>;
 type State = {
   presence: PhoenixPresence | null;

--- a/assets/src/components/conversations/RelatedCustomerConversations.tsx
+++ b/assets/src/components/conversations/RelatedCustomerConversations.tsx
@@ -44,8 +44,8 @@ const RelatedConversationItem = ({
   const color = customerId ? getColorByUuid(customerId) : colors.gray[0];
   const isOpen = status === 'open';
   const url = isOpen
-    ? `/conversations/all?cid=${id}`
-    : `/conversations/closed?cid=${id}`;
+    ? `/conversations/all/${id}`
+    : `/conversations/closed/${id}`;
 
   return (
     <a key={id} className="RelatedCustomerConversation--link" href={url}>

--- a/assets/src/components/customers/CustomerDetailsPage.tsx
+++ b/assets/src/components/customers/CustomerDetailsPage.tsx
@@ -95,8 +95,8 @@ class CustomerDetailsPage extends React.Component<Props, State> {
     );
     const isClosed = conversation && conversation.status === 'closed';
     const url = isClosed
-      ? `/conversations/closed?cid=${conversationId}`
-      : `/conversations/all?cid=${conversationId}`;
+      ? `/conversations/closed/${conversationId}`
+      : `/conversations/all/${conversationId}`;
 
     this.props.history.push(url);
   };

--- a/assets/src/components/customers/CustomersTable.tsx
+++ b/assets/src/components/customers/CustomersTable.tsx
@@ -41,9 +41,7 @@ const CustomerActionsDropdown = ({customer}: {customer: Customer}) => {
                 description: (
                   <Text>
                     Click{' '}
-                    <a href={`/conversations/all?cid=${conversation.id}`}>
-                      here
-                    </a>{' '}
+                    <a href={`/conversations/all/${conversation.id}`}>here</a>{' '}
                     to view the conversation.
                   </Text>
                 ),

--- a/assets/src/components/integrations/HubspotAuthorizationButton.tsx
+++ b/assets/src/components/integrations/HubspotAuthorizationButton.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {Box, Flex} from 'theme-ui';
+import {Button, Popconfirm} from '../common';
+
+// const HUBSPOT_CLIENT_ID = '01ec4478-4828-43b5-b505-38f517856add';
+// const HUBSPOT_REDIRECT_URI = 'http://localhost:3000/integrations/hubspot';
+// const HUBSPOT_OAUTH_URL = `https://app.hubspot.com/oauth/authorize?client_id=${HUBSPOT_CLIENT_ID}&redirect_uri=${HUBSPOT_REDIRECT_URI}&scope=contacts%20content`;
+const HUBSPOT_OAUTH_URL =
+  'https://app.hubspot.com/oauth/authorize?client_id=01ec4478-4828-43b5-b505-38f517856add&redirect_uri=http://localhost:3000/integrations/hubspot&scope=contacts%20content';
+
+export const HubspotAuthorizationButton = ({
+  isConnected,
+  authorizationId,
+  onDisconnect,
+}: {
+  isConnected?: boolean;
+  authorizationId?: string | null;
+  onDisconnect: (id: string) => void;
+}) => {
+  return (
+    <>
+      {authorizationId && isConnected ? (
+        <Flex mx={-1}>
+          <Box mx={1}>
+            <a
+              href={HUBSPOT_OAUTH_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button>Reconnect</Button>
+            </a>
+          </Box>
+          <Box mx={1}>
+            <Popconfirm
+              title="Are you sure you want to disconnect from Hubspot?"
+              okText="Yes"
+              cancelText="No"
+              placement="topLeft"
+              onConfirm={() => onDisconnect(authorizationId)}
+            >
+              <Button danger>Disconnect</Button>
+            </Popconfirm>
+          </Box>
+        </Flex>
+      ) : (
+        <a href={HUBSPOT_OAUTH_URL} target="_blank" rel="noopener noreferrer">
+          <Button>Connect</Button>
+        </a>
+      )}
+    </>
+  );
+};
+
+export default HubspotAuthorizationButton;

--- a/assets/src/components/integrations/HubspotAuthorizationButton.tsx
+++ b/assets/src/components/integrations/HubspotAuthorizationButton.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import {Box, Flex} from 'theme-ui';
 import {Button, Popconfirm} from '../common';
-
-// const HUBSPOT_CLIENT_ID = '01ec4478-4828-43b5-b505-38f517856add';
-// const HUBSPOT_REDIRECT_URI = 'http://localhost:3000/integrations/hubspot';
-// const HUBSPOT_OAUTH_URL = `https://app.hubspot.com/oauth/authorize?client_id=${HUBSPOT_CLIENT_ID}&redirect_uri=${HUBSPOT_REDIRECT_URI}&scope=contacts%20content`;
-const HUBSPOT_OAUTH_URL =
-  'https://app.hubspot.com/oauth/authorize?client_id=01ec4478-4828-43b5-b505-38f517856add&redirect_uri=http://localhost:3000/integrations/hubspot&scope=contacts%20content';
+import {getHubspotAuthUrl} from './support';
 
 export const HubspotAuthorizationButton = ({
   isConnected,
@@ -17,16 +12,14 @@ export const HubspotAuthorizationButton = ({
   authorizationId?: string | null;
   onDisconnect: (id: string) => void;
 }) => {
+  const url = getHubspotAuthUrl();
+
   return (
     <>
       {authorizationId && isConnected ? (
         <Flex mx={-1}>
           <Box mx={1}>
-            <a
-              href={HUBSPOT_OAUTH_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={url} target="_blank" rel="noopener noreferrer">
               <Button>Reconnect</Button>
             </a>
           </Box>
@@ -43,7 +36,7 @@ export const HubspotAuthorizationButton = ({
           </Box>
         </Flex>
       ) : (
-        <a href={HUBSPOT_OAUTH_URL} target="_blank" rel="noopener noreferrer">
+        <a href={url} target="_blank" rel="noopener noreferrer">
           <Button>Connect</Button>
         </a>
       )}

--- a/assets/src/components/integrations/HubspotIntegrationDetails.tsx
+++ b/assets/src/components/integrations/HubspotIntegrationDetails.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import {RouteComponentProps} from 'react-router';
+import {Link} from 'react-router-dom';
+import {Box, Flex} from 'theme-ui';
+import qs from 'query-string';
+
+import {
+  notification,
+  Button,
+  Card,
+  Container,
+  Divider,
+  Paragraph,
+  Tag,
+  Text,
+  Title,
+} from '../common';
+import {ArrowLeftOutlined, CheckCircleOutlined} from '../icons';
+import * as API from '../../api';
+import logger from '../../logger';
+import HubspotAuthorizationButton from './HubspotAuthorizationButton';
+import Spinner from '../Spinner';
+import {Account} from '../../types';
+
+type Props = RouteComponentProps<{}>;
+type State = {
+  status: 'loading' | 'success' | 'error';
+  account: Account | null;
+  authorization: any | null;
+  error: any;
+};
+
+class HubspotIntegrationDetails extends React.Component<Props, State> {
+  state: State = {
+    status: 'loading',
+    account: null,
+    authorization: null,
+    error: null,
+  };
+
+  async componentDidMount() {
+    try {
+      const {location, history} = this.props;
+      const {search} = location;
+      const q = qs.parse(search);
+      const code = q.code ? String(q.code) : null;
+
+      if (code) {
+        await this.authorize(code);
+
+        history.push(`/integrations/hubspot`);
+      }
+
+      this.fetchHubspotAuthorization();
+    } catch (error) {
+      logger.error(error);
+
+      this.setState({status: 'error', error});
+    }
+  }
+
+  fetchHubspotAuthorization = async () => {
+    try {
+      const account = await API.fetchAccountInfo();
+      const auth = await API.fetchHubspotAuthorization();
+
+      this.setState({
+        account,
+        authorization: auth,
+        status: 'success',
+      });
+    } catch (error) {
+      logger.error(error);
+
+      this.setState({status: 'error', error});
+    }
+  };
+
+  authorize = async (code: string | null) => {
+    if (!code) {
+      return null;
+    }
+
+    return API.authorizeHubspotIntegration({code})
+      .then((result) =>
+        logger.debug('Successfully authorized Hubspot:', result)
+      )
+      .catch((err) => {
+        logger.error('Failed to authorize Hubspot:', err);
+
+        const description =
+          err?.response?.body?.error?.message || err?.message || String(err);
+
+        notification.error({
+          message: 'Failed to authorize Hubspot',
+          duration: null,
+          description,
+        });
+      });
+  };
+
+  disconnect = () => {
+    const {authorization} = this.state;
+    const authorizationId = authorization?.id;
+
+    if (!authorizationId) {
+      return null;
+    }
+
+    return API.deleteHubspotAuthorization(authorizationId)
+      .then(() => this.fetchHubspotAuthorization())
+      .catch((err) =>
+        logger.error('Failed to remove Hubspot authorization:', err)
+      );
+  };
+
+  render() {
+    const {authorization, status} = this.state;
+
+    if (status === 'loading') {
+      return (
+        <Flex
+          sx={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}
+        >
+          <Spinner size={40} />
+        </Flex>
+      );
+    }
+
+    const hasAuthorization = !!(authorization && authorization.id);
+
+    return (
+      <Container sx={{maxWidth: 720}}>
+        <Box mb={4}>
+          <Link to="/integrations">
+            <Button icon={<ArrowLeftOutlined />}>Back to integrations</Button>
+          </Link>
+        </Box>
+
+        <Box mb={4}>
+          <Title level={3}>HubSpot</Title>
+
+          <Paragraph>
+            <Text>Sync and view customer data from HubSpot.</Text>
+          </Paragraph>
+        </Box>
+
+        <Box mb={4}>
+          <Card sx={{p: 3}}>
+            <Paragraph>
+              <Flex sx={{alignItems: 'center'}}>
+                <img src="/hubspot.svg" alt="HubSpot" style={{height: 20}} />
+                <Text strong style={{marginLeft: 8}}>
+                  How does it work?
+                </Text>
+              </Flex>
+            </Paragraph>
+
+            <Text type="secondary">
+              When you link Papercups with HubSpot, you can easily view and sync
+              data with your customers in HubSpot.
+            </Text>
+          </Card>
+        </Box>
+
+        <Divider />
+
+        <Box mb={4}>
+          <Card sx={{p: 3}}>
+            <Flex sx={{justifyContent: 'space-between'}}>
+              <Flex sx={{alignItems: 'center'}}>
+                <img src="/hubspot.svg" alt="HubSpot" style={{height: 20}} />
+                <Text strong style={{marginLeft: 8, marginRight: 8}}>
+                  HubSpot
+                </Text>
+                {hasAuthorization && (
+                  <Tag icon={<CheckCircleOutlined />} color="success">
+                    connected
+                  </Tag>
+                )}
+              </Flex>
+
+              <HubspotAuthorizationButton
+                authorizationId={authorization?.id}
+                isConnected={hasAuthorization}
+                onDisconnect={this.disconnect}
+              />
+            </Flex>
+          </Card>
+        </Box>
+      </Container>
+    );
+  }
+}
+
+export default HubspotIntegrationDetails;

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -270,13 +270,16 @@ class IntegrationsOverview extends React.Component<Props, State> {
   };
 
   fetchHubSpotIntegration = async (): Promise<IntegrationType> => {
+    const auth = await API.fetchHubspotAuthorization();
+
     return {
       key: 'hubspot',
       integration: 'HubSpot',
-      status: 'not_connected',
-      createdAt: null,
-      authorizationId: null,
+      status: auth ? 'connected' : 'not_connected',
+      createdAt: auth ? auth.created_at : null,
+      authorizationId: auth ? auth.id : null,
       icon: '/hubspot.svg',
+      description: 'View and sync customer data from HubSpot',
     };
   };
 

--- a/assets/src/components/integrations/IntegrationsTable.tsx
+++ b/assets/src/components/integrations/IntegrationsTable.tsx
@@ -101,6 +101,17 @@ const IntegrationsTable = ({
               </Link>
             );
 
+          case 'hubspot':
+            return (
+              <Link to="/integrations/hubspot">
+                {isConnected ? (
+                  <Button icon={<SettingOutlined />}>Configure</Button>
+                ) : (
+                  <Button icon={<PlusOutlined />}>Add</Button>
+                )}
+              </Link>
+            );
+
           default:
             return isChatAvailable ? (
               <Button onClick={Papercups.toggle}>Chat with us!</Button>

--- a/assets/src/components/integrations/support.ts
+++ b/assets/src/components/integrations/support.ts
@@ -1,5 +1,5 @@
 import qs from 'query-string';
-import {SLACK_CLIENT_ID, isDev} from '../../config';
+import {SLACK_CLIENT_ID, HUBSPOT_CLIENT_ID, isDev} from '../../config';
 import {GoogleIntegrationParams} from '../../types';
 
 export type IntegrationType = {
@@ -97,3 +97,15 @@ export const getGoogleAuthUrl = ({
 
 // Both Google and Slack auth states are handled the same for now
 export const parseGoogleAuthState = parseSlackAuthState;
+
+export const getHubspotRedirectUrl = () => {
+  const origin = window.location.origin;
+
+  return `${origin}/integrations/hubspot`;
+};
+
+export const getHubspotAuthUrl = () => {
+  const redirect = getHubspotRedirectUrl();
+
+  return `https://app.hubspot.com/oauth/authorize?client_id=${HUBSPOT_CLIENT_ID}&redirect_uri=${redirect}&scope=contacts%20content`;
+};

--- a/assets/src/components/tags/TagDetailsPage.tsx
+++ b/assets/src/components/tags/TagDetailsPage.tsx
@@ -120,8 +120,8 @@ class TagDetailsPage extends React.Component<Props, State> {
     );
     const isClosed = conversation && conversation.status === 'closed';
     const url = isClosed
-      ? `/conversations/closed?cid=${conversationId}`
-      : `/conversations/all?cid=${conversationId}`;
+      ? `/conversations/closed/${conversationId}`
+      : `/conversations/all/${conversationId}`;
 
     this.props.history.push(url);
   };

--- a/assets/src/config.ts
+++ b/assets/src/config.ts
@@ -45,3 +45,7 @@ export const SLACK_CLIENT_ID =
   env.REACT_APP_SLACK_CLIENT_ID || '1192316529232.1250363411891';
 
 export const GITHUB_APP_NAME = env.REACT_APP_GITHUB_APP_NAME || 'papercups-io';
+
+// Defaults to Papercups client ID (it's ok for this value to be public)
+export const HUBSPOT_CLIENT_ID =
+  env.REACT_APP_HUBSPOT_CLIENT_ID || '01ec4478-4828-43b5-b505-38f517856add';

--- a/lib/chat_api/emails/email.ex
+++ b/lib/chat_api/emails/email.ex
@@ -215,7 +215,7 @@ defmodule ChatApi.Emails.Email do
   # TODO: figure out a better way to create templates for these
   defp mention_notification_text(messages, from: from, to: _user, company: company) do
     conversation_id = messages |> List.first() |> Map.get(:conversation_id)
-    dashboard_link = "#{get_app_domain()}/conversations/mentions?cid=#{conversation_id}"
+    dashboard_link = "#{get_app_domain()}/conversations/mentions/#{conversation_id}"
 
     """
     Hi there!
@@ -237,7 +237,7 @@ defmodule ChatApi.Emails.Email do
 
   defp mention_notification_html(messages, from: from, to: _user, company: company) do
     conversation_id = messages |> List.first() |> Map.get(:conversation_id)
-    dashboard_link = "#{get_app_domain()}/conversations/mentions?cid=#{conversation_id}"
+    dashboard_link = "#{get_app_domain()}/conversations/mentions/#{conversation_id}"
 
     """
     <p>Hi there!</p>

--- a/lib/chat_api/hubspot.ex
+++ b/lib/chat_api/hubspot.ex
@@ -4,8 +4,7 @@ defmodule ChatApi.Hubspot do
   """
 
   import Ecto.Query, warn: false
-  alias ChatApi.Repo
-
+  alias ChatApi.{Hubspot, Repo}
   alias ChatApi.Hubspot.HubspotAuthorization
 
   @spec list_hubspot_authorizations() :: [HubspotAuthorization.t()]
@@ -77,6 +76,42 @@ defmodule ChatApi.Hubspot do
     |> order_by(desc: :inserted_at)
     |> first()
     |> Repo.one()
+  end
+
+  @spec is_authorization_expired?(HubspotAuthorization.t()) :: boolean()
+  def is_authorization_expired?(%HubspotAuthorization{expires_at: expires_at}) do
+    # If less than 10 mins until expiry, consider authorization expired
+    DateTime.diff(expires_at, DateTime.utc_now()) < 60 * 10
+  end
+
+  @spec refresh_authorization(HubspotAuthorization.t()) ::
+          {:ok, HubspotAuthorization.t()} | {:error, any}
+  def refresh_authorization(%HubspotAuthorization{} = authorization) do
+    # TODO: what's the best way to handle errors here?
+    case Hubspot.Client.refresh_auth_tokens(authorization.refresh_token) do
+      {:ok,
+       %{
+         status: 200,
+         body: %{
+           "access_token" => access_token,
+           "refresh_token" => refresh_token,
+           "expires_in" => expires_in,
+           "token_type" => token_type
+         }
+       }} ->
+        update_hubspot_authorization(authorization, %{
+          access_token: access_token,
+          refresh_token: refresh_token,
+          token_type: token_type,
+          expires_at: DateTime.utc_now() |> DateTime.add(expires_in)
+        })
+
+      {:ok, result} ->
+        {:error, result}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   defp filter_authorizations_where(params) do

--- a/lib/chat_api/hubspot.ex
+++ b/lib/chat_api/hubspot.ex
@@ -1,0 +1,98 @@
+defmodule ChatApi.Hubspot do
+  @moduledoc """
+  The Hubspot context.
+  """
+
+  import Ecto.Query, warn: false
+  alias ChatApi.Repo
+
+  alias ChatApi.Hubspot.HubspotAuthorization
+
+  @spec list_hubspot_authorizations() :: [HubspotAuthorization.t()]
+  def list_hubspot_authorizations() do
+    Repo.all(HubspotAuthorization)
+  end
+
+  @spec get_hubspot_authorization!(binary()) :: HubspotAuthorization.t()
+  def get_hubspot_authorization!(id), do: Repo.get!(HubspotAuthorization, id)
+
+  @spec create_hubspot_authorization(map()) ::
+          {:ok, HubspotAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def create_hubspot_authorization(attrs \\ %{}) do
+    %HubspotAuthorization{}
+    |> HubspotAuthorization.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @spec update_hubspot_authorization(HubspotAuthorization.t(), map()) ::
+          {:ok, HubspotAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def update_hubspot_authorization(
+        %HubspotAuthorization{} = hubspot_authorization,
+        attrs
+      ) do
+    hubspot_authorization
+    |> HubspotAuthorization.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec create_or_update_authorization(map()) ::
+          {:ok, HubspotAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def create_or_update_authorization(%{account_id: account_id} = attrs) do
+    case get_authorization_by_account(account_id) do
+      %HubspotAuthorization{} = authorization ->
+        update_hubspot_authorization(authorization, attrs)
+
+      nil ->
+        create_hubspot_authorization(attrs)
+    end
+  end
+
+  @spec delete_hubspot_authorization(HubspotAuthorization.t()) ::
+          {:ok, HubspotAuthorization.t()} | {:error, Ecto.Changeset.t()}
+  def delete_hubspot_authorization(%HubspotAuthorization{} = hubspot_authorization) do
+    Repo.delete(hubspot_authorization)
+  end
+
+  @spec change_hubspot_authorization(HubspotAuthorization.t(), map()) :: Ecto.Changeset.t()
+  def change_hubspot_authorization(
+        %HubspotAuthorization{} = hubspot_authorization,
+        attrs \\ %{}
+      ) do
+    HubspotAuthorization.changeset(hubspot_authorization, attrs)
+  end
+
+  @spec get_authorization_by_account(binary(), map()) :: HubspotAuthorization.t() | nil
+  def get_authorization_by_account(account_id, _filters \\ %{}) do
+    HubspotAuthorization
+    |> where(account_id: ^account_id)
+    |> order_by(desc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
+  @spec find_hubspot_authorization(map()) :: HubspotAuthorization.t() | nil
+  def find_hubspot_authorization(filters \\ %{}) do
+    HubspotAuthorization
+    |> where(^filter_authorizations_where(filters))
+    |> order_by(desc: :inserted_at)
+    |> first()
+    |> Repo.one()
+  end
+
+  defp filter_authorizations_where(params) do
+    Enum.reduce(params, dynamic(true), fn
+      {:account_id, value}, dynamic ->
+        dynamic([r], ^dynamic and r.account_id == ^value)
+
+      {:scope, value}, dynamic ->
+        dynamic([r], ^dynamic and r.scope == ^value)
+
+      {:token_type, value}, dynamic ->
+        dynamic([r], ^dynamic and r.token_type == ^value)
+
+      {_, _}, dynamic ->
+        # Not a where parameter
+        dynamic
+    end)
+  end
+end

--- a/lib/chat_api/hubspot/client.ex
+++ b/lib/chat_api/hubspot/client.ex
@@ -17,6 +17,7 @@ defmodule ChatApi.Hubspot.Client do
   plug(Tesla.Middleware.Logger)
 
   # TODO: determine whether v1 or v3 API is more reliable/feature-rich
+  # (May need to use a combination of the two until v3 has everything we need)
 
   @spec list_contacts_v1(binary(), keyword()) :: {:error, any()} | {:ok, Tesla.Env.t()}
   def list_contacts_v1(access_token, query \\ [count: 100]) do
@@ -38,7 +39,17 @@ defmodule ChatApi.Hubspot.Client do
     )
   end
 
-  @spec retrieve_contact(binary, any, any) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  @spec list_companies(binary(), keyword()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def list_companies(access_token, query \\ [limit: 100]) do
+    get("/crm/v3/objects/companies",
+      query: query,
+      headers: [
+        {"Authorization", "Bearer " <> access_token}
+      ]
+    )
+  end
+
+  @spec retrieve_contact(binary(), any, any()) :: {:error, any()} | {:ok, Tesla.Env.t()}
   def retrieve_contact(access_token, contact_id, query \\ []) do
     get("/crm/v3/objects/contacts/#{contact_id}",
       query: query,
@@ -91,6 +102,16 @@ defmodule ChatApi.Hubspot.Client do
     )
   end
 
+  @spec retrieve_account_details(binary()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def retrieve_account_details(access_token) do
+    get("/integrations/v1/me",
+      query: [access_token: access_token],
+      headers: [
+        {"Authorization", "Bearer " <> access_token}
+      ]
+    )
+  end
+
   @spec refresh_auth_tokens(binary()) :: {:error, any()} | {:ok, Tesla.Env.t()}
   def refresh_auth_tokens(refresh_token) do
     create_auth_tokens(%{
@@ -129,6 +150,15 @@ defmodule ChatApi.Hubspot.Client do
         "client_id" => client_id,
         "client_secret" => client_secret
       })
+    )
+  end
+
+  @spec retrieve_token_info(binary()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def retrieve_token_info(access_token) do
+    get("/oauth/v1/access-tokens/#{access_token}",
+      headers: [
+        {"Authorization", "Bearer " <> access_token}
+      ]
     )
   end
 end

--- a/lib/chat_api/hubspot/client.ex
+++ b/lib/chat_api/hubspot/client.ex
@@ -49,7 +49,7 @@ defmodule ChatApi.Hubspot.Client do
     )
   end
 
-  @spec retrieve_contact(binary(), any, any()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  @spec retrieve_contact(binary(), binary(), any()) :: {:error, any()} | {:ok, Tesla.Env.t()}
   def retrieve_contact(access_token, contact_id, query \\ []) do
     get("/crm/v3/objects/contacts/#{contact_id}",
       query: query,

--- a/lib/chat_api/hubspot/client.ex
+++ b/lib/chat_api/hubspot/client.ex
@@ -216,13 +216,9 @@ defmodule ChatApi.Hubspot.Client do
   def get_authorization_token(%HubspotAuthorization{} = authorization) do
     with true <- Hubspot.is_authorization_expired?(authorization),
          {:ok, refreshed} <- Hubspot.refresh_authorization(authorization) do
-      IO.inspect(refreshed, label: "Successfully refreshed HubSpot authorization!")
-
       refreshed.access_token
     else
       _ ->
-        IO.inspect(authorization, label: "Using existing HubSpot authorization")
-
         authorization.access_token
     end
   end

--- a/lib/chat_api/hubspot/hubspot_authorization.ex
+++ b/lib/chat_api/hubspot/hubspot_authorization.ex
@@ -1,0 +1,58 @@
+defmodule ChatApi.Hubspot.HubspotAuthorization do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias ChatApi.Accounts.Account
+  alias ChatApi.Users.User
+
+  @type t :: %__MODULE__{
+          access_token: String.t() | nil,
+          refresh_token: String.t() | nil,
+          expires_at: DateTime.t() | nil,
+          token_type: String.t() | nil,
+          scope: String.t() | nil,
+          metadata: any(),
+          # Foreign keys
+          account_id: Ecto.UUID.t(),
+          user_id: integer(),
+          # Timestamps
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "hubspot_authorizations" do
+    field(:access_token, :string)
+    field(:refresh_token, :string)
+    field(:expires_at, :utc_datetime)
+    field(:token_type, :string)
+    field(:scope, :string)
+    field(:metadata, :map)
+
+    belongs_to(:account, Account)
+    belongs_to(:user, User, type: :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(hubspot_authorization, attrs) do
+    hubspot_authorization
+    |> cast(attrs, [
+      :account_id,
+      :user_id,
+      :access_token,
+      :refresh_token,
+      :expires_at,
+      :token_type,
+      :scope,
+      :metadata
+    ])
+    |> validate_required([
+      :account_id,
+      :access_token,
+      :refresh_token
+    ])
+  end
+end

--- a/lib/chat_api/hubspot/hubspot_authorization.ex
+++ b/lib/chat_api/hubspot/hubspot_authorization.ex
@@ -10,6 +10,8 @@ defmodule ChatApi.Hubspot.HubspotAuthorization do
           refresh_token: String.t() | nil,
           expires_at: DateTime.t() | nil,
           token_type: String.t() | nil,
+          hubspot_app_id: integer() | nil,
+          hubspot_portal_id: integer() | nil,
           scope: String.t() | nil,
           metadata: any(),
           # Foreign keys
@@ -27,6 +29,8 @@ defmodule ChatApi.Hubspot.HubspotAuthorization do
     field(:refresh_token, :string)
     field(:expires_at, :utc_datetime)
     field(:token_type, :string)
+    field(:hubspot_app_id, :integer)
+    field(:hubspot_portal_id, :integer)
     field(:scope, :string)
     field(:metadata, :map)
 
@@ -46,6 +50,8 @@ defmodule ChatApi.Hubspot.HubspotAuthorization do
       :refresh_token,
       :expires_at,
       :token_type,
+      :hubspot_app_id,
+      :hubspot_portal_id,
       :scope,
       :metadata
     ])

--- a/lib/chat_api/slack/helpers.ex
+++ b/lib/chat_api/slack/helpers.ex
@@ -709,7 +709,7 @@ defmodule ChatApi.Slack.Helpers do
         "https://" <> url
       end
 
-    "#{base}/conversations/all?cid=#{conversation_id}"
+    "#{base}/conversations/all/#{conversation_id}"
   end
 
   @spec format_message_body(Message.t()) :: binary()

--- a/lib/chat_api_web/controllers/hubspot_controller.ex
+++ b/lib/chat_api_web/controllers/hubspot_controller.ex
@@ -3,26 +3,80 @@ defmodule ChatApiWeb.HubspotController do
 
   require Logger
 
-  action_fallback ChatApiWeb.FallbackController
+  alias ChatApi.Hubspot
+  alias ChatApi.Hubspot.HubspotAuthorization
+
+  action_fallback(ChatApiWeb.FallbackController)
 
   @spec oauth(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def oauth(conn, %{"code" => code}) do
     Logger.debug("Code from HubSpot OAuth: #{inspect(code)}")
 
-    case ChatApi.Hubspot.Client.generate_auth_tokens(code) do
-      {:ok, result} ->
-        json(conn, %{data: %{ok: true, result: result.body}})
-
-      # TODO: figure out a better way to handle errors (e.g. does `reason` include an HTTP status code?)
-      {:error, reason} ->
+    with %{account_id: account_id, id: user_id} <- conn.assigns.current_user,
+         {:ok,
+          %{
+            status: 200,
+            body: %{
+              "access_token" => access_token,
+              "refresh_token" => refresh_token,
+              "expires_in" => expires_in,
+              "token_type" => token_type
+            }
+          }} <-
+           Hubspot.Client.generate_auth_tokens(code),
+         {:ok, authorization} <-
+           Hubspot.create_or_update_authorization(%{
+             account_id: account_id,
+             user_id: user_id,
+             access_token: access_token,
+             refresh_token: refresh_token,
+             token_type: token_type,
+             expires_at: DateTime.utc_now() |> DateTime.add(expires_in)
+           }) do
+      json(conn, %{data: %{ok: true, id: authorization.id}})
+    else
+      {:ok, %{status: status, body: body}} ->
         conn
-        |> put_status(400)
+        |> put_status(status)
         |> json(%{
           error: %{
-            status: 400,
-            message: inspect(reason)
+            status: status,
+            message: Map.get(body, "message", "Failed to create HubSpot authorization.")
           }
         })
+
+      error ->
+        IO.inspect(error, label: "Unexpected error while authorizing Hubspot:")
+    end
+  end
+
+  @spec authorization(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def authorization(conn, _payload) do
+    current_user = Pow.Plug.current_user(conn)
+
+    case Hubspot.get_authorization_by_account(current_user.account_id) do
+      nil ->
+        json(conn, %{data: nil})
+
+      auth ->
+        json(conn, %{
+          data: %{
+            id: auth.id,
+            created_at: auth.inserted_at,
+            token_type: auth.token_type,
+            scope: auth.scope
+          }
+        })
+    end
+  end
+
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def delete(conn, %{"id" => id}) do
+    with %{account_id: _account_id} <- conn.assigns.current_user,
+         %HubspotAuthorization{} = auth <-
+           Hubspot.get_hubspot_authorization!(id),
+         {:ok, %HubspotAuthorization{}} <- Hubspot.delete_hubspot_authorization(auth) do
+      send_resp(conn, :no_content, "")
     end
   end
 end

--- a/lib/chat_api_web/controllers/hubspot_controller.ex
+++ b/lib/chat_api_web/controllers/hubspot_controller.ex
@@ -24,14 +24,26 @@ defmodule ChatApiWeb.HubspotController do
             }
           }} <-
            Hubspot.Client.generate_auth_tokens(code),
+         {:ok,
+          %{
+            status: 200,
+            body: %{
+              "app_id" => hubspot_app_id,
+              "hub_id" => hubspot_portal_id,
+              "scopes" => scopes
+            }
+          }} <- Hubspot.Client.retrieve_token_info(access_token),
          {:ok, authorization} <-
            Hubspot.create_or_update_authorization(%{
              account_id: account_id,
              user_id: user_id,
              access_token: access_token,
              refresh_token: refresh_token,
+             hubspot_app_id: hubspot_app_id,
+             hubspot_portal_id: hubspot_portal_id,
              token_type: token_type,
-             expires_at: DateTime.utc_now() |> DateTime.add(expires_in)
+             expires_at: DateTime.utc_now() |> DateTime.add(expires_in),
+             scope: Enum.join(scopes, ",")
            }) do
       json(conn, %{data: %{ok: true, id: authorization.id}})
     else

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -119,6 +119,8 @@ defmodule ChatApiWeb.Router do
     post("/gmail/send", GmailController, :send)
     get("/hubspot/oauth", HubspotController, :oauth)
     get("/hubspot/authorization", HubspotController, :authorization)
+    get("/hubspot/contacts", HubspotController, :list_contacts)
+    post("/hubspot/contacts", HubspotController, :create_contact)
     delete("/hubspot/authorizations/:id", HubspotController, :delete)
     put("/widget_settings", WidgetSettingsController, :update)
     get("/profile", UserProfileController, :show)

--- a/lib/chat_api_web/router.ex
+++ b/lib/chat_api_web/router.ex
@@ -72,8 +72,6 @@ defmodule ChatApiWeb.Router do
     post("/twilio/webhook", TwilioController, :webhook)
     post("/github/webhook", GithubController, :webhook)
     post("/ses/webhook", SesController, :webhook)
-    # TODO: move to protected route after testing?
-    get("/hubspot/oauth", HubspotController, :oauth)
 
     post("/newsletters/:newsletter/subscribe", NewsletterController, :subscribe)
   end
@@ -119,6 +117,9 @@ defmodule ChatApiWeb.Router do
     delete("/google/authorizations/:id", GoogleController, :delete)
     get("/gmail/profile", GmailController, :profile)
     post("/gmail/send", GmailController, :send)
+    get("/hubspot/oauth", HubspotController, :oauth)
+    get("/hubspot/authorization", HubspotController, :authorization)
+    delete("/hubspot/authorizations/:id", HubspotController, :delete)
     put("/widget_settings", WidgetSettingsController, :update)
     get("/profile", UserProfileController, :show)
     put("/profile", UserProfileController, :update)

--- a/priv/repo/migrations/20210930131150_create_hubspot_authorizations.exs
+++ b/priv/repo/migrations/20210930131150_create_hubspot_authorizations.exs
@@ -8,6 +8,8 @@ defmodule ChatApi.Repo.Migrations.CreateHubspotAuthorizations do
       add(:refresh_token, :string, null: false)
       add(:expires_at, :utc_datetime)
       add(:token_type, :string)
+      add(:hubspot_app_id, :integer)
+      add(:hubspot_portal_id, :integer)
       add(:scope, :string)
       add(:metadata, :map)
 

--- a/priv/repo/migrations/20210930131150_create_hubspot_authorizations.exs
+++ b/priv/repo/migrations/20210930131150_create_hubspot_authorizations.exs
@@ -1,0 +1,26 @@
+defmodule ChatApi.Repo.Migrations.CreateHubspotAuthorizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:hubspot_authorizations, primary_key: false) do
+      add(:id, :binary_id, primary_key: true)
+      add(:access_token, :string, null: false)
+      add(:refresh_token, :string, null: false)
+      add(:expires_at, :utc_datetime)
+      add(:token_type, :string)
+      add(:scope, :string)
+      add(:metadata, :map)
+
+      add(:user_id, references(:users, on_delete: :delete_all))
+
+      add(:account_id, references(:accounts, on_delete: :delete_all, type: :binary_id),
+        null: false
+      )
+
+      timestamps()
+    end
+
+    create(index(:hubspot_authorizations, [:user_id]))
+    create(index(:hubspot_authorizations, [:account_id]))
+  end
+end

--- a/test/chat_api/hubspot_test.exs
+++ b/test/chat_api/hubspot_test.exs
@@ -1,0 +1,123 @@
+defmodule ChatApi.HubspotTest do
+  use ChatApi.DataCase
+  import ChatApi.Factory
+  alias ChatApi.Hubspot
+
+  describe "hubspot_authorizations" do
+    alias ChatApi.Hubspot.HubspotAuthorization
+
+    @valid_attrs %{
+      access_token: "some access_token",
+      refresh_token: "some refresh_token",
+      metadata: %{},
+      scope: "some scope",
+      token_type: "some token_type"
+    }
+    @update_attrs %{
+      access_token: "some updated access_token",
+      refresh_token: "some updated refresh_token",
+      metadata: %{},
+      scope: "some updated scope",
+      token_type: "some updated token_type"
+    }
+    @invalid_attrs %{
+      access_token: nil,
+      refresh_token: nil,
+      scope: nil,
+      token_type: nil,
+      metadata: nil,
+      account_id: nil,
+      user_id: nil
+    }
+
+    setup do
+      account = insert(:account)
+      user = insert(:user, account: account, role: "admin")
+      hubspot_authorization = insert(:hubspot_authorization, account: account, user: user)
+
+      {:ok, account: account, user: user, hubspot_authorization: hubspot_authorization}
+    end
+
+    test "list_hubspot_authorizations/0 returns all hubspot_authorizations", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      assert Hubspot.list_hubspot_authorizations() |> Enum.map(&extract_comparable_fields/1) == [
+               extract_comparable_fields(hubspot_authorization)
+             ]
+    end
+
+    test "get_hubspot_authorization!/1 returns the hubspot_authorization with given id", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      result = Hubspot.get_hubspot_authorization!(hubspot_authorization.id)
+
+      assert extract_comparable_fields(result) == extract_comparable_fields(hubspot_authorization)
+    end
+
+    test "create_hubspot_authorization/1 with valid data creates a hubspot_authorization", %{
+      account: account,
+      user: user
+    } do
+      params = Map.merge(@valid_attrs, %{user_id: user.id, account_id: account.id})
+
+      assert {:ok, %HubspotAuthorization{} = hubspot_authorization} =
+               Hubspot.create_hubspot_authorization(params)
+
+      assert hubspot_authorization.access_token == "some access_token"
+      assert hubspot_authorization.account_id == account.id
+      assert hubspot_authorization.metadata == %{}
+      assert hubspot_authorization.scope == "some scope"
+      assert hubspot_authorization.token_type == "some token_type"
+      assert hubspot_authorization.user_id == user.id
+    end
+
+    test "create_hubspot_authorization/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Hubspot.create_hubspot_authorization(@invalid_attrs)
+    end
+
+    test "update_hubspot_authorization/2 with valid data updates the hubspot_authorization", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      assert {:ok, %HubspotAuthorization{} = hubspot_authorization} =
+               Hubspot.update_hubspot_authorization(hubspot_authorization, @update_attrs)
+
+      assert hubspot_authorization.access_token == "some updated access_token"
+      assert hubspot_authorization.metadata == %{}
+      assert hubspot_authorization.scope == "some updated scope"
+      assert hubspot_authorization.token_type == "some updated token_type"
+    end
+
+    test "update_hubspot_authorization/2 with invalid data returns error changeset", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      assert {:error, %Ecto.Changeset{}} =
+               Hubspot.update_hubspot_authorization(hubspot_authorization, @invalid_attrs)
+
+      current = Hubspot.get_hubspot_authorization!(hubspot_authorization.id)
+
+      assert extract_comparable_fields(current) ==
+               extract_comparable_fields(hubspot_authorization)
+    end
+
+    test "delete_hubspot_authorization/1 deletes the hubspot_authorization", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      assert {:ok, %HubspotAuthorization{}} =
+               Hubspot.delete_hubspot_authorization(hubspot_authorization)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Hubspot.get_hubspot_authorization!(hubspot_authorization.id)
+      end
+    end
+
+    test "change_hubspot_authorization/1 returns a hubspot_authorization changeset", %{
+      hubspot_authorization: hubspot_authorization
+    } do
+      assert %Ecto.Changeset{} = Hubspot.change_hubspot_authorization(hubspot_authorization)
+    end
+
+    defp extract_comparable_fields(hubspot_authorization) do
+      Map.take(hubspot_authorization, [:access_token, :scope, :token_type, :account_id, :user_id])
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -121,6 +121,17 @@ defmodule ChatApi.Factory do
     }
   end
 
+  def hubspot_authorization_factory do
+    %ChatApi.Hubspot.HubspotAuthorization{
+      access_token: "some access_token",
+      refresh_token: "some refresh_token",
+      token_type: "some token_type",
+      scope: "some scope",
+      account: build(:account),
+      user: build(:user)
+    }
+  end
+
   def inbox_factory do
     %ChatApi.Inboxes.Inbox{
       account: build(:account),


### PR DESCRIPTION
### Description

This PR sets up a basic HubSpot integration:
- [x] User can connect their HubSpot account in the Papercups dashboard
- [x] User can view customer info from HubSpot in sidebar
- [x] User can click on link to customer details page in HubSpot if available

### Issue

#981 

### Screenshots

![hubspot-integration](https://user-images.githubusercontent.com/5264279/135514741-b2eecff3-c20f-4f85-b459-9332a8abd2ac.gif)

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
