### PR TITLE
Show popular integrations more clearly, include account details in AuthProvider

### DIFF
--- a/assets/src/components/Dashboard.tsx
+++ b/assets/src/components/Dashboard.tsx
@@ -43,7 +43,6 @@ import {
   isWindowHidden,
 } from '../utils';
 import {Account, User} from '../types';
-import * as API from '../api';
 import {useAuth} from './auth/AuthProvider';
 import {SocketProvider, SocketContext} from './auth/SocketProvider';
 import AccountOverview from './settings/AccountOverview';
@@ -244,14 +243,9 @@ const Dashboard = (props: RouteComponentProps) => {
   const auth = useAuth();
   const {pathname} = useLocation();
   const {unread} = useConversations();
-  const [account, setAccount] = React.useState<Account | null>(null);
-  const {currentUser} = auth;
-  const isAdminUser = currentUser?.role === 'admin';
 
-  React.useEffect(() => {
-    // TODO: figure out a better way to handle this
-    API.fetchAccountInfo().then((account) => setAccount(account));
-  }, []);
+  const {currentUser, account} = auth;
+  const isAdminUser = currentUser?.role === 'admin';
 
   const [section, key] = getSectionKey(pathname);
   const totalNumUnread = unread.conversations.open || 0;

--- a/assets/src/components/conversations/ConversationsDashboard.tsx
+++ b/assets/src/components/conversations/ConversationsDashboard.tsx
@@ -672,51 +672,14 @@ const Wrapper = (
   props: RouteComponentProps<{bucket: string; conversation_id?: string}>
 ) => {
   const {bucket, conversation_id: conversationId = null} = props.match.params;
-  const [account, setAccount] = React.useState<Account | null>(null);
-  const [status, setStatus] = React.useState<'loading' | 'success' | 'error'>(
-    'loading'
-  );
-  const [error, setErrorMessage] = React.useState<string | null>(null);
-  const {currentUser} = useAuth();
-
-  React.useEffect(() => {
-    setStatus('loading');
-
-    API.fetchAccountInfo()
-      .then((account) => setAccount(account))
-      .then(() => setStatus('success'))
-      .catch((error) => {
-        setStatus('error');
-        setErrorMessage(formatServerError(error));
-      });
-  }, [bucket]);
+  const {currentUser, account} = useAuth();
 
   if (!isValidBucket(bucket)) {
     // TODO: render error or redirect to default
     return null;
   }
 
-  if (error || status === 'error') {
-    // TODO: render better error state?
-    return (
-      <Flex
-        sx={{
-          flex: 1,
-          justifyContent: 'center',
-          alignItems: 'center',
-          height: '100%',
-        }}
-      >
-        <Result
-          status="error"
-          title="Error retrieving inbox"
-          subTitle={error || 'Unknown error'}
-        />
-      </Flex>
-    );
-  } else if (status === 'loading') {
-    return null;
-  } else if (!account || !currentUser) {
+  if (!account || !currentUser) {
     return null;
   }
 

--- a/assets/src/components/inboxes/InboxConversations.tsx
+++ b/assets/src/components/inboxes/InboxConversations.tsx
@@ -3,7 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import {Flex} from 'theme-ui';
 
 import * as API from '../../api';
-import {Account, Conversation, Inbox} from '../../types';
+import {Conversation, Inbox} from '../../types';
 import {Result} from '../common';
 import {formatServerError} from '../../utils';
 import {useAuth} from '../auth/AuthProvider';
@@ -16,21 +16,18 @@ const Wrapper = (
     inbox_id: inboxId,
     conversation_id: conversationId = null,
   } = props.match.params;
-  const [account, setAccount] = React.useState<Account | null>(null);
   const [inbox, setSelectedInbox] = React.useState<Inbox | null>(null);
   const [status, setStatus] = React.useState<'loading' | 'success' | 'error'>(
     'loading'
   );
   const [error, setErrorMessage] = React.useState<string | null>(null);
-  const {currentUser} = useAuth();
+  const {currentUser, account} = useAuth();
 
   React.useEffect(() => {
     setStatus('loading');
 
-    Promise.all([
-      API.fetchAccountInfo().then((account) => setAccount(account)),
-      API.fetchInbox(inboxId).then((result) => setSelectedInbox(result)),
-    ])
+    API.fetchInbox(inboxId)
+      .then((result) => setSelectedInbox(result))
       .then(() => setStatus('success'))
       .catch((error) => {
         setStatus('error');

--- a/assets/src/components/integrations/IntegrationsOverview.tsx
+++ b/assets/src/components/integrations/IntegrationsOverview.tsx
@@ -457,6 +457,16 @@ class IntegrationsOverview extends React.Component<Props, State> {
     return keys.map((key) => integrationsByKey[key] || null).filter(Boolean);
   };
 
+  getPopularIntegrations = () => {
+    const {integrationsByKey = {}} = this.state;
+
+    return Object.keys(integrationsByKey)
+      .map((key) => integrationsByKey[key])
+      .filter((record) => {
+        return record && record.isPopular;
+      });
+  };
+
   getInboxSourceChannels = () => {
     return this.getIntegrationsByKeys([
       'chat',
@@ -529,6 +539,17 @@ class IntegrationsOverview extends React.Component<Props, State> {
                     }
                     type="info"
                     showIcon
+                  />
+                </Box>
+
+                <Box px={3} mb={3}>
+                  <Title level={4}>Popular</Title>
+                </Box>
+                <Box mb={4}>
+                  <InboxIntegrationsTable
+                    loading={refreshing}
+                    inboxId={inbox.id}
+                    integrations={this.getPopularIntegrations()}
                   />
                 </Box>
 


### PR DESCRIPTION
### Description

Include account in AuthProvider, show popular integrations more clearly

### Issue

People tend to connect the "Slack sync" integration before the "Slack reply" integration because it appears above.

## Checklist

- [x] Everything passes when running `mix test`
- [x] Ran `mix format`
- [x] No frontend compilation warnings
