### PR TITLE
Bump react-emoji-render to fix broken Twemoji image URLs

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -14368,22 +14368,15 @@
       }
     },
     "react-emoji-render": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-emoji-render/-/react-emoji-render-1.2.4.tgz",
-      "integrity": "sha512-AqktVXV38uDpgf02BoCXrzLYFsHAsxfdWwjrLexSJ22l1JgB01y1KejjxW/zTuCzod6O7BZfiMS866LEEfMHmA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-emoji-render/-/react-emoji-render-2.0.1.tgz",
+      "integrity": "sha512-SKtsdwgEf2BFNiE9y4UBFZBWjkRcyWmhMprVly52+J77/zxThcfaQ3sCA0+2LtGJIRMpm4DGWSvyLg72fd1rXQ==",
       "requires": {
         "classnames": "^2.2.5",
-        "emoji-regex": "^6.4.1",
+        "emoji-regex": "^8.0.0",
         "lodash.flatten": "^4.4.0",
         "prop-types": "^15.5.8",
         "string-replace-to-array": "^1.0.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-          "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
-        }
       }
     },
     "react-error-overlay": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -45,7 +45,7 @@
     "react": "^16.13.1",
     "react-color": "^2.18.1",
     "react-dom": "^16.13.1",
-    "react-emoji-render": "^1.2.4",
+    "react-emoji-render": "^2.0.1",
     "react-helmet": "^6.1.0",
     "react-markdown": "^4.3.1",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
### Description

Twemoji in react-emoji-render 1.2.4 no longer works at all because it points to an old twemoji.maxcdn.com URL that’s no longer functional. Upgrade to react-emoji-render 2.0.1 to fix this.

### Issue

- https://github.com/tommoor/react-emoji-render/issues/104

### Screenshots

_For frontend updates, please include a screenshot._

## Checklist

- [ ] Everything passes when running `mix test`
- [ ] Ran `mix format`
- [ ] No frontend compilation warnings
