### PR TITLE
Improve message error handling and caching drafts

### DIFF
--- a/assets/src/api.ts
+++ b/assets/src/api.ts
@@ -13,6 +13,7 @@ import {
   Inbox,
   Issue,
   Lambda,
+  Message,
   Tag,
   User,
   WidgetSettings,
@@ -668,8 +669,7 @@ export const archiveConversation = async (
 };
 
 export const createNewMessage = async (
-  conversationId: string,
-  message: any,
+  message: Partial<Message>,
   token = getAccessToken()
 ) => {
   if (!token) {
@@ -681,7 +681,6 @@ export const createNewMessage = async (
     .set('Authorization', token)
     .send({
       message: {
-        conversation_id: conversationId,
         sent_at: new Date().toISOString(),
         ...message,
       },

--- a/assets/src/components/conversations/ConversationFooter.tsx
+++ b/assets/src/components/conversations/ConversationFooter.tsx
@@ -88,6 +88,12 @@ const ConversationFooter = ({
   const [isSendDisabled, setSendDisabled] = React.useState<boolean>(false);
 
   React.useEffect(() => {
+    const el = textAreaEl.current?.textarea;
+
+    if (el) {
+      el.selectionStart = message.length;
+    }
+
     Promise.all([API.fetchAccountUsers(), API.fetchCannedResponses()]).then(
       ([users, responses]) => {
         setMentionableUsers(users);

--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -6,7 +6,6 @@ import {useConversations} from './ConversationsProvider';
 import ConversationMessages from '../conversations/ConversationMessages';
 import ConversationFooter from '../conversations/ConversationFooter';
 import {Conversation, Message, User} from '../../types';
-import {useNotifications} from './NotificationsProvider';
 import {useAuth} from '../auth/AuthProvider';
 
 type Props = {
@@ -14,7 +13,6 @@ type Props = {
   conversation: Conversation;
   currentUser: User | null;
   messages: Array<Message>;
-  onSendMessage: (message: Partial<Message>, cb?: () => void) => void;
   onClose: () => void;
 };
 
@@ -40,16 +38,6 @@ class ConversationModal extends React.Component<Props> {
     if (el) {
       this.scrollIntoView();
     }
-  };
-
-  handleSendMessage = (message: Partial<Message>) => {
-    const {id: conversationId} = this.props.conversation;
-
-    if (!conversationId) {
-      return null;
-    }
-
-    this.props.onSendMessage({...message, conversation_id: conversationId});
   };
 
   render() {
@@ -100,7 +88,7 @@ class ConversationModal extends React.Component<Props> {
           <ConversationFooter
             sx={{px: 3, pb: 3}}
             conversationId={conversation.id}
-            onSendMessage={this.handleSendMessage}
+            onSendMessage={this.scrollIntoView}
           />
         </Flex>
       </Modal>
@@ -123,7 +111,6 @@ const ConversationModalWrapper = ({
     fetchConversationById,
     getConversationById,
   } = useConversations();
-  const {handleSendMessage} = useNotifications();
 
   React.useEffect(() => {
     fetchConversationById(conversationId);
@@ -148,7 +135,6 @@ const ConversationModalWrapper = ({
       conversation={conversation}
       messages={messages}
       currentUser={currentUser}
-      onSendMessage={handleSendMessage}
       onClose={onClose}
     />
   );

--- a/assets/src/components/conversations/ConversationModal.tsx
+++ b/assets/src/components/conversations/ConversationModal.tsx
@@ -99,6 +99,7 @@ class ConversationModal extends React.Component<Props> {
 
           <ConversationFooter
             sx={{px: 3, pb: 3}}
+            conversationId={conversation.id}
             onSendMessage={this.handleSendMessage}
           />
         </Flex>

--- a/assets/src/components/conversations/ConversationsDashboard.tsx
+++ b/assets/src/components/conversations/ConversationsDashboard.tsx
@@ -143,7 +143,7 @@ export const ConversationsDashboard = ({
 
   const {
     channel,
-    handleSendMessage,
+
     handleConversationSeen,
     onNewMessage,
     onNewConversation,
@@ -499,17 +499,6 @@ export const ConversationsDashboard = ({
     setConversationIds(validConversationIds);
   }
 
-  function handleSendNewMessage(message: Partial<Message>) {
-    if (!selectedConversationId) {
-      return;
-    }
-
-    handleSendMessage({
-      conversation_id: selectedConversationId,
-      ...message,
-    });
-  }
-
   // TODO: test this out more!
   async function handleSearchConversations(query: string) {
     if (!query || !query.trim().length) {
@@ -636,7 +625,6 @@ export const ConversationsDashboard = ({
             conversation={conversation}
             isClosing={isClosingSelected}
             setScrollRef={setScrollRef}
-            onSendMessage={handleSendNewMessage}
           />
         ) : (
           <EmptyState

--- a/assets/src/components/conversations/SelectedConversationContainer.tsx
+++ b/assets/src/components/conversations/SelectedConversationContainer.tsx
@@ -116,8 +116,8 @@ const SelectedConversationContainer = ({
         // NB: the `key` forces a rerender so the input can clear
         // any text from the last conversation and trigger autofocus
         <ConversationFooter
-          key={conversation.id}
-          conversationId={conversation.id}
+          key={selectedConversationId}
+          conversationId={selectedConversationId}
           onSendMessage={onSendMessage}
           currentUser={currentUser}
         />

--- a/assets/src/components/conversations/SelectedConversationContainer.tsx
+++ b/assets/src/components/conversations/SelectedConversationContainer.tsx
@@ -117,6 +117,7 @@ const SelectedConversationContainer = ({
         // any text from the last conversation and trigger autofocus
         <ConversationFooter
           key={conversation.id}
+          conversationId={conversation.id}
           onSendMessage={onSendMessage}
           currentUser={currentUser}
         />

--- a/assets/src/components/conversations/SelectedConversationContainer.tsx
+++ b/assets/src/components/conversations/SelectedConversationContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Box, Flex} from 'theme-ui';
-import {Account, Conversation, Message, User} from '../../types';
+import {Account, Conversation, User} from '../../types';
 import * as API from '../../api';
 import ConversationMessages from './ConversationMessages';
 import ConversationFooter from './ConversationFooter';
@@ -15,7 +15,6 @@ const SelectedConversationContainer = ({
   conversation,
   isClosing,
   setScrollRef,
-  onSendMessage,
 }: {
   loading: boolean;
   account: Account;
@@ -24,7 +23,6 @@ const SelectedConversationContainer = ({
   isClosing: boolean;
   // TODO: handle scrolling within this component?
   setScrollRef: any; // (el: any) => void;
-  onSendMessage: (message: Partial<Message>) => void;
 }) => {
   const {isCustomerOnline} = useNotifications();
   const [history, setConversationHistory] = React.useState<Array<Conversation>>(
@@ -118,7 +116,6 @@ const SelectedConversationContainer = ({
         <ConversationFooter
           key={selectedConversationId}
           conversationId={selectedConversationId}
-          onSendMessage={onSendMessage}
           currentUser={currentUser}
         />
       )}

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -51,7 +51,7 @@ class ConversationSidebar extends React.Component<Props, any> {
   };
 
   render() {
-    const {currentUser, messages = []} = this.props;
+    const {currentUser, conversation, messages = []} = this.props;
 
     return (
       <Flex
@@ -75,6 +75,7 @@ class ConversationSidebar extends React.Component<Props, any> {
 
         <ConversationFooter
           sx={{px: 3, pb: 3}}
+          conversationId={conversation.id}
           onSendMessage={this.handleSendMessage}
         />
       </Flex>

--- a/assets/src/components/sessions/ConversationSidebar.tsx
+++ b/assets/src/components/sessions/ConversationSidebar.tsx
@@ -5,14 +5,12 @@ import ConversationMessages from '../conversations/ConversationMessages';
 import ConversationFooter from '../conversations/ConversationFooter';
 import {Conversation, Message, User} from '../../types';
 import {useConversations} from '../conversations/ConversationsProvider';
-import {useNotifications} from '../conversations/NotificationsProvider';
 import {useAuth} from '../auth/AuthProvider';
 
 type Props = {
   conversation: Conversation;
   currentUser: User | null;
   messages: Array<Message>;
-  onSendMessage: (message: Partial<Message>, cb: () => void) => void;
 };
 
 class ConversationSidebar extends React.Component<Props, any> {
@@ -33,21 +31,6 @@ class ConversationSidebar extends React.Component<Props, any> {
 
   scrollIntoView = () => {
     this.scrollToEl && this.scrollToEl.scrollIntoView();
-  };
-
-  handleSendMessage = (message: Partial<Message>) => {
-    const {id: conversationId} = this.props.conversation;
-
-    if (!conversationId) {
-      return null;
-    }
-
-    this.props.onSendMessage(
-      {...message, conversation_id: conversationId},
-      () => {
-        this.scrollIntoView();
-      }
-    );
   };
 
   render() {
@@ -76,7 +59,7 @@ class ConversationSidebar extends React.Component<Props, any> {
         <ConversationFooter
           sx={{px: 3, pb: 3}}
           conversationId={conversation.id}
-          onSendMessage={this.handleSendMessage}
+          onSendMessage={this.scrollIntoView}
         />
       </Flex>
     );
@@ -94,11 +77,9 @@ const ConversationSidebarWrapper = ({
     fetchConversationById,
     getConversationById,
   } = useConversations();
-  const {handleSendMessage} = useNotifications();
 
   React.useEffect(() => {
     Promise.all([fetchConversationById(conversationId)]);
-
     // eslint-disable-next-line
   }, [conversationId]);
 
@@ -119,7 +100,6 @@ const ConversationSidebarWrapper = ({
       conversation={conversation}
       messages={messages}
       currentUser={currentUser}
-      onSendMessage={handleSendMessage}
     />
   );
 };

--- a/assets/src/storage.ts
+++ b/assets/src/storage.ts
@@ -1,6 +1,6 @@
 const PREFIX = '__PAPERCUPS__';
 
-const get = (key: string) => {
+export const get = (key: string) => {
   const result = localStorage.getItem(`${PREFIX}${key}`);
 
   if (!result) {
@@ -14,11 +14,11 @@ const get = (key: string) => {
   }
 };
 
-const set = (key: string, value: any) => {
+export const set = (key: string, value: any) => {
   localStorage.setItem(`${PREFIX}${key}`, JSON.stringify(value));
 };
 
-const remove = (key: string) => {
+export const remove = (key: string) => {
   localStorage.removeItem(`${PREFIX}${key}`);
 };
 
@@ -50,3 +50,12 @@ export const setRunKitCode = (prefix: string, code: any) =>
 
 export const removeRunKitCode = (prefix: string) =>
   remove(`:__RUNKIT_SOURCE_CODE__:${prefix}`);
+
+export const getMessageDraft = (conversationId: string) =>
+  get(`:__MESSAGE_DRAFT__:${conversationId}`);
+
+export const setMessageDraft = (conversationId: string, message: string) =>
+  set(`:__MESSAGE_DRAFT__:${conversationId}`, message);
+
+export const removeMessageDraft = (conversationId: string) =>
+  remove(`:__MESSAGE_DRAFT__:${conversationId}`);

--- a/lib/chat_api/messages/notification.ex
+++ b/lib/chat_api/messages/notification.ex
@@ -5,6 +5,7 @@ defmodule ChatApi.Messages.Notification do
 
   alias ChatApi.{EventSubscriptions, Lambdas}
   alias ChatApi.Conversations.Conversation
+  alias ChatApi.Customers.Customer
   alias ChatApi.Messages.{Helpers, Message}
   alias ChatApi.Users.User
 
@@ -41,11 +42,7 @@ defmodule ChatApi.Messages.Notification do
   @spec notify(Message.t(), atom(), keyword()) :: Message.t()
   def notify(message, type, opts \\ [])
 
-  def notify(
-        %Message{body: _, conversation_id: _} = message,
-        :slack,
-        opts
-      ) do
+  def notify(%Message{body: _, conversation_id: _} = message, :slack, opts) do
     Logger.info("Sending message notification: :slack (message #{inspect(message.id)})")
 
     case opts do
@@ -116,7 +113,8 @@ defmodule ChatApi.Messages.Notification do
     message
   end
 
-  def notify(%Message{} = message, :new_message_email, opts) do
+  # TODO: make this a paid feature?
+  def notify(%Message{customer: %Customer{}, private: false} = message, :new_message_email, opts) do
     Logger.info(
       "Sending message notification: :new_message_email (message #{inspect(message.id)})"
     )
@@ -134,6 +132,8 @@ defmodule ChatApi.Messages.Notification do
 
     message
   end
+
+  def notify(%Message{} = message, :new_message_email, _opts), do: message
 
   def notify(%Message{} = message, :mattermost, opts) do
     Logger.info("Sending message notification: :mattermost (message #{inspect(message.id)})")


### PR DESCRIPTION
### Description

- Improve message error handling, display error message in UI if message fails to send
- Caching message drafts so they persist after refresh/error/switching conversations

### Issue

Fixes https://github.com/papercups-io/papercups/issues/955

### Screenshots

TODO

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
